### PR TITLE
Name the cabin in a sourced cruise's rate rows

### DIFF
--- a/.changeset/cruise-cabin-name-join.md
+++ b/.changeset/cruise-cabin-name-join.md
@@ -1,0 +1,23 @@
+---
+"@voyant-travel/catalog-react": patch
+---
+
+Name the cabin in a sourced cruise's rate rows instead of printing the provider's raw id.
+
+The per-cabin rate rows under a selected sailing join live pricing to catalog
+cabins by provider id. The decode behind that join only understood the
+SourceRef-wrapped catalog id (`<prefix>_sr_<base64url>`) and returned `null` for
+anything else — but the cruise content adapter emits cabin category ids as bare
+provider ids (`88-from-2027_CLASSIC`). So no cabin carried an external id, the
+join never matched, and every row fell back to printing the id where the cabin
+name belongs.
+
+A catalog id is now read for what it is: unwrapped when it carries a SourceRef,
+taken verbatim when it does not — the same rule
+`sourceRefFromExternalKeyRef` already applies in `@voyant-travel/cruises`, where
+an unwrappable ref is a raw external id rather than an absent one. The join
+itself is now a named `findCabinForPrice` so it is the thing under test.
+
+Only visible now that per-cabin pricing returns rows at all; a platform ingest
+bug had aborted every pricing chunk before it wrote, so the join had never run
+against real data.

--- a/packages/catalog-react/src/components/cruise-detail-page-parts.ts
+++ b/packages/catalog-react/src/components/cruise-detail-page-parts.ts
@@ -15,7 +15,10 @@ export interface CruiseSailing {
 
 export interface CruiseCabin {
   id: string
-  /** Provider cabin code (e.g. `omi_V`) — joins to live pricing rows. */
+  /**
+   * Provider cabin id (e.g. `omi_V`, `88-from-2027_CLASSIC`) — the join key
+   * against a live pricing row's `code`. See `providerExternalIdFromCatalogId`.
+   */
   externalId: string | null
   name: string
   type: string | null
@@ -118,7 +121,7 @@ export function mapCruiseContent(content: unknown): CruiseDetail | null {
       const r = asRecord(row) ?? {}
       return {
         id: asStr(r.id) ?? `cabin-${i}`,
-        externalId: decodeCatalogExternalId(asStr(r.id)),
+        externalId: providerExternalIdFromCatalogId(asStr(r.id)),
         // Pure mapper, no messages in scope; "Cabin" is a last-resort fallback for an unnamed upstream cabin, not chrome copy.
         // i18n-literal-ok
         name: asStr(r.name) ?? asStr(r.code) ?? "Cabin",
@@ -172,12 +175,28 @@ export function formatDay(iso: string | null, locale?: string): string {
   }).format(d)
 }
 
-// Catalog ids are `<prefix>_sr_<base64url(JSON{externalId,…})>`; pull the
-// provider externalId so cabins can join to live pricing rows.
-function decodeCatalogExternalId(id: string | null): string | null {
+/**
+ * The provider id a catalog id stands for — the join key against a live pricing
+ * row's `code`.
+ *
+ * A catalog id arrives in one of two shapes, and only one of them wraps
+ * anything:
+ *
+ * - `<prefix>_sr_<base64url(JSON{externalId,…})>` — the SourceRef-wrapped id the
+ *   catalog plane builds for a sourced entity; the provider id is inside it.
+ * - a bare provider id (`88-from-2027_CLASSIC`) — what the cruise content
+ *   adapter emits for a cabin category. It already *is* the provider id.
+ *
+ * Anything that does not decode is the second shape, matching
+ * `sourceRefFromExternalKeyRef` in `@voyant-travel/cruises`: an unwrappable ref
+ * is a raw external id, not an absent one. Returning `null` for the bare shape
+ * instead left every cabin unjoinable, so the rate rows printed the raw
+ * provider id where the cabin name belongs (#4766).
+ */
+export function providerExternalIdFromCatalogId(id: string | null): string | null {
   if (!id) return null
   const idx = id.indexOf("_sr_")
-  if (idx < 0) return null
+  if (idx < 0) return id
   try {
     const b64 = id
       .slice(idx + 4)
@@ -185,10 +204,22 @@ function decodeCatalogExternalId(id: string | null): string | null {
       .replace(/_/g, "/")
     const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4)
     const obj = JSON.parse(atob(padded)) as { externalId?: string }
-    return typeof obj.externalId === "string" ? obj.externalId : null
+    return typeof obj.externalId === "string" && obj.externalId.length > 0 ? obj.externalId : id
   } catch {
-    return null
+    return id
   }
+}
+
+/**
+ * The catalog cabin a live pricing row describes. Named and exported so the
+ * page's join is the one under test — the bug in #4766 was the join failing,
+ * not the decode in isolation.
+ */
+export function findCabinForPrice(
+  cabins: CruiseCabin[],
+  price: CabinPrice,
+): CruiseCabin | undefined {
+  return cabins.find((c) => c.externalId === price.code)
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/packages/catalog-react/src/components/cruise-detail-page.tsx
+++ b/packages/catalog-react/src/components/cruise-detail-page.tsx
@@ -27,6 +27,7 @@ import {
   type CabinPrice,
   type CruiseDetail,
   type CruiseSailing,
+  findCabinForPrice,
   formatCruiseType,
   formatDay,
   formatMoney,
@@ -400,7 +401,7 @@ export function CruiseDetailPage({
                         ) : isActive && cabinPricing && cabinPricing.cabins.length > 0 ? (
                           <ul className="divide-y">
                             {cabinPricing.cabins.map((cab) => {
-                              const cabin = detail.cabins.find((c) => c.externalId === cab.code)
+                              const cabin = findCabinForPrice(detail.cabins, cab)
                               return (
                                 <li
                                   key={cab.code}

--- a/packages/catalog-react/tests/cruise-detail-page-parts.test.ts
+++ b/packages/catalog-react/tests/cruise-detail-page-parts.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  type CabinPrice,
+  findCabinForPrice,
+  mapCruiseContent,
+  providerExternalIdFromCatalogId,
+} from "../src/components/cruise-detail-page-parts.js"
+
+function sourceRefId(prefix: string, ref: Record<string, unknown>): string {
+  const json = JSON.stringify(ref)
+  const b64 = btoa(json).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+  return `${prefix}_sr_${b64}`
+}
+
+function price(code: string): CabinPrice {
+  return { code, fromAmountMinor: 249_900, available: true }
+}
+
+/**
+ * The cabin rate rows under a sailing join live pricing to catalog cabins by
+ * provider id. #4766: the Uniworld content payload emits cabin category ids as
+ * bare provider ids, the decode only understood the SourceRef-wrapped form, and
+ * every row rendered `88-from-2027_CLASSIC` where `Classic` belongs.
+ */
+describe("providerExternalIdFromCatalogId", () => {
+  it("passes a bare provider id through — it already is the external id", () => {
+    expect(providerExternalIdFromCatalogId("88-from-2027_CLASSIC")).toBe("88-from-2027_CLASSIC")
+  })
+
+  it("unwraps a SourceRef-wrapped catalog id", () => {
+    const id = sourceRefId("cbcat", { connectionId: "cnx_1", externalId: "omi_V" })
+    expect(providerExternalIdFromCatalogId(id)).toBe("omi_V")
+  })
+
+  it("treats an undecodable `_sr_` id as a raw external id", () => {
+    expect(providerExternalIdFromCatalogId("cbcat_sr_not-base64!!")).toBe("cbcat_sr_not-base64!!")
+  })
+
+  it("treats a decodable ref with no externalId as a raw external id", () => {
+    const id = sourceRefId("cbcat", { connectionId: "cnx_1" })
+    expect(providerExternalIdFromCatalogId(id)).toBe(id)
+  })
+
+  it("has no external id for a cabin the payload gave no id", () => {
+    expect(providerExternalIdFromCatalogId(null)).toBeNull()
+  })
+})
+
+describe("cabin rate row join", () => {
+  const content = {
+    cruise: { name: "Castles Along the Rhine" },
+    cabin_categories: [
+      { id: "88-from-2027_CLASSIC", code: "CLASSIC", name: "Classic" },
+      { id: "88-from-2027_SUITE", code: "SUITE", name: "Suite", view_type: "balcony" },
+      { id: sourceRefId("cbcat", { externalId: "omi_V" }), code: "V", name: "Veranda" },
+    ],
+  }
+
+  it("names a cabin whose catalog id is a bare provider id", () => {
+    const detail = mapCruiseContent(content)
+    expect(detail).not.toBeNull()
+    const cabin = findCabinForPrice(detail?.cabins ?? [], price("88-from-2027_CLASSIC"))
+    expect(cabin?.name).toBe("Classic")
+  })
+
+  it("still names a cabin whose catalog id is SourceRef-wrapped", () => {
+    const detail = mapCruiseContent(content)
+    expect(findCabinForPrice(detail?.cabins ?? [], price("omi_V"))?.name).toBe("Veranda")
+  })
+
+  it("resolves every cabin the pricing route returned for the affected cruise", () => {
+    const detail = mapCruiseContent(content)
+    const names = ["88-from-2027_CLASSIC", "88-from-2027_SUITE"].map(
+      (code) => findCabinForPrice(detail?.cabins ?? [], price(code))?.name,
+    )
+    expect(names).toEqual(["Classic", "Suite"])
+  })
+
+  it("matches nothing for a code the catalog has no cabin for", () => {
+    const detail = mapCruiseContent(content)
+    expect(findCabinForPrice(detail?.cabins ?? [], price("88-from-2027_UNKNOWN"))).toBeUndefined()
+  })
+
+  it("does not join an unidentified cabin to an arbitrary price row", () => {
+    const detail = mapCruiseContent({
+      cruise: { name: "x" },
+      cabin_categories: [{ name: "Classic" }],
+    })
+    expect(detail?.cabins[0]?.externalId).toBeNull()
+    expect(findCabinForPrice(detail?.cabins ?? [], price("88-from-2027_CLASSIC"))).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Fixes #4766.

## What was wrong

The per-cabin rate rows under a selected sailing join live pricing to catalog cabins by provider id:

```ts
const cabin = detail.cabins.find((c) => c.externalId === cab.code)
…
{cabin?.name ?? cab.code}
```

`externalId` came from a decode that only understood the SourceRef-wrapped catalog id, `<prefix>_sr_<base64url>`, and returned `null` for anything else. The cruise content adapter emits cabin category ids as **bare provider ids** — `88-from-2027_CLASSIC` — so no cabin carried an external id, the `find` never matched, and every row fell through to printing the raw id where the cabin name belongs.

Only visible now that per-cabin pricing returns rows at all: a `market` bind bug in platform ingest (voyant-travel/platform#2305) had aborted every pricing chunk before it wrote, so the join had never run against real data.

## The fix

Read a catalog id for what it is. Unwrap it when it carries a SourceRef; take it verbatim when it does not — including when it *looks* wrapped but does not decode. That is the rule `sourceRefFromExternalKeyRef` already applies in `@voyant-travel/cruises` ("an unwrappable ref is a raw external id, not an absent one"), so the two halves of the codebase now agree on what a bare id means. The helper is renamed `providerExternalIdFromCatalogId` to say what it returns rather than what it parses.

The issue asked whether the old `null` was load-bearing anywhere as "this is not a SourceRef id". It was not — `decodeCatalogExternalId` had exactly one caller, the cabin mapper, and its result had exactly one consumer, this join. So no split into two helpers is needed; there is only one question being asked of a catalog id here.

The join itself moves out of the page into a named `findCabinForPrice`, so the test exercises the thing that broke rather than a copy of it.

## Verification

`packages/catalog-react/tests/cruise-detail-page-parts.test.ts` drives `mapCruiseContent` over the content shape from the issue and joins it against the pricing codes the route returns — the real path, not a hand-built cabin.

```
✓ passes a bare provider id through — it already is the external id
✓ unwraps a SourceRef-wrapped catalog id
✓ treats an undecodable `_sr_` id as a raw external id
✓ treats a decodable ref with no externalId as a raw external id
✓ has no external id for a cabin the payload gave no id
✓ names a cabin whose catalog id is a bare provider id
✓ still names a cabin whose catalog id is SourceRef-wrapped
✓ resolves every cabin the pricing route returned for the affected cruise
✓ matches nothing for a code the catalog has no cabin for
✓ does not join an unidentified cabin to an arbitrary price row

Test Files  1 passed (1)   Tests  10 passed (10)
```

Control: restoring the old `if (idx < 0) return null` turns **3 of the 10 red** — the test would have caught this.

Full package suite: 19 files / 131 tests passed. Biome clean on the changed files. Typecheck and build are running on the lab against this branch.

Not confirmed in a browser — flights/cruise sourcing cannot be exercised locally (no connector in-repo), so the visual confirm the issue asks for still wants doing against a deployment with Uniworld pricing synced.