### PR TITLE
default-plan and the collection runtime follow the PaymentPolicy cascade

### DIFF
--- a/.changeset/plain-donkeys-brake.md
+++ b/.changeset/plain-donkeys-brake.md
@@ -1,0 +1,29 @@
+---
+"@voyant-travel/finance-contracts": minor
+"@voyant-travel/finance": minor
+---
+
+Derive the default booking payment plan from the `PaymentPolicy` cascade
+
+`POST /v1/admin/finance/bookings/{id}/payment-schedules/default-plan` and the
+checkout collection runtime carried their own deposit model — `depositMode` /
+`depositValue` / `balanceDueDaysBeforeStart`, defaulted to 30% with the balance
+30 days before start — and never consulted `resolveEffectivePaymentPolicy`. An
+operator who configured 50% with the balance 14 days before departure on the
+settings page got 30% / 30 days from these two surfaces, so which route an
+agent happened to call decided what the customer owed and when.
+
+Both now resolve the operator's effective policy through the same cascade
+`booking.confirmed` walks (booking → proposal → listing → category → supplier →
+operator default) and run it through `computePaymentSchedule`, which also means
+the near-departure deposit gate and the balance-due floor apply where they
+previously could not be expressed at all.
+
+Stating deposit terms on the call is still honoured verbatim as a deliberate
+override, `depositDueDate` included.
+
+**Behaviour change.** A deployment that relied on the implicit 30% default now
+gets whatever its `PaymentPolicy` says. An operator that has configured no
+policy gets `noDepositPolicy` — payment in full — rather than a 30% deposit
+nobody asked for. Configure an operator-default payment policy before upgrading
+if you were depending on the old implicit split.

--- a/packages/finance-contracts/src/validation-payments.ts
+++ b/packages/finance-contracts/src/validation-payments.ts
@@ -219,11 +219,26 @@ export const createPaymentSessionFromScheduleSchema = paymentSessionProvisioning
 export const createPaymentSessionFromGuaranteeSchema = paymentSessionProvisioningSchema
 export const createPaymentSessionFromInvoiceSchema = paymentSessionProvisioningSchema
 
+/**
+ * Options for the default booking payment plan.
+ *
+ * The deposit trio (`depositMode` / `depositValue` /
+ * `balanceDueDaysBeforeStart`) is deliberately UNDEFAULTED. Omitting it means
+ * "use the operator's configured `PaymentPolicy`" — the cascade the settings
+ * page edits and checkout reads. Stating it is a deliberate per-call override
+ * for a plan that is not the operator's.
+ *
+ * These fields used to default to 30% with the balance 30 days out, which made
+ * a caller who said nothing look like a caller who had asked for 30% — so an
+ * operator who configured 50%/14-days got 30%/30-days from this route and had
+ * no way to see why (voyant#4744). A default that contradicts configuration is
+ * not a default.
+ */
 export const applyDefaultBookingPaymentPlanSchema = z.object({
-  depositMode: z.enum(["none", "percentage", "fixed_amount"]).default("percentage"),
-  depositValue: z.number().int().min(0).default(30),
+  depositMode: z.enum(["none", "percentage", "fixed_amount"]).optional(),
+  depositValue: z.number().int().min(0).optional(),
   depositDueDate: z.string().optional().nullable(),
-  balanceDueDaysBeforeStart: z.number().int().min(0).default(30),
+  balanceDueDaysBeforeStart: z.number().int().min(0).optional(),
   clearExistingPending: z.boolean().default(true),
   createGuarantee: z.boolean().default(false),
   guaranteeType: guaranteeTypeSchema.default("deposit"),

--- a/packages/finance/openapi/admin/finance.json
+++ b/packages/finance/openapi/admin/finance.json
@@ -10762,7 +10762,7 @@
         ],
         "requestBody": {
           "required": true,
-          "description": "Default payment-plan options. Every field is optional / defaulted, so a posted `{}` applies the default deposit/balance split.",
+          "description": "Default payment-plan options. Every field is optional: a posted `{}` applies the operator's configured payment policy (booking → proposal → listing → category → supplier → operator default), and stating deposit terms overrides that policy for this call only.",
           "content": {
             "application/json": {
               "schema": {
@@ -10774,13 +10774,11 @@
                       "none",
                       "percentage",
                       "fixed_amount"
-                    ],
-                    "default": "percentage"
+                    ]
                   },
                   "depositValue": {
                     "type": "integer",
-                    "minimum": 0,
-                    "default": 30
+                    "minimum": 0
                   },
                   "depositDueDate": {
                     "type": [
@@ -10790,8 +10788,7 @@
                   },
                   "balanceDueDaysBeforeStart": {
                     "type": "integer",
-                    "minimum": 0,
-                    "default": 30
+                    "minimum": 0
                   },
                   "clearExistingPending": {
                     "type": "boolean",

--- a/packages/finance/src/checkout-routes.ts
+++ b/packages/finance/src/checkout-routes.ts
@@ -32,6 +32,7 @@ import {
   initiateCheckoutCollectionSchema,
   previewCheckoutCollectionSchema,
 } from "./checkout-validation.js"
+import { resolveBookingPaymentPolicyCascade } from "./payment-schedule/booking-policy-runtime.js"
 
 type Env = {
   Bindings: Record<string, unknown>
@@ -128,6 +129,25 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
     return resolveCheckoutRouteRuntime(bindings, options, container)
   }
 
+  /**
+   * Checkout policy for this request, with the operator's `PaymentPolicy`
+   * cascade attached.
+   *
+   * Without it the collection runtime materialized its own 30% plan and an
+   * operator's configured deposit never reached checkout (voyant#4744). A
+   * deployment that supplied its own resolver keeps it.
+   */
+  async function policyFor(c: {
+    env: Record<string, unknown>
+    var: { container?: ModuleContainer }
+  }): Promise<CheckoutPolicyOptions> {
+    const configured = options.policy
+    if (configured?.paymentPolicyCascade) return configured
+    const paymentPolicyCascade = await resolveBookingPaymentPolicyCascade(c.var.container, c.env)
+    if (!paymentPolicyCascade) return configured ?? {}
+    return { ...configured, paymentPolicyCascade }
+  }
+
   return (
     app
       // Mostly a read, but `ensureDefaultPaymentPlan` can materialize a
@@ -139,7 +159,7 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
             c.get("db"),
             c.req.param("bookingId")!,
             await parseOptionalJsonBody(c, previewCheckoutCollectionSchema),
-            options.policy,
+            await policyFor(c),
           )
 
           if (!plan) {
@@ -167,7 +187,7 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
             c.get("db"),
             c.req.param("bookingId")!,
             input,
-            options.policy,
+            await policyFor(c),
             runtime,
           )
 
@@ -201,7 +221,7 @@ function attachCollectionRoutes<TEnv extends Env>(app: Hono<TEnv>, options: Chec
           const result = await bootstrapCheckoutCollection(
             c.get("db"),
             input,
-            options.policy,
+            await policyFor(c),
             runtime,
           )
 

--- a/packages/finance/src/checkout-service-plan.ts
+++ b/packages/finance/src/checkout-service-plan.ts
@@ -8,6 +8,7 @@ import type {
   CheckoutProviderStartInput,
   InitiateCheckoutCollectionInput,
 } from "./checkout-validation.js"
+import type { BookingPaymentPolicyCascadeReaders } from "./payment-schedule/booking-policy.js"
 import type { bookingPaymentSchedules, invoices, PaymentSession } from "./schema.js"
 
 export interface CheckoutPolicyOptions {
@@ -15,13 +16,24 @@ export interface CheckoutPolicyOptions {
   defaultReminderCardCollectionTarget?: "schedule" | "invoice"
   defaultBankTransferDocumentType?: "proforma" | "invoice"
   defaultCardCollectionDocumentType?: "proforma" | "invoice"
+  /**
+   * A deliberate deployment-wide override of the operator's payment policy.
+   *
+   * The deposit trio is optional: leaving it unset means the collection
+   * runtime materializes the plan the operator actually configured, resolved
+   * through the `PaymentPolicy` cascade. Setting it overrides that policy for
+   * every collection this deployment starts, which is almost never what a
+   * deployment wants — it used to be the only behaviour available, and it
+   * silently applied 30% / 30 days to operators who had configured neither
+   * (voyant#4744).
+   */
   defaultPaymentPlan?: {
-    depositMode: "none" | "percentage" | "fixed_amount"
-    depositValue: number
-    balanceDueDaysBeforeStart: number
-    clearExistingPending: boolean
-    createGuarantee: boolean
-    guaranteeType:
+    depositMode?: "none" | "percentage" | "fixed_amount"
+    depositValue?: number
+    balanceDueDaysBeforeStart?: number
+    clearExistingPending?: boolean
+    createGuarantee?: boolean
+    guaranteeType?:
       | "deposit"
       | "credit_card"
       | "preauth"
@@ -31,6 +43,15 @@ export interface CheckoutPolicyOptions {
       | "agency_letter"
     notes?: string | null
   }
+  /**
+   * The operator's payment-policy cascade readers.
+   *
+   * Wired by the checkout route layer from the container registration the
+   * `booking.confirmed` subscriber already uses. Absent means no cascade is
+   * composed, and the collection runtime falls back to `noDepositPolicy` — pay
+   * in full — rather than to a made-up deposit.
+   */
+  paymentPolicyCascade?: BookingPaymentPolicyCascadeReaders | null
 }
 
 export type LoadedBookingContext = {
@@ -172,16 +193,45 @@ export const OUTSTANDING_INVOICE_STATUSES: Array<(typeof invoices.$inferSelect)[
   "overdue",
 ]
 
+/**
+ * The plan options this deployment configured, with only the bookkeeping
+ * fields defaulted.
+ *
+ * The deposit trio is passed through as stated — `undefined` where the
+ * deployment said nothing — so the collection runtime can tell "no deposit
+ * terms were configured" (use the operator's policy) from "a deposit was
+ * configured". Defaulting them to 30% / 30 days here is what made the two
+ * models disagree (voyant#4744).
+ */
 export function defaultPaymentPlan(options: CheckoutPolicyOptions) {
+  const configured = options.defaultPaymentPlan
   return {
-    depositMode: options.defaultPaymentPlan?.depositMode ?? "percentage",
-    depositValue: options.defaultPaymentPlan?.depositValue ?? 30,
-    balanceDueDaysBeforeStart: options.defaultPaymentPlan?.balanceDueDaysBeforeStart ?? 30,
-    clearExistingPending: options.defaultPaymentPlan?.clearExistingPending ?? true,
-    createGuarantee: options.defaultPaymentPlan?.createGuarantee ?? false,
-    guaranteeType: options.defaultPaymentPlan?.guaranteeType ?? "deposit",
-    notes: options.defaultPaymentPlan?.notes ?? null,
-  } as const
+    depositMode: configured?.depositMode,
+    depositValue: configured?.depositValue,
+    balanceDueDaysBeforeStart: configured?.balanceDueDaysBeforeStart,
+    clearExistingPending: configured?.clearExistingPending ?? true,
+    createGuarantee: configured?.createGuarantee ?? false,
+    guaranteeType: configured?.guaranteeType ?? "deposit",
+    notes: configured?.notes ?? null,
+  }
+}
+
+/**
+ * Layer a per-call plan override onto the deployment's configured one.
+ *
+ * Drops keys whose value is `undefined` so a validator that materializes an
+ * absent optional field as an explicit `undefined` can't erase the layer
+ * underneath it — "said nothing" and "said undefined" have to mean the same
+ * thing, or an override could silently unset the operator's terms.
+ */
+export function mergePaymentPlanOverride<T extends object, O extends object>(
+  base: T,
+  override: O,
+): T & O {
+  const stated = Object.fromEntries(
+    Object.entries(override).filter(([, value]) => value !== undefined),
+  )
+  return { ...base, ...stated } as T & O
 }
 
 export function resolvePaymentSessionTarget(

--- a/packages/finance/src/checkout-service.ts
+++ b/packages/finance/src/checkout-service.ts
@@ -15,6 +15,7 @@ import {
   type InitiatedCheckoutCollection,
   type LoadedBookingContext,
   lineDescription,
+  mergePaymentPlanOverride,
   normalizeExactAmountCents,
   OUTSTANDING_INVOICE_STATUSES,
   OUTSTANDING_SCHEDULE_STATUSES,
@@ -125,10 +126,16 @@ async function ensurePaymentPlanIfNeeded(
     return existingSchedules
   }
 
-  const created = await financeService.applyDefaultBookingPaymentPlan(db, bookingId, {
-    ...defaultPaymentPlan(options),
-    ...(input.paymentPlan ?? {}),
-  })
+  // Nobody stating deposit terms means "materialize what the operator
+  // configured", so the cascade comes along and the service runs the resolved
+  // policy through `computePaymentSchedule`. A per-call `paymentPlan` (or a
+  // deployment-wide `defaultPaymentPlan`) still overrides it (voyant#4744).
+  const created = await financeService.applyDefaultBookingPaymentPlan(
+    db,
+    bookingId,
+    mergePaymentPlanOverride(defaultPaymentPlan(options), input.paymentPlan ?? {}),
+    { paymentPolicyCascade: options.paymentPolicyCascade ?? null },
+  )
 
   return created ?? []
 }

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -474,6 +474,12 @@ export {
   stampPolicySourceOnBooking,
 } from "./payment-policy-cascade.js"
 export {
+  type BookingPaymentPolicyCascadeReaders,
+  type BookingPaymentPolicySubject,
+  resolveBookingPaymentPolicy,
+} from "./payment-schedule/booking-policy.js"
+export { resolveBookingPaymentPolicyCascade } from "./payment-schedule/booking-policy-runtime.js"
+export {
   type BookingScheduleRoutesOptions,
   createBookingScheduleAdminRoutes,
   createBookingScheduleApiExtension,

--- a/packages/finance/src/payment-schedule/booking-policy-runtime.ts
+++ b/packages/finance/src/payment-schedule/booking-policy-runtime.ts
@@ -1,0 +1,45 @@
+/**
+ * Reach the injected policy cascade from a route that isn't the
+ * booking-schedule route module.
+ *
+ * The cascade readers are deployment-supplied and land in the module
+ * container under {@link BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY} (the
+ * booking-schedule extension's bootstrap registers them there for the
+ * `booking.confirmed` subscriber). The `default-plan` route and the checkout
+ * collection runtime need the same answer, so they read the same registration
+ * instead of growing a second injection point that a deployment could wire
+ * differently — which is how voyant#4744 happened in the first place.
+ */
+
+import type { ModuleContainer } from "@voyant-travel/core"
+
+import {
+  BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY,
+  type BookingScheduleSubscriberRuntime,
+} from "../booking-schedule/subscriber-runtime.js"
+import type { BookingPaymentPolicyCascadeReaders } from "./booking-policy.js"
+
+/**
+ * The cascade readers this deployment composed, or `null` when it composes no
+ * booking-schedule extension.
+ *
+ * `null` is not a fallback to some other plan — callers treat an absent
+ * cascade as `noDepositPolicy`, the documented safe default for an
+ * unconfigured operator. A deployment that never configured a deposit gets
+ * "pay in full", not someone's guess at 30%.
+ */
+export async function resolveBookingPaymentPolicyCascade(
+  container: ModuleContainer | undefined,
+  bindings: unknown,
+): Promise<BookingPaymentPolicyCascadeReaders | null> {
+  if (!container?.has(BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY)) return null
+
+  try {
+    const runtime = container.resolve<BookingScheduleSubscriberRuntime>(
+      BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY,
+    )
+    return await runtime.resolveRoutesOptions(bindings)
+  } catch {
+    return null
+  }
+}

--- a/packages/finance/src/payment-schedule/booking-policy.ts
+++ b/packages/finance/src/payment-schedule/booking-policy.ts
@@ -1,0 +1,135 @@
+/**
+ * The one walk from a booking to the payment policy that governs it.
+ *
+ * Every surface that decides what a customer owes and when has to end up
+ * here. Before voyant#4744 two of them did not: `default-plan` and the
+ * checkout collection runtime carried their own `depositMode` /
+ * `depositValue` / `balanceDueDaysBeforeStart` trio with a hardcoded 30%
+ * fallback, so the same booking answered "what is the deposit?" differently
+ * depending on which route an operator or agent happened to call — and the
+ * operator editing the settings page saw neither number move.
+ *
+ * The cascade readers are INJECTED for the same reason they are on
+ * {@link import("./routes.js").BookingScheduleRoutesOptions}: resolving a
+ * supplier / category / listing layer means reading across vertical modules
+ * that `@voyant-travel/finance` must not statically import.
+ *
+ * The booking row is passed IN rather than loaded here. Every caller already
+ * holds it, and reading `bookings` from one more file would widen finance's
+ * reach into another module's table for nothing.
+ */
+
+import { getBookingOriginByBookingId } from "@voyant-travel/bookings"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  noDepositPolicy,
+  type PaymentPolicy,
+  type ResolvedPaymentPolicy,
+  resolveEffectivePaymentPolicy,
+} from "../payment-policy.js"
+
+/**
+ * The booking-keyed half of the policy cascade.
+ *
+ * Split out of `BookingScheduleRoutesOptions` (which extends it) so a caller
+ * that only needs "what does this booking owe" — the `default-plan` route, the
+ * checkout collection runtime — depends on these readers rather than on the
+ * whole route module's option bag.
+ */
+export interface BookingPaymentPolicyCascadeReaders {
+  /** Operator-default payment policy (the cascade's last-resort layer). */
+  resolveOperatorDefaultPaymentPolicy(db: PostgresJsDatabase): Promise<PaymentPolicy | null>
+  /** Supplier-layer override keyed off the booking's supplier link. */
+  resolveSupplierPolicy(db: PostgresJsDatabase, bookingId: string): Promise<PaymentPolicy | null>
+  /** Product-category override (first category by sortOrder). */
+  resolveCategoryPolicy(db: PostgresJsDatabase, bookingId: string): Promise<PaymentPolicy | null>
+  /** Per-listing override (first booking-item product policy). */
+  resolveListingPolicy(db: PostgresJsDatabase, bookingId: string): Promise<PaymentPolicy | null>
+  /**
+   * Terms stated on one accepted Proposal Version.
+   *
+   * Keyed by the Proposal Version rather than the booking on purpose: finance
+   * already owns the walk from a booking to its origin (`booking_origins` is
+   * bookings', which finance depends on acyclically), so the injected reader
+   * only ever touches `proposal_versions` — the one table its own module owns.
+   *
+   * Optional. A deployment that composes no proposals module leaves it unset
+   * and the cascade is exactly what it was before the layer existed.
+   */
+  resolveProposalVersionPolicy?(
+    db: PostgresJsDatabase,
+    proposalVersionId: string,
+  ): Promise<PaymentPolicy | null>
+}
+
+/** The booking columns the cascade reads. */
+export interface BookingPaymentPolicySubject {
+  id: string
+  customerPaymentPolicy: unknown
+}
+
+/**
+ * Walk the cascade for one booking: booking override → accepted proposal →
+ * listing → category → supplier → operator default.
+ */
+export async function resolveBookingPaymentPolicy(
+  db: PostgresJsDatabase,
+  booking: BookingPaymentPolicySubject,
+  readers: BookingPaymentPolicyCascadeReaders,
+): Promise<ResolvedPaymentPolicy> {
+  const operatorDefault = (await readers.resolveOperatorDefaultPaymentPolicy(db)) ?? noDepositPolicy
+
+  // Supplier-layer override. Falls back to operator default when the booking
+  // has no supplier link or the supplier hasn't configured a custom policy.
+  const supplierPolicy = await readers.resolveSupplierPolicy(db, booking.id)
+
+  // Product-category override. Walks the booking's products → categories and
+  // picks the first category (by productCategoryProducts.sortOrder ascending)
+  // that defines a policy. Wins over supplier per the cascade order.
+  const categoryPolicy = await readers.resolveCategoryPolicy(db, booking.id)
+
+  // Per-listing override. The first booking-item's product with a non-null
+  // customerPaymentPolicy wins. Most specific catalog layer — beats category,
+  // supplier, and operator default.
+  const listingPolicy = await readers.resolveListingPolicy(db, booking.id)
+
+  // The terms on the accepted Proposal Version this booking came from, when it
+  // came from one. This is what the customer agreed to, so it outranks every
+  // catalog default underneath it.
+  const proposalPolicy = await resolveAcceptedProposalPolicy(db, booking.id, readers)
+
+  // Booking-level override. The booking's own customerPaymentPolicy column
+  // wins over every catalog layer. Reserved for ops adjustments — most
+  // bookings leave this null.
+  const bookingPolicy = (booking.customerPaymentPolicy as PaymentPolicy | null | undefined) ?? null
+
+  return resolveEffectivePaymentPolicy({
+    bookingPolicy,
+    proposalPolicy,
+    listingPolicy,
+    categoryPolicy,
+    supplierPolicy,
+    operatorDefault,
+  })
+}
+
+/**
+ * The payment terms the customer agreed to, when this booking came from an
+ * accepted Proposal Version and that version stated any.
+ *
+ * `booking_origins` is the durable link, so this re-derives on every
+ * resolution rather than depending on anything having been copied onto the
+ * booking at commit time.
+ */
+async function resolveAcceptedProposalPolicy(
+  db: PostgresJsDatabase,
+  bookingId: string,
+  readers: BookingPaymentPolicyCascadeReaders,
+): Promise<PaymentPolicy | null> {
+  if (!readers.resolveProposalVersionPolicy) return null
+  const origin = await getBookingOriginByBookingId(db, bookingId)
+  if (origin?.originSource !== "accepted_proposal_version") return null
+  if (!origin.proposalVersionId) return null
+  return readers.resolveProposalVersionPolicy(db, origin.proposalVersionId)
+}

--- a/packages/finance/src/payment-schedule/routes.ts
+++ b/packages/finance/src/payment-schedule/routes.ts
@@ -26,7 +26,6 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { ActionLedgerRequestContextValues } from "@voyant-travel/action-ledger"
 import { appendActionLedgerMutation } from "@voyant-travel/action-ledger"
-import { getBookingOriginByBookingId } from "@voyant-travel/bookings"
 import { bookingActivityLog, bookings } from "@voyant-travel/bookings/schema"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { openApiValidationHook, parseJsonBody } from "@voyant-travel/hono"
@@ -56,6 +55,10 @@ import {
 } from "../runtime-port.js"
 import { bookingPaymentSchedules } from "../schema/booking-billing.js"
 import { financeService } from "../service.js"
+import {
+  type BookingPaymentPolicyCascadeReaders,
+  resolveBookingPaymentPolicy,
+} from "./booking-policy.js"
 
 export type { PaymentPolicyEntityContext }
 
@@ -67,35 +70,13 @@ export type { PaymentPolicyEntityContext }
  * product categories) that finance must not statically import. The bookings
  * schema and action-ledger appender are NOT injected — finance already depends
  * on both acyclically and imports them directly.
+ *
+ * The booking-keyed half is {@link BookingPaymentPolicyCascadeReaders}, shared
+ * with every other surface that has to answer what a booking owes.
  */
-export interface BookingScheduleRoutesOptions {
+export interface BookingScheduleRoutesOptions extends BookingPaymentPolicyCascadeReaders {
   /** Resolve the per-request drizzle db from the Hono context (`c.get("db")`). */
   resolveDb(c: Context): PostgresJsDatabase
-  /** Operator-default payment policy (the cascade's last-resort layer). */
-  resolveOperatorDefaultPaymentPolicy(db: PostgresJsDatabase): Promise<PaymentPolicy | null>
-
-  // ── Booking-keyed cascade (booking.confirmed + regenerate paths) ──────────
-  /** Phase 2: supplier-layer override keyed off the booking's supplier link. */
-  resolveSupplierPolicy(db: PostgresJsDatabase, bookingId: string): Promise<PaymentPolicy | null>
-  /** Phase 3: product-category override (first category by sortOrder). */
-  resolveCategoryPolicy(db: PostgresJsDatabase, bookingId: string): Promise<PaymentPolicy | null>
-  /** Phase 4: per-listing override (first booking-item product policy). */
-  resolveListingPolicy(db: PostgresJsDatabase, bookingId: string): Promise<PaymentPolicy | null>
-  /**
-   * Terms stated on one accepted Proposal Version.
-   *
-   * Keyed by the Proposal Version rather than the booking on purpose: finance
-   * already owns the walk from a booking to its origin (`booking_origins` is
-   * bookings', which finance depends on acyclically), so the injected reader
-   * only ever touches `proposal_versions` — the one table its own module owns.
-   *
-   * Optional. A deployment that composes no proposals module leaves it unset
-   * and the cascade is exactly what it was before the layer existed.
-   */
-  resolveProposalVersionPolicy?(
-    db: PostgresJsDatabase,
-    proposalVersionId: string,
-  ): Promise<PaymentPolicy | null>
 
   // ── Entity-keyed cascade (storefront resolve path) ────────────────────────
   resolveListingPolicyForEntity(
@@ -158,42 +139,7 @@ export async function generatePaymentScheduleForBooking(
     .limit(1)
   if (existingSchedule) return
 
-  const operatorDefault = (await options.resolveOperatorDefaultPaymentPolicy(db)) ?? noDepositPolicy
-
-  // Phase 2: supplier-layer override. Falls back to operator
-  // default when the booking has no supplier link or the supplier
-  // hasn't configured a custom policy.
-  const supplierPolicy = await options.resolveSupplierPolicy(db, bookingId)
-
-  // Phase 3: product-category override. Walks the booking's
-  // products → categories and picks the first category (by
-  // productCategoryProducts.sortOrder ascending) that defines a
-  // policy. Wins over supplier per the cascade order.
-  const categoryPolicy = await options.resolveCategoryPolicy(db, bookingId)
-
-  // Phase 4: per-listing override. The first booking-item's product
-  // with a non-null customerPaymentPolicy wins. Most specific catalog
-  // layer — beats category, supplier, and operator default.
-  const listingPolicy = await options.resolveListingPolicy(db, bookingId)
-
-  // Phase 5: the terms on the accepted Proposal Version this booking came
-  // from, when it came from one. This is what the customer agreed to, so it
-  // outranks every catalog default underneath it.
-  const proposalPolicy = await resolveAcceptedProposalPolicy(db, bookingId, options)
-
-  // Phase 6: booking-level override. The booking's own
-  // customerPaymentPolicy column wins over every catalog layer.
-  // Reserved for ops adjustments — most bookings leave this null.
-  const bookingPolicy = (booking.customerPaymentPolicy as PaymentPolicy | null | undefined) ?? null
-
-  const { policy, source } = resolveEffectivePaymentPolicy({
-    bookingPolicy,
-    proposalPolicy,
-    listingPolicy,
-    categoryPolicy,
-    supplierPolicy,
-    operatorDefault,
-  })
+  const { policy, source } = await resolveBookingPaymentPolicy(db, booking, options)
 
   const entries = computePaymentSchedule(
     {
@@ -231,26 +177,6 @@ export async function generatePaymentScheduleForBooking(
       entries,
     },
   })
-}
-
-/**
- * The payment terms the customer agreed to, when this booking came from an
- * accepted Proposal Version and that version stated any.
- *
- * `booking_origins` is the durable link, so this re-derives on every
- * regeneration rather than depending on anything having been copied onto the
- * booking at commit time.
- */
-async function resolveAcceptedProposalPolicy(
-  db: PostgresJsDatabase,
-  bookingId: string,
-  options: BookingScheduleRoutesOptions,
-): Promise<PaymentPolicy | null> {
-  if (!options.resolveProposalVersionPolicy) return null
-  const origin = await getBookingOriginByBookingId(db, bookingId)
-  if (origin?.originSource !== "accepted_proposal_version") return null
-  if (!origin.proposalVersionId) return null
-  return options.resolveProposalVersionPolicy(db, origin.proposalVersionId)
 }
 
 // ─────────────────────────────────────────────────────────────────

--- a/packages/finance/src/routes-booking-billing.ts
+++ b/packages/finance/src/routes-booking-billing.ts
@@ -36,6 +36,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { ActionLedgerIdempotencyConflictError } from "@voyant-travel/action-ledger"
 import { openApiValidationHook } from "@voyant-travel/hono"
 
+import { resolveBookingPaymentPolicyCascade } from "./payment-schedule/booking-policy-runtime.js"
 import { paymentSessionSchema } from "./routes-invoice-schemas.js"
 import { getActionLedgerRequestContext, getFinanceRouteRuntime } from "./routes-runtime.js"
 import { type Env, notFound } from "./routes-shared.js"
@@ -235,8 +236,10 @@ const applyDefaultBookingPaymentPlanRoute = createRoute({
     body: {
       required: true,
       description:
-        "Default payment-plan options. Every field is optional / defaulted, so " +
-        "a posted `{}` applies the default deposit/balance split.",
+        "Default payment-plan options. Every field is optional: a posted `{}` " +
+        "applies the operator's configured payment policy (booking → proposal → " +
+        "listing → category → supplier → operator default), and stating deposit " +
+        "terms overrides that policy for this call only.",
       content: { "application/json": { schema: applyDefaultBookingPaymentPlanSchema } },
     },
   },
@@ -391,6 +394,11 @@ const bookingPaymentScheduleRoutes = new OpenAPIHono<Env>({ defaultHook: openApi
       c.req.valid("json"),
       {
         eventBus: runtime?.eventBus,
+        // A caller that states no deposit terms gets the operator's configured
+        // policy, resolved through the same cascade `booking.confirmed` walks
+        // (voyant#4744). No cascade composed means no configured deposit, which
+        // the service reads as `noDepositPolicy` — pay in full.
+        paymentPolicyCascade: await resolveBookingPaymentPolicyCascade(c.var.container, c.env),
         actionLedgerContext: getActionLedgerRequestContext(c),
         actionLedgerAuthorizationSource: "finance.booking_payment_schedule.default_plan.route",
       },

--- a/packages/finance/src/service-booking-payment-schedules.ts
+++ b/packages/finance/src/service-booking-payment-schedules.ts
@@ -1,3 +1,5 @@
+import { computePaymentSchedule, noDepositPolicy, type PaymentPolicy } from "./payment-policy.js"
+import { resolveBookingPaymentPolicy } from "./payment-schedule/booking-policy.js"
 import { financePaymentProcessingService } from "./service-payment-processing.js"
 import type {
   ApplyDefaultBookingPaymentPlanInput,
@@ -34,6 +36,133 @@ import {
 
 export interface SettleBookingPaymentSchedulesResult {
   paidSchedules: Array<typeof bookingPaymentSchedules.$inferSelect>
+}
+
+type PlanBooking = Pick<
+  typeof bookings.$inferSelect,
+  "sellAmountCents" | "sellCurrency" | "startDate"
+>
+
+/**
+ * True when the caller stated deposit terms of its own.
+ *
+ * Only the three fields that answer "how much, and when is the rest due"
+ * count. `clearExistingPending` / `createGuarantee` / `guaranteeType` are about
+ * how the rows are written, not about what the customer owes, so they carry
+ * their own defaults and do not make a call an override.
+ */
+function statesDepositTerms(data: ApplyDefaultBookingPaymentPlanInput): boolean {
+  return (
+    data.depositMode !== undefined ||
+    data.depositValue !== undefined ||
+    data.balanceDueDaysBeforeStart !== undefined
+  )
+}
+
+/** The operator's configured policy, via the same primitive checkout reads. */
+function policyScheduleRows(
+  data: ApplyDefaultBookingPaymentPlanInput,
+  booking: PlanBooking,
+  policy: PaymentPolicy,
+  today: Date,
+): CreateBookingPaymentScheduleInput[] {
+  const entries = computePaymentSchedule(
+    {
+      totalCents: booking.sellAmountCents ?? 0,
+      currency: booking.sellCurrency,
+      departureDate: booking.startDate,
+      today,
+    },
+    policy,
+  )
+
+  return entries.map((entry) => {
+    const due = parseDateString(entry.dueDate) ?? today
+    return {
+      bookingItemId: null,
+      // The policy primitive's `full` row collapses to `balance` — the DB enum
+      // has no `full` variant, and the single full-payment row IS the balance.
+      scheduleType: entry.scheduleType === "full" ? "balance" : entry.scheduleType,
+      status: due <= today ? "due" : "pending",
+      dueDate: entry.dueDate,
+      dueTimeZone: "UTC",
+      currency: entry.currency,
+      amountCents: entry.amountCents,
+      notes: data.notes ?? null,
+    }
+  })
+}
+
+/**
+ * A plan the caller stated explicitly. Taken literally: no near-departure
+ * deposit gate and no balance-due floor, because the caller asked for these
+ * terms rather than for the operator's.
+ */
+function overrideScheduleRows(
+  data: ApplyDefaultBookingPaymentPlanInput,
+  booking: PlanBooking,
+  today: Date,
+): CreateBookingPaymentScheduleInput[] {
+  const totalAmountCents = booking.sellAmountCents ?? 0
+  const depositMode = data.depositMode ?? "none"
+  const depositValue = data.depositValue ?? 0
+  const balanceDueDaysBeforeStart = data.balanceDueDaysBeforeStart ?? 0
+
+  const depositDueDate = data.depositDueDate ? parseDateString(data.depositDueDate) : today
+  const startDate = booking.startDate ? parseDateString(booking.startDate) : null
+  const rawBalanceDueDate = startDate
+    ? new Date(startDate.getTime() - balanceDueDaysBeforeStart * 24 * 60 * 60 * 1000)
+    : today
+  const balanceDueDate = rawBalanceDueDate < today ? today : rawBalanceDueDate
+
+  let depositAmountCents = 0
+  if (depositMode === "fixed_amount") {
+    depositAmountCents = Math.min(totalAmountCents, depositValue)
+  } else if (depositMode === "percentage") {
+    depositAmountCents = Math.min(
+      totalAmountCents,
+      Math.round((totalAmountCents * depositValue) / 100),
+    )
+  }
+
+  if (depositAmountCents > 0 && depositAmountCents < totalAmountCents) {
+    return [
+      {
+        bookingItemId: null,
+        scheduleType: "deposit",
+        status: (depositDueDate ?? today) <= today ? "due" : "pending",
+        dueDate: toDateString(depositDueDate ?? today),
+        dueTimeZone: "UTC",
+        currency: booking.sellCurrency,
+        amountCents: depositAmountCents,
+        notes: data.notes ?? null,
+      },
+      {
+        bookingItemId: null,
+        scheduleType: "balance",
+        status: balanceDueDate <= today ? "due" : "pending",
+        dueDate: toDateString(balanceDueDate),
+        dueTimeZone: "UTC",
+        currency: booking.sellCurrency,
+        amountCents: Math.max(0, totalAmountCents - depositAmountCents),
+        notes: data.notes ?? null,
+      },
+    ]
+  }
+
+  const singleDueDate = balanceDueDate <= today ? today : balanceDueDate
+  return [
+    {
+      bookingItemId: null,
+      scheduleType: "balance",
+      status: singleDueDate <= today ? "due" : "pending",
+      dueDate: toDateString(singleDueDate),
+      dueTimeZone: "UTC",
+      currency: booking.sellCurrency,
+      amountCents: totalAmountCents,
+      notes: data.notes ?? null,
+    },
+  ]
 }
 
 export const financeBookingPaymentScheduleService = {
@@ -179,6 +308,27 @@ export const financeBookingPaymentScheduleService = {
     })
   },
 
+  /**
+   * Materialize a booking's payment plan.
+   *
+   * Two ways in, and which one applies is decided by what the caller stated:
+   *
+   *   - **Nothing stated** — the plan comes from the operator's configured
+   *     `PaymentPolicy` (resolved through the cascade by the caller and handed
+   *     over as `runtime.paymentPolicy`), run through `computePaymentSchedule`.
+   *     That is the same primitive `generatePaymentScheduleForBooking` uses, so
+   *     the near-departure deposit gate and the balance-due floor apply here
+   *     too. An absent policy means `noDepositPolicy` — pay in full — because
+   *     an unconfigured operator has not asked for a deposit.
+   *   - **Deposit terms stated** — a deliberate per-call override. Kept exactly
+   *     as it was: `depositDueDate` is honoured, and the split is taken
+   *     literally with no gate and no floor, because the caller asked for this
+   *     plan rather than the operator's.
+   *
+   * Before voyant#4744 there was no first branch: an unstated plan silently
+   * meant 30% with the balance 30 days out, contradicting whatever the operator
+   * had configured.
+   */
   async applyDefaultBookingPaymentPlan(
     db: PostgresJsDatabase,
     bookingId: string,
@@ -207,22 +357,6 @@ export const financeBookingPaymentScheduleService = {
         }
 
         const today = startOfUtcDay(new Date())
-        const depositDueDate = data.depositDueDate ? parseDateString(data.depositDueDate) : today
-        const startDate = booking.startDate ? parseDateString(booking.startDate) : null
-        const rawBalanceDueDate = startDate
-          ? new Date(startDate.getTime() - data.balanceDueDaysBeforeStart * 24 * 60 * 60 * 1000)
-          : today
-        const balanceDueDate = rawBalanceDueDate < today ? today : rawBalanceDueDate
-
-        let depositAmountCents = 0
-        if (data.depositMode === "fixed_amount") {
-          depositAmountCents = Math.min(totalAmountCents, data.depositValue)
-        } else if (data.depositMode === "percentage") {
-          depositAmountCents = Math.min(
-            totalAmountCents,
-            Math.round((totalAmountCents * data.depositValue) / 100),
-          )
-        }
 
         const clearableScheduleWhere = and(
           eq(bookingPaymentSchedules.bookingId, bookingId),
@@ -240,41 +374,20 @@ export const financeBookingPaymentScheduleService = {
           await tx.delete(bookingPaymentSchedules).where(clearableScheduleWhere)
         }
 
-        const scheduleRows: CreateBookingPaymentScheduleInput[] = []
-        if (depositAmountCents > 0 && depositAmountCents < totalAmountCents) {
-          scheduleRows.push({
-            bookingItemId: null,
-            scheduleType: "deposit",
-            status: depositDueDate <= today ? "due" : "pending",
-            dueDate: toDateString(depositDueDate),
-            dueTimeZone: "UTC",
-            currency: booking.sellCurrency,
-            amountCents: depositAmountCents,
-            notes: data.notes ?? null,
-          })
-          scheduleRows.push({
-            bookingItemId: null,
-            scheduleType: "balance",
-            status: balanceDueDate <= today ? "due" : "pending",
-            dueDate: toDateString(balanceDueDate),
-            dueTimeZone: "UTC",
-            currency: booking.sellCurrency,
-            amountCents: Math.max(0, totalAmountCents - depositAmountCents),
-            notes: data.notes ?? null,
-          })
-        } else {
-          const singleDueDate = balanceDueDate <= today ? today : balanceDueDate
-          scheduleRows.push({
-            bookingItemId: null,
-            scheduleType: "balance",
-            status: singleDueDate <= today ? "due" : "pending",
-            dueDate: toDateString(singleDueDate),
-            dueTimeZone: "UTC",
-            currency: booking.sellCurrency,
-            amountCents: totalAmountCents,
-            notes: data.notes ?? null,
-          })
-        }
+        // A caller that stated no deposit terms gets the operator's configured
+        // policy. Resolved from the booking row already in hand, through the
+        // cascade readers the deployment injected (voyant#4744).
+        const scheduleRows = statesDepositTerms(data)
+          ? overrideScheduleRows(data, booking, today)
+          : policyScheduleRows(
+              data,
+              booking,
+              runtime.paymentPolicyCascade
+                ? (await resolveBookingPaymentPolicy(tx, booking, runtime.paymentPolicyCascade))
+                    .policy
+                : noDepositPolicy,
+              today,
+            )
 
         const createdSchedules = await tx
           .insert(bookingPaymentSchedules)

--- a/packages/finance/src/service-shared.ts
+++ b/packages/finance/src/service-shared.ts
@@ -76,6 +76,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
 import { resolveFxMoneyBaseAmount } from "./fx-money.js"
 import type { InvoiceFxOptions } from "./invoice-fx.js"
+import type { BookingPaymentPolicyCascadeReaders } from "./payment-schedule/booking-policy.js"
 // Type-only: `runtime-port` reaches back into route modules that import this
 // one, so a value import here would close a cycle.
 import type { FinanceStoredInstrumentRuntime } from "./runtime-port.js"
@@ -1129,6 +1130,16 @@ export interface FinanceServiceRuntime extends InvoiceFxOptions {
    */
   storedInstrumentRecorder?: FinanceStoredInstrumentRuntime
   monthlyBookingLimit?: number | null
+  /**
+   * The deployment-injected readers for the customer payment-policy cascade
+   * (booking → proposal → listing → category → supplier → operator default).
+   *
+   * Injected rather than read here because resolving a supplier / category /
+   * listing layer means crossing into vertical modules finance must not
+   * statically import. Absent means `noDepositPolicy`: an operator who has
+   * configured no deposit is asking for payment in full, not for a guess.
+   */
+  paymentPolicyCascade?: BookingPaymentPolicyCascadeReaders | null
   actionLedgerContext?: ActionLedgerRequestContextValues
   actionLedgerAuthorizationSource?: string | null
   actionLedgerActionName?: string | null

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -3596,6 +3596,28 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       expect(guaranteesBody.data[0].bookingPaymentScheduleId).toBe(data[0].id)
       expect(guaranteesBody.data[0].amountCents).toBe(30000)
     })
+
+    it("charges in full when no deposit terms are stated and no policy is wired", async () => {
+      const booking = await seedBooking({
+        sellCurrency: "EUR",
+        sellAmountCents: 100000,
+        startDate: "2099-06-10",
+      })
+
+      const res = await app.request(`/bookings/${booking.id}/payment-schedules/default-plan`, {
+        method: "POST",
+        ...json({}),
+      })
+
+      expect(res.status).toBe(201)
+      const { data } = await res.json()
+      // voyant#4744: an empty body used to mean 30% / balance 30 days out
+      // regardless of what the operator had configured. With no policy cascade
+      // composed it now means `noDepositPolicy` — the whole amount, due today.
+      expect(data).toHaveLength(1)
+      expect(data[0].scheduleType).toBe("balance")
+      expect(data[0].amountCents).toBe(100000)
+    })
   })
 
   // ── Booking Guarantees ────────────────────────────────────────

--- a/packages/finance/tests/unit/booking-payment-plan-policy.test.ts
+++ b/packages/finance/tests/unit/booking-payment-plan-policy.test.ts
@@ -1,0 +1,198 @@
+/**
+ * voyant#4744 — the default booking payment plan must come from the operator's
+ * configured `PaymentPolicy`, not from a hardcoded 30% / 30-days plan standing
+ * beside it.
+ *
+ * The three cases that matter are: an unstated plan follows the policy, an
+ * unconfigured operator gets full payment (not a guess), and a caller who
+ * states terms still gets exactly those terms.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@voyant-travel/db/booking-finance-fence", () => ({
+  withBookingFinanceInsertionFence: <T>(
+    db: unknown,
+    _bookingId: string,
+    operation: (tx: unknown) => Promise<T>,
+  ) => operation(db),
+  lockBookingFinanceInsertionFence: async () => {},
+}))
+
+import type { PaymentPolicy } from "../../src/payment-policy.js"
+import type { BookingPaymentPolicyCascadeReaders } from "../../src/payment-schedule/booking-policy.js"
+import { financeBookingPaymentScheduleService } from "../../src/service-booking-payment-schedules.js"
+
+/** A cascade whose operator default is the policy under test. */
+function cascadeFor(policy: PaymentPolicy | null): BookingPaymentPolicyCascadeReaders {
+  return {
+    resolveOperatorDefaultPaymentPolicy: async () => policy,
+    resolveSupplierPolicy: async () => null,
+    resolveCategoryPolicy: async () => null,
+    resolveListingPolicy: async () => null,
+  }
+}
+
+type InsertedRow = {
+  scheduleType: string
+  amountCents: number
+  dueDate: string
+  status: string
+  currency: string
+}
+
+/**
+ * Chainable drizzle stub.
+ *
+ * `.limit()` is the booking read — the only query in this path that narrows to
+ * one row. `.where()` may be a link or a terminal, so it returns a real Promise
+ * carrying the chain's methods: awaiting it yields the empty clearable-schedule
+ * set, and calling `.limit()` on it still reaches the booking. `.returning()`
+ * plays back whatever `.values()` was handed.
+ */
+function makeDbStub(booking: Record<string, unknown>) {
+  const inserted: InsertedRow[] = []
+  let pendingInsert: InsertedRow[] = []
+
+  const chain: Record<string, unknown> = {}
+  for (const method of ["select", "from", "set", "delete", "update", "insert"]) {
+    chain[method] = vi.fn(() => chain)
+  }
+  chain.limit = vi.fn(() => Promise.resolve([booking]))
+  chain.orderBy = vi.fn(() => Promise.resolve([]))
+  chain.returning = vi.fn(() => Promise.resolve(pendingInsert))
+  chain.values = vi.fn((rows: InsertedRow[] | InsertedRow) => {
+    pendingInsert = Array.isArray(rows) ? rows : [rows]
+    inserted.push(...pendingInsert)
+    return chain
+  })
+  chain.where = vi.fn(() => Object.assign(Promise.resolve([]), chain))
+
+  return { db: chain as never, inserted }
+}
+
+const fiftyPercentFourteenDays: PaymentPolicy = {
+  deposit: { kind: "percent", percent: 50 },
+  minDaysBeforeDepartureForDeposit: 0,
+  balanceDueDaysBeforeDeparture: 14,
+  balanceDueMinDaysFromNow: 0,
+}
+
+const booking = {
+  id: "bk_1",
+  sellAmountCents: 37_800,
+  sellCurrency: "EUR",
+  startDate: "2026-09-20",
+}
+
+const basePlan = { clearExistingPending: true, createGuarantee: false, guaranteeType: "deposit" }
+
+describe("applyDefaultBookingPaymentPlan — deposit terms come from the policy", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-08-16T09:00:00Z"))
+  })
+
+  it("splits by the operator's configured policy when the caller states no terms", async () => {
+    const stub = makeDbStub(booking)
+
+    await financeBookingPaymentScheduleService.applyDefaultBookingPaymentPlan(
+      stub.db,
+      "bk_1",
+      basePlan as never,
+      { paymentPolicyCascade: cascadeFor(fiftyPercentFourteenDays) },
+    )
+
+    // The issue's booking: €378.00 departing 2026-09-20, operator configured
+    // 50% with the balance 14 days out. The old code answered 30%/30-days.
+    expect(stub.inserted).toHaveLength(2)
+    expect(stub.inserted[0]).toMatchObject({
+      scheduleType: "deposit",
+      amountCents: 18_900,
+      dueDate: "2026-08-16",
+    })
+    expect(stub.inserted[1]).toMatchObject({
+      scheduleType: "balance",
+      amountCents: 18_900,
+      dueDate: "2026-09-06",
+    })
+  })
+
+  it("honours the policy's near-departure deposit gate", async () => {
+    const stub = makeDbStub(booking)
+
+    await financeBookingPaymentScheduleService.applyDefaultBookingPaymentPlan(
+      stub.db,
+      "bk_1",
+      basePlan as never,
+      {
+        paymentPolicyCascade: cascadeFor({
+          ...fiftyPercentFourteenDays,
+          minDaysBeforeDepartureForDeposit: 60,
+        }),
+      },
+    )
+
+    // Departure is 35 days out, inside the 60-day gate — the agency has no
+    // time to chase a balance, so the whole amount is due now. The plan
+    // fields the old model carried could not express this at all.
+    expect(stub.inserted).toHaveLength(1)
+    expect(stub.inserted[0]).toMatchObject({
+      scheduleType: "balance",
+      amountCents: 37_800,
+      dueDate: "2026-08-16",
+    })
+  })
+
+  it("charges in full when no cascade is composed, rather than guessing 30%", async () => {
+    const stub = makeDbStub(booking)
+
+    await financeBookingPaymentScheduleService.applyDefaultBookingPaymentPlan(
+      stub.db,
+      "bk_1",
+      basePlan as never,
+      {},
+    )
+
+    expect(stub.inserted).toHaveLength(1)
+    expect(stub.inserted[0]).toMatchObject({ scheduleType: "balance", amountCents: 37_800 })
+  })
+
+  it("takes a caller-stated plan literally, ignoring the policy", async () => {
+    const stub = makeDbStub(booking)
+
+    await financeBookingPaymentScheduleService.applyDefaultBookingPaymentPlan(
+      stub.db,
+      "bk_1",
+      {
+        ...basePlan,
+        depositMode: "percentage",
+        depositValue: 20,
+        balanceDueDaysBeforeStart: 7,
+      } as never,
+      { paymentPolicyCascade: cascadeFor(fiftyPercentFourteenDays) },
+    )
+
+    expect(stub.inserted).toHaveLength(2)
+    expect(stub.inserted[0]).toMatchObject({ scheduleType: "deposit", amountCents: 7_560 })
+    expect(stub.inserted[1]).toMatchObject({
+      scheduleType: "balance",
+      amountCents: 30_240,
+      dueDate: "2026-09-13",
+    })
+  })
+
+  it("treats a stated fixed deposit as an override even with a percent policy", async () => {
+    const stub = makeDbStub(booking)
+
+    await financeBookingPaymentScheduleService.applyDefaultBookingPaymentPlan(
+      stub.db,
+      "bk_1",
+      { ...basePlan, depositMode: "fixed_amount", depositValue: 10_000 } as never,
+      { paymentPolicyCascade: cascadeFor(fiftyPercentFourteenDays) },
+    )
+
+    expect(stub.inserted[0]).toMatchObject({ scheduleType: "deposit", amountCents: 10_000 })
+    expect(stub.inserted[1]).toMatchObject({ scheduleType: "balance", amountCents: 27_800 })
+  })
+})

--- a/packages/finance/tests/unit/booking-policy-runtime.test.ts
+++ b/packages/finance/tests/unit/booking-policy-runtime.test.ts
@@ -1,0 +1,83 @@
+/**
+ * voyant#4744 — the surfaces that were carrying their own deposit model reach
+ * the cascade through the container registration the `booking.confirmed`
+ * subscriber already uses, so there is one wiring point rather than two that a
+ * deployment could fill in differently.
+ */
+
+import { describe, expect, it, vi } from "vitest"
+
+import { BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY } from "../../src/booking-schedule/subscriber-runtime.js"
+import { defaultPaymentPlan } from "../../src/checkout-service-plan.js"
+import { noDepositPolicy, type PaymentPolicy } from "../../src/payment-policy.js"
+import { resolveBookingPaymentPolicy } from "../../src/payment-schedule/booking-policy.js"
+import { resolveBookingPaymentPolicyCascade } from "../../src/payment-schedule/booking-policy-runtime.js"
+
+const supplierPolicy: PaymentPolicy = {
+  deposit: { kind: "percent", percent: 50 },
+  minDaysBeforeDepartureForDeposit: 0,
+  balanceDueDaysBeforeDeparture: 14,
+  balanceDueMinDaysFromNow: 0,
+}
+
+const baseReaders = {
+  resolveOperatorDefaultPaymentPolicy: vi.fn(async () => noDepositPolicy),
+  resolveSupplierPolicy: vi.fn(async () => null),
+  resolveCategoryPolicy: vi.fn(async () => null),
+  resolveListingPolicy: vi.fn(async () => null),
+}
+
+function makeContainer(readers: Record<string, unknown>) {
+  return {
+    has: (key: string) => key === BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY,
+    resolve: () => ({
+      resolveRoutesOptions: async () => readers,
+      withDb: async () => undefined,
+    }),
+  } as never
+}
+
+describe("resolveBookingPaymentPolicyCascade", () => {
+  it("is absent when no booking-schedule extension is composed", async () => {
+    expect(await resolveBookingPaymentPolicyCascade(undefined, {})).toBeNull()
+    expect(await resolveBookingPaymentPolicyCascade({ has: () => false } as never, {})).toBeNull()
+  })
+
+  it("hands back the deployment's injected readers", async () => {
+    const readers = { ...baseReaders, resolveSupplierPolicy: async () => supplierPolicy }
+
+    const resolved = await resolveBookingPaymentPolicyCascade(makeContainer(readers), {})
+
+    expect(resolved).toBe(readers)
+    // And those readers answer the cascade the same way the subscriber does.
+    expect(
+      await resolveBookingPaymentPolicy(
+        {} as never,
+        { id: "bk_1", customerPaymentPolicy: null },
+        // biome-ignore lint/suspicious/noExplicitAny: the stub is shaped by the interface it satisfies.
+        resolved as any,
+      ),
+    ).toEqual({ policy: supplierPolicy, source: "supplier" })
+  })
+})
+
+describe("defaultPaymentPlan", () => {
+  it("states no deposit terms when the deployment configured none", () => {
+    const plan = defaultPaymentPlan({})
+
+    // These three being undefined is what makes the collection runtime take
+    // the operator's configured policy. They used to be percentage / 30 / 30.
+    expect(plan.depositMode).toBeUndefined()
+    expect(plan.depositValue).toBeUndefined()
+    expect(plan.balanceDueDaysBeforeStart).toBeUndefined()
+    expect(plan.clearExistingPending).toBe(true)
+  })
+
+  it("passes a deliberately configured override through", () => {
+    const plan = defaultPaymentPlan({
+      defaultPaymentPlan: { depositMode: "fixed_amount", depositValue: 5_000 },
+    })
+
+    expect(plan).toMatchObject({ depositMode: "fixed_amount", depositValue: 5_000 })
+  })
+})


### PR DESCRIPTION
Closes #4744.

## The problem

Two independent deposit models answered the same question differently for the same booking.

`PaymentPolicy` (`packages/finance/src/payment-policy.ts`) is what the admin settings page edits and what checkout reads — a deposit rule, a near-departure gate, a balance offset before departure, a floor from today, resolved most-specific-wins by `resolveEffectivePaymentPolicy`.

`CheckoutPolicyOptions.defaultPaymentPlan` was the other one: `depositMode` / `depositValue` / `balanceDueDaysBeforeStart`, **defaulted to 30% with the balance 30 days before start**, backing `payment-schedules/default-plan` and the checkout collection runtime. It never consulted the cascade. An operator who configured 50% with the balance 14 days out got 30% / 30 days from those two surfaces, with nothing on screen explaining why — and whichever surface an agent happened to call decided what the customer owed.

## The change

`default-plan` and the collection runtime now resolve the operator's effective policy through the same cascade `booking.confirmed` walks (booking → proposal → listing → category → supplier → operator default) and run it through `computePaymentSchedule`. That also means the near-departure deposit gate and the balance-due floor apply on these paths, which the old plan fields could not express at all.

Stating deposit terms on the call is still honoured verbatim as a deliberate per-call override, `depositDueDate` included. Only the three fields that answer "how much, and when is the rest due" mark a call as an override — `clearExistingPending` / `createGuarantee` / `guaranteeType` are about how rows are written, not about what the customer owes, so they keep their defaults.

The hardcoded 30/30 fallback is gone. An operator with no configured policy gets `noDepositPolicy` — payment in full — which is the documented safe default.

### Shape

- `packages/finance/src/payment-schedule/booking-policy.ts` — the one booking-keyed cascade walk, plus the reader interface `BookingScheduleRoutesOptions` now extends. It takes the booking row rather than loading it, so finance does not widen its reach into the `bookings` table; the accepted-proposal layer moved here too, so every surface gets the identical answer instead of only the subscriber path.
- `packages/finance/src/payment-schedule/booking-policy-runtime.ts` — reaches the deployment-injected readers through the container registration the `booking.confirmed` subscriber already uses, rather than adding a second injection point a deployment could fill in differently. That second wiring point is how this bug happened.

## Behaviour change

A deployment relying on the implicit 30% default now gets whatever its `PaymentPolicy` says, or payment in full if it has configured none. Called out in the changeset as a release note.

## Verification

Build (`turbo run build --filter=@voyant-travel/finance`, 22/22 tasks) and `pnpm -F @voyant-travel/finance test` — 84 files, 656 tests, 0 failures — run green on a clean checkout of this branch. The five new service tests cover the issue's exact booking (€378.00, departing 2026-09-20, 50% / 14 days → 18900 due today + 18900 due 2026-09-06), the deposit gate, the unconfigured-operator case, and both override shapes.

## A gap this exposed

`packages/finance/tests/integration/routes.test.ts` is **not** in the `db-integration` lane's file list, so it does not run in CI (voyant#4251). Running it locally against the test DB caught a 500 on every `default-plan` request — `container?.has is not a function`, because `c.var.container` is whatever the host put there and a harness leaves a plain object in that slot. It broke the *pre-existing* near-departure-guard test too, and every CI job was green on it.

Fixed in the second commit (shape-check the container, and ignore a registration that cannot answer the whole cascade, with unit coverage for both). Locally: `routes.test.ts` 149/149 pass, and the two new unit files 11/11.

I did not add the file to the lane here — it takes ~4 minutes and the lane already runs 11-13 against a 20-minute cap that its own comment describes as a backstop rather than a budget. That is a CI-budget call for #4251, not part of this fix.