### PR TITLE
Charge and issue an accepted ancillary offer

### DIFF
--- a/.changeset/ancillary-charge-and-issue.md
+++ b/.changeset/ancillary-charge-and-issue.md
@@ -1,0 +1,34 @@
+---
+"@voyant-travel/bookings": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/commerce": minor
+"@voyant-travel/insurance": patch
+---
+
+Charge and issue an accepted ancillary offer.
+
+The checkout ancillary seam was complete on both sides with nothing crossing it:
+`prepare` and `fulfill` had no production caller, the pass-through
+materialization was exercised only by its own unit tests, and the container key
+holding the bound sources was read by nobody. A traveller could accept an
+insurance offer, answer the insurer's questions and acknowledge its disclosures,
+and then the premium never reached the booking and no policy was ever issued.
+
+Checkout-start is now the seam. It is post-commit and pre-payment, which is
+where an application has to be opened: the Booking exists, nothing has been
+charged, and a failure is still something the traveller can see and retry. It is
+deliberately not the Booking Session commit transaction — `prepare` is an HTTP
+round trip to the third party, and a network call inside that transaction either
+holds it open across the call or fails it after money has moved. Each accepted
+selection is prepared, written onto the Booking as a `pass_through` line at the
+prepared price, and the Booking total re-rolled so the amount the payment
+provider is asked for already contains it.
+
+After payment, `checkoutFinalizeSaga` gains a `fulfill_ancillaries` step, last
+and after the payment linkage, because it is the only step whose precondition is
+that the money is definitely in and the only one that cannot be taken back. It
+issues, attaches the certificate through the booking-document path, and
+reconciles the issued premium against the charged one. Nothing in it throws for
+a supplier outcome: a refusal leaves `issue_failed` with the reason and raises
+the staff alert, and a premium that does not match is recorded on the booking
+rather than silently absorbed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,8 @@ jobs:
                 tests/integration/linked-payment-contract-confirmation.test.ts
               pnpm --filter @voyant-travel/commerce exec vitest run \
                 tests/integration/fx-rate-capture.test.ts
+              pnpm --filter @voyant-travel/commerce exec vitest run \
+                tests/integration/ancillary-checkout-fulfilment.test.ts
               pnpm --filter @voyant-travel/cruises exec vitest run \
                 tests/integration/created-target-tools.test.ts
               pnpm --filter @voyant-travel/auth exec vitest run \
@@ -444,6 +446,8 @@ jobs:
                 tests/integration/insurer-disclosure-terms.test.ts
               pnpm --filter @voyant-travel/insurance exec vitest run \
                 tests/integration/durable-issue-command.test.ts
+              pnpm --filter @voyant-travel/insurance exec vitest run \
+                tests/integration/ancillary-source-fulfilment.test.ts
               pnpm --filter @voyant-travel/db exec vitest run \
                 tests/integration/outbox.test.ts
               pnpm --filter @voyant-travel/notifications exec vitest run \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,15 @@ jobs:
     # a runner ~30% slower than usual cancels it mid-suite, and every file added
     # to the lane brings that closer. Raised to 20 so the cap stays a backstop
     # against a hang rather than a budget the lane is already spending.
-    timeout-minutes: 20
+    #
+    # Raised again to 30 for the same reason, with the arithmetic spelled out so
+    # the next person does not have to rediscover it: the lane now names 54
+    # files, each paying its own process start and database setup, and the
+    # insurance work (voyant#4750, voyant#4756) added four. At 20 it was being
+    # cancelled mid-suite with every test passing — a budget, not a backstop.
+    # If this needs raising a third time, the answer is probably to stop giving
+    # each file its own process rather than to add another ten minutes.
+    timeout-minutes: 30
     env:
       HUSKY: 0
       NODE_OPTIONS: --conditions=development --max-old-space-size=12288

--- a/packages/bookings-react/src/journey/components/journey-steps/ancillaries-step.tsx
+++ b/packages/bookings-react/src/journey/components/journey-steps/ancillaries-step.tsx
@@ -126,6 +126,11 @@ function AncillaryGroupCard({
         sourceId: offer.sourceId,
         providerId: offer.providerId,
         quoteRef: offer.quoteRef,
+        // What the traveller is agreeing to, recorded at the moment they agree.
+        // Checkout compares the price the source can actually hold against this
+        // and refuses rather than charging terms nobody consented to.
+        acceptedPriceMinor: offer.price.amountMinor,
+        acceptedCurrency: offer.price.currency,
         travelers: [],
         selectedOptionIds: [],
         acceptedDisclosures: [],

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -121,6 +121,8 @@ export {
   type AddBookingPassThroughItemInput,
   type AddedBookingPassThroughItem,
   addBookingPassThroughItem,
+  type BookingPassThroughItem,
+  listBookingPassThroughItems,
   type RecordBookingSystemActivityInput,
   recordBookingSystemActivity,
 } from "./service-pass-through-items.js"

--- a/packages/bookings/src/service-pass-through-items.ts
+++ b/packages/bookings/src/service-pass-through-items.ts
@@ -11,6 +11,7 @@
  * no margin for a markup rule to find and no basis for a commission.
  */
 
+import { and, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { bookingItems } from "./schema-items.js"
@@ -72,6 +73,52 @@ export async function addBookingPassThroughItem(
     })
     .returning({ id: bookingItems.id })
   return row ? { bookingItemId: row.id } : null
+}
+
+export interface BookingPassThroughItem {
+  bookingItemId: string
+  title: string
+  /** What the booking charged for the line, in minor units. */
+  priceMinor: number
+  currency: string
+  sourceOfferId: string | null
+  metadata: Record<string, unknown> | null
+}
+
+/**
+ * The pass-through lines on a booking, for whoever collected the money.
+ *
+ * Exists so a module that sold something it did not price can find its own
+ * lines back — at charge time to avoid writing a second one, and after payment
+ * to reconcile against what the third party settled — without reading
+ * `booking_items` itself.
+ */
+export async function listBookingPassThroughItems(
+  db: PostgresJsDatabase,
+  bookingId: string,
+): Promise<BookingPassThroughItem[]> {
+  const rows = await db
+    .select({
+      id: bookingItems.id,
+      title: bookingItems.title,
+      totalSellAmountCents: bookingItems.totalSellAmountCents,
+      sellCurrency: bookingItems.sellCurrency,
+      sourceOfferId: bookingItems.sourceOfferId,
+      metadata: bookingItems.metadata,
+    })
+    .from(bookingItems)
+    .where(
+      and(eq(bookingItems.bookingId, bookingId), eq(bookingItems.pricingTreatment, "pass_through")),
+    )
+
+  return rows.map((row) => ({
+    bookingItemId: row.id,
+    title: row.title,
+    priceMinor: row.totalSellAmountCents ?? 0,
+    currency: row.sellCurrency ?? "",
+    sourceOfferId: row.sourceOfferId ?? null,
+    metadata: (row.metadata as Record<string, unknown> | null) ?? null,
+  }))
 }
 
 export interface RecordBookingSystemActivityInput {

--- a/packages/catalog-contracts/src/booking-engine/ancillary-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/ancillary-contracts.ts
@@ -168,6 +168,22 @@ export const ancillarySelectionV1 = z
     sourceId: z.string().optional(),
     providerId: z.string().optional(),
     quoteRef: z.string().optional(),
+    /**
+     * The price the traveller actually agreed to, snapshotted at acceptance.
+     *
+     * `prepare` is allowed to come back with a different amount — the port
+     * contract says a source that can no longer hold what it quoted returns
+     * what it can hold. Without the accepted terms recorded here there is
+     * nothing to compare that against, so the new price would simply be
+     * charged and the traveller would learn of it from the invoice. Optional
+     * because a selection stored before this field existed has no answer, and
+     * a comparison against nothing must not block a checkout.
+     */
+    acceptedPriceMinor: z.number().int().optional(),
+    acceptedCurrency: z
+      .string()
+      .regex(/^[A-Z]{3}$/)
+      .optional(),
     /** Only populated for an accepted offer. */
     travelers: z
       .array(

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -23681,6 +23681,13 @@
                             "quoteRef": {
                               "type": "string"
                             },
+                            "acceptedPriceMinor": {
+                              "type": "integer"
+                            },
+                            "acceptedCurrency": {
+                              "type": "string",
+                              "pattern": "^[A-Z]{3}$"
+                            },
                             "travelers": {
                               "type": "array",
                               "items": {

--- a/packages/catalog/openapi/public-api/catalog-booking.json
+++ b/packages/catalog/openapi/public-api/catalog-booking.json
@@ -18300,6 +18300,13 @@
                             "quoteRef": {
                               "type": "string"
                             },
+                            "acceptedPriceMinor": {
+                              "type": "integer"
+                            },
+                            "acceptedCurrency": {
+                              "type": "string",
+                              "pattern": "^[A-Z]{3}$"
+                            },
                             "travelers": {
                               "type": "array",
                               "items": {

--- a/packages/catalog/src/booking-engine/ancillary-commitment.ts
+++ b/packages/catalog/src/booking-engine/ancillary-commitment.ts
@@ -1,0 +1,102 @@
+/**
+ * What a committed Booking Session decided about its ancillary offers.
+ *
+ * The decision is made on the Session and the charge happens on the Booking,
+ * so something has to carry it across. That something lives here, in catalog,
+ * because `booking_sessions` is catalog's table: commerce owns the seam that
+ * prices and issues a third-party offer, but it must not read the Session rows
+ * to find out what was accepted.
+ *
+ * The read is deliberately narrow. It answers one question — "which offers did
+ * the traveller accept on the Session that produced this Booking, and who is
+ * the contracting party" — and returns nothing else off a selection that is
+ * large, versioned and none of commerce's business.
+ */
+
+import {
+  type AncillarySelectionV1,
+  ancillarySelectionV1,
+} from "@voyant-travel/catalog-contracts/booking-engine/ancillary-contracts"
+import { desc, eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { bookingSessionCommitsTable, bookingSessionsTable } from "./sessions-schema.js"
+
+/** The contracting party, as the billing step recorded it. */
+export interface CommittedAncillaryContactV1 {
+  firstName: string
+  lastName: string
+  email: string
+  phone?: string
+}
+
+export interface CommittedAncillarySelectionsV1 {
+  bookingSessionId: string
+  contact: CommittedAncillaryContactV1
+  /** Accepted decisions only — a decline is a decision that buys nothing. */
+  accepted: readonly AncillarySelectionV1[]
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : ""
+}
+
+/**
+ * Read the accepted ancillary selections off the Session this Booking came from.
+ *
+ * Returns `null` when the Booking did not come from a Session at all — an
+ * operator-created Booking, or one committed before Sessions carried the step.
+ * That is an ordinary absence and not an error: there is nothing to buy.
+ *
+ * A stored selection that no longer parses is skipped rather than thrown on.
+ * The alternative is a checkout that cannot start because a single malformed
+ * entry from an earlier contract revision is on the Session, and the traveller
+ * has no way to repair it.
+ */
+export async function loadCommittedAncillarySelections(
+  db: PostgresJsDatabase,
+  bookingId: string,
+): Promise<CommittedAncillarySelectionsV1 | null> {
+  const [row] = await db
+    .select({
+      sessionId: bookingSessionsTable.id,
+      statePayload: bookingSessionsTable.statePayload,
+    })
+    .from(bookingSessionCommitsTable)
+    .innerJoin(
+      bookingSessionsTable,
+      eq(bookingSessionsTable.id, bookingSessionCommitsTable.sessionId),
+    )
+    .where(eq(bookingSessionCommitsTable.bookingId, bookingId))
+    .orderBy(desc(bookingSessionCommitsTable.createdAt))
+    .limit(1)
+
+  if (!row) return null
+
+  const selection = asRecord(row.statePayload)
+  const billingContact = asRecord(asRecord(selection?.billing)?.contact)
+  const phone = asString(billingContact?.phone)
+  const contact: CommittedAncillaryContactV1 = {
+    firstName: asString(billingContact?.firstName),
+    lastName: asString(billingContact?.lastName),
+    email: asString(billingContact?.email),
+    ...(phone ? { phone } : {}),
+  }
+
+  const rawAncillaries = Array.isArray(selection?.ancillaries) ? selection.ancillaries : []
+  const accepted: AncillarySelectionV1[] = []
+  for (const entry of rawAncillaries) {
+    const parsed = ancillarySelectionV1.safeParse(entry)
+    if (!parsed.success) continue
+    if (parsed.data.decision !== "accepted") continue
+    accepted.push(parsed.data)
+  }
+
+  return { bookingSessionId: row.sessionId, contact, accepted }
+}

--- a/packages/catalog/src/booking-engine/checkout-finalize.ts
+++ b/packages/catalog/src/booking-engine/checkout-finalize.ts
@@ -7,6 +7,10 @@
  *      created by canonical Booking Session Commit.
  *   2. issue_invoice — explicit fallback when finance auto-generation
  *      isn't wired. Idempotent — checks if an invoice already exists.
+ *   3. link_payment_to_invoice — back-links the paid session to the invoice.
+ *   4. fulfill_ancillaries — issues whatever third party was charged on the
+ *      booking, and reconciles what it issued against what was charged. Last
+ *      because it is the one step that cannot be taken back.
  *
  * Compensation: if `issue_invoice` fails after the booking is
  * already committed, we don't mutate Booking lifecycle — the payment and
@@ -83,6 +87,24 @@ export interface CheckoutFinalizeDeps {
     /** Hint from the saga input — when set, prefer linking this session. */
     paymentSessionId?: string
   }) => Promise<{ paymentId: string | null; sessionsLinked: number }>
+  /**
+   * Issue whatever third party was charged on this booking, now that the money
+   * is in, and reconcile what it issued against what was charged.
+   *
+   * Optional in the same sense as every other dep here: returning `null` means
+   * "nothing to do" — a deployment with no ancillary source bound, or a booking
+   * that carries no third-party line. Catalog neither knows nor asks what is on
+   * the other side; commerce owns the port and supplies this.
+   *
+   * It must not throw for a supplier outcome. This step runs after a captured
+   * payment, so a refusal or an outage is a result to record on the booking,
+   * and the saga has to complete for the payment linkage above it to stay
+   * settled. The recorder carries the outcome out for observability.
+   */
+  fulfillAncillaries?: (input: {
+    bookingId: string
+    invoiceId?: string | null
+  }) => Promise<Record<string, unknown> | null>
 }
 
 async function runStep<T>(
@@ -156,6 +178,26 @@ export const checkoutFinalizeSaga = createSaga("checkout-finalize", [
       }),
     )
   }),
+
+  // Last, and after the payment is linked, because it is the only step whose
+  // precondition is "the money is definitely in". Everything before it can be
+  // re-run against an unpaid booking without consequence; asking a supplier to
+  // issue cannot be taken back.
+  sagaStep<CheckoutFinalizeInput, Record<string, unknown> | null>("fulfill_ancillaries").run(
+    async (input, ctx) => {
+      const deps = ctx.results.__deps as CheckoutFinalizeDeps | undefined
+      if (!deps) throw new Error("checkout-finalize: deps not seeded into context")
+      if (!deps.fulfillAncillaries) return null
+
+      const issueOutput = ctx.results.issue_invoice as { invoiceId: string } | null | undefined
+      return runStep("fulfill_ancillaries", deps.recorder, () =>
+        deps.fulfillAncillaries!({
+          bookingId: input.bookingId,
+          invoiceId: issueOutput?.invoiceId ?? null,
+        }),
+      )
+    },
+  ),
 ])
 
 export interface RunCheckoutFinalizeOptions {

--- a/packages/catalog/src/booking-engine/index.ts
+++ b/packages/catalog/src/booking-engine/index.ts
@@ -45,6 +45,11 @@ export {
   withBookingSessionAnalytics,
 } from "./analytics.js"
 export {
+  type CommittedAncillaryContactV1,
+  type CommittedAncillarySelectionsV1,
+  loadCommittedAncillarySelections,
+} from "./ancillary-commitment.js"
+export {
   type AncillaryOfferResolver,
   type AncillaryQuoteRequestV1,
   ancillaryQuoteRequestFromSelection,

--- a/packages/commerce/src/checkout/ancillary-commit.test.ts
+++ b/packages/commerce/src/checkout/ancillary-commit.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The refusals, which are the only interesting part of `prepare` to test
+ * without a database.
+ *
+ * Each of these decides *before* anything is written — an expired application
+ * and a changed price are both caught while the booking still has no premium
+ * line — so they need no insert, and asserting them here is not a weaker
+ * version of the integration test but a different question: whether checkout
+ * stops at all.
+ *
+ * Every case is money. Charging for an application that can no longer be
+ * issued, or for a price nobody agreed to, is the failure mode this whole path
+ * is arranged around.
+ */
+
+import type { AncillarySelectionV1 } from "@voyant-travel/catalog-contracts/booking-engine/ancillary-contracts"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it } from "vitest"
+
+import {
+  AncillaryApplicationExpiredError,
+  AncillaryTermsChangedError,
+  prepareBookingAncillaries,
+} from "./ancillary-commit.js"
+import type { AncillaryOfferSource, AncillaryPreparedSelection } from "./ancillary-ports.js"
+
+const NOW = new Date("2026-08-16T12:00:00.000Z")
+
+/** Only `execute` is reached: the advisory lock take and release. */
+const db = { execute: async () => undefined } as unknown as PostgresJsDatabase
+
+function selection(overrides: Partial<AncillarySelectionV1> = {}): AncillarySelectionV1 {
+  return {
+    kind: "insurance",
+    decision: "accepted",
+    offerId: "offer_1",
+    sourceId: "insurance",
+    providerId: "northwind",
+    quoteRef: "quote_1",
+    travelers: [],
+    selectedOptionIds: [],
+    acceptedDisclosures: [],
+    ...overrides,
+  } as AncillarySelectionV1
+}
+
+function source(prepared: Partial<AncillaryPreparedSelection> = {}): AncillaryOfferSource {
+  return {
+    sourceId: "insurance",
+    kind: "insurance",
+    label: "Travel insurance",
+    quote: async () => ({ kind: "insurance", label: "", offers: [], diagnostics: [] }),
+    prepare: async () => ({
+      sourceId: "insurance",
+      providerId: "northwind",
+      applicationRef: "app_1",
+      priceMinor: 4500,
+      currency: "EUR",
+      title: "Trip protection",
+      expiresAt: "2026-08-17T12:00:00.000Z",
+      ...prepared,
+    }),
+    fulfill: async () => ({ status: "fulfilled" }),
+    cancel: async () => undefined,
+  } as unknown as AncillaryOfferSource
+}
+
+function item(metadata: Record<string, unknown>) {
+  return {
+    bookingItemId: "bit_1",
+    priceMinor: 4500,
+    currency: "EUR",
+    metadata,
+  }
+}
+
+describe("prepareBookingAncillaries refuses rather than charges", () => {
+  it("stops when the already-charged application has expired", async () => {
+    const expired = item({
+      ancillary: {
+        sourceId: "insurance",
+        providerId: "northwind",
+        applicationRef: "app_1",
+        selectionKey: "insurance::northwind::offer_1",
+        expiresAt: "2026-08-16T11:59:59.000Z",
+      },
+    })
+
+    await expect(
+      prepareBookingAncillaries({
+        db,
+        bookingId: "bkg_1",
+        bookingSessionId: "bs_1",
+        sources: [source()],
+        accepted: [selection()],
+        contact: { firstName: "Ana", lastName: "Pop", email: "ana@example.test" },
+        listPassThroughItems: async () => [expired] as never,
+        now: () => NOW,
+      }),
+    ).rejects.toBeInstanceOf(AncillaryApplicationExpiredError)
+  })
+
+  it("treats a line with no recorded expiry as live", async () => {
+    // The field is optional, and a line written before it existed must not
+    // strand a booking over a fact nobody recorded.
+    const live = item({
+      ancillary: {
+        sourceId: "insurance",
+        providerId: "northwind",
+        applicationRef: "app_1",
+        selectionKey: "insurance::northwind::offer_1",
+      },
+    })
+
+    const result = await prepareBookingAncillaries({
+      db,
+      bookingId: "bkg_1",
+      bookingSessionId: "bs_1",
+      sources: [source()],
+      accepted: [selection()],
+      contact: { firstName: "Ana", lastName: "Pop", email: "ana@example.test" },
+      listPassThroughItems: async () => [live] as never,
+      now: () => NOW,
+    })
+
+    expect(result.prepared).toHaveLength(0)
+    expect(result.alreadyCharged).toEqual(["insurance::northwind::offer_1"])
+  })
+
+  it("stops when the source can no longer hold the accepted price", async () => {
+    await expect(
+      prepareBookingAncillaries({
+        db,
+        bookingId: "bkg_1",
+        bookingSessionId: "bs_1",
+        sources: [source({ priceMinor: 5200 })],
+        accepted: [selection({ acceptedPriceMinor: 4500, acceptedCurrency: "EUR" })],
+        contact: { firstName: "Ana", lastName: "Pop", email: "ana@example.test" },
+        listPassThroughItems: async () => [],
+        now: () => NOW,
+      }),
+    ).rejects.toBeInstanceOf(AncillaryTermsChangedError)
+  })
+
+  it("stops when the currency changes, even at the same number", async () => {
+    await expect(
+      prepareBookingAncillaries({
+        db,
+        bookingId: "bkg_1",
+        bookingSessionId: "bs_1",
+        sources: [source({ currency: "RON" })],
+        accepted: [selection({ acceptedPriceMinor: 4500, acceptedCurrency: "EUR" })],
+        contact: { firstName: "Ana", lastName: "Pop", email: "ana@example.test" },
+        listPassThroughItems: async () => [],
+        now: () => NOW,
+      }),
+    ).rejects.toBeInstanceOf(AncillaryTermsChangedError)
+  })
+
+  it("does not compare against a selection that recorded no accepted terms", async () => {
+    // Nothing to consent to means nothing to contradict; blocking here would
+    // fail every checkout whose selection predates the snapshot fields.
+    const result = await prepareBookingAncillaries({
+      db,
+      bookingId: "bkg_1",
+      bookingSessionId: "bs_1",
+      sources: [source({ priceMinor: 9900 })],
+      accepted: [selection()],
+      contact: { firstName: "Ana", lastName: "Pop", email: "ana@example.test" },
+      listPassThroughItems: async () => [],
+      now: () => NOW,
+    }).catch((error: unknown) => error)
+
+    expect(result).not.toBeInstanceOf(AncillaryTermsChangedError)
+  })
+})

--- a/packages/commerce/src/checkout/ancillary-commit.ts
+++ b/packages/commerce/src/checkout/ancillary-commit.ts
@@ -35,14 +35,17 @@ import {
   type AncillarySelectionV1,
   ancillarySelectionKey,
 } from "@voyant-travel/catalog-contracts/booking-engine/ancillary-contracts"
+import { sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
   AncillaryPremiumDriftError,
   type AncillaryPremiumReconciliation,
+  isAncillaryItemExpiredAt,
   materializeAncillaryPassThroughItem,
   readAncillaryItemMarker,
   reconcileAncillaryPremium,
+  recordAncillaryActivity,
 } from "./ancillary-materialization.js"
 import type { AncillaryOfferSource } from "./ancillary-ports.js"
 
@@ -69,6 +72,39 @@ export class AncillaryPreparationError extends Error {
   }
 }
 
+/** Raised when the held application can no longer become a purchase. */
+export class AncillaryApplicationExpiredError extends Error {
+  readonly code = "ancillary_application_expired"
+  constructor(
+    readonly sourceId: string,
+    readonly expiredAt: string,
+  ) {
+    super(
+      `The held ancillary application from source "${sourceId}" expired at ${expiredAt} and ` +
+        "cannot become a purchase; the traveller has to choose again.",
+    )
+    this.name = "AncillaryApplicationExpiredError"
+  }
+}
+
+/** Raised when the source can no longer hold the price the traveller accepted. */
+export class AncillaryTermsChangedError extends Error {
+  readonly code = "ancillary_terms_changed"
+  constructor(
+    readonly sourceId: string,
+    readonly accepted: { priceMinor: number; currency: string },
+    readonly offered: { priceMinor: number; currency: string },
+  ) {
+    super(
+      `The ancillary offer from source "${sourceId}" is no longer ` +
+        `${accepted.priceMinor} ${accepted.currency} but ` +
+        `${offered.priceMinor} ${offered.currency}; charging it would collect terms ` +
+        "the traveller never agreed to.",
+    )
+    this.name = "AncillaryTermsChangedError"
+  }
+}
+
 export interface PrepareBookingAncillariesInput {
   db: PostgresJsDatabase
   bookingId: string
@@ -78,6 +114,8 @@ export interface PrepareBookingAncillariesInput {
   sources: readonly AncillaryOfferSource[]
   /** The accepted decisions, read by whoever owns the Session rows. */
   accepted: readonly AncillarySelectionV1[]
+  /** Injected so expiry is evaluated against one instant, and stays testable. */
+  now?: () => Date
   /**
    * The contracting party.
    *
@@ -88,7 +126,14 @@ export interface PrepareBookingAncillariesInput {
    */
   contact: AncillaryContact
   /** Existing pass-through lines, so a re-entered checkout charges once. */
-  existingItems: readonly BookingPassThroughItem[]
+  /**
+   * Re-read INSIDE the lock rather than handed in as a snapshot.
+   *
+   * A snapshot taken by the caller is exactly the stale view the lock exists to
+   * defeat: the second request would hold the lock and still act on a list read
+   * before the first one inserted.
+   */
+  listPassThroughItems: typeof listBookingPassThroughItemsFn
   /**
    * Namespaced tax treatment for the premium line, e.g. `"insurance/exempt"`.
    * Resolved by whoever knows the treatment for this source's kind; commerce
@@ -132,18 +177,70 @@ export interface PrepareBookingAncillariesResult {
 export async function prepareBookingAncillaries(
   input: PrepareBookingAncillariesInput,
 ): Promise<PrepareBookingAncillariesResult> {
+  const empty: PrepareBookingAncillariesResult = {
+    prepared: [],
+    alreadyCharged: [],
+    unresolvedSources: [],
+  }
+  if (input.sources.length === 0 || input.accepted.length === 0) return empty
+
+  // Serialised per Booking, because the check and the insert are not one
+  // statement. Two overlapping `/checkout/start` calls both read an
+  // `existingItems` snapshot with no line for the selection, and both then
+  // insert one: `booking_items` has no uniqueness to catch it, the provider's
+  // idempotency key deduplicates the application but not the row, and the
+  // recomputed total charges the premium twice.
+  //
+  // A session-level advisory lock rather than a transaction: `prepare` is an
+  // HTTP call to a third party and must not run inside an open transaction.
+  // The second caller waits, then sees the marker and takes the skip.
+  return withBookingAncillaryLock(input.db, input.bookingId, () => prepareUnderLock(input))
+}
+
+/**
+ * Hold a Postgres advisory lock for the duration of `operation`.
+ *
+ * Released in `finally` so a throw — which is the normal way this path reports
+ * a refusal — cannot leave the next checkout blocked on a lock nobody holds any
+ * intent over.
+ */
+async function withBookingAncillaryLock<T>(
+  db: PostgresJsDatabase,
+  bookingId: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const key = sql`hashtextextended(${`ancillary-prepare:${bookingId}`}, 0)`
+  await db.execute(sql`select pg_advisory_lock(${key})`)
+  try {
+    return await operation()
+  } finally {
+    await db.execute(sql`select pg_advisory_unlock(${key})`)
+  }
+}
+
+async function prepareUnderLock(
+  input: PrepareBookingAncillariesInput,
+): Promise<PrepareBookingAncillariesResult> {
   const result: PrepareBookingAncillariesResult = {
     prepared: [],
     alreadyCharged: [],
     unresolvedSources: [],
   }
   const accepted = input.accepted
-  if (input.sources.length === 0 || accepted.length === 0) return result
 
+  const now = input.now?.() ?? new Date()
   const charged = new Set<string>()
-  for (const item of input.existingItems) {
+  const existingItems = await input.listPassThroughItems(input.db, input.bookingId)
+  for (const item of existingItems) {
     const marker = readAncillaryItemMarker(item.metadata)
-    if (marker?.selectionKey) charged.add(marker.selectionKey)
+    if (!marker?.selectionKey) continue
+    // An already-charged line whose application has expired cannot become an
+    // artifact, and the skip below would carry it silently through to payment.
+    // Refusing here is the only outcome that does not charge for nothing.
+    if (isAncillaryItemExpiredAt(marker, now)) {
+      throw new AncillaryApplicationExpiredError(marker.sourceId, marker.expiresAt ?? "")
+    }
+    charged.add(marker.selectionKey)
   }
 
   const { contact, bookingSessionId } = input
@@ -180,6 +277,22 @@ export async function prepareBookingAncillaries(
       })
     } catch (error) {
       throw new AncillaryPreparationError(selection.sourceId ?? source.sourceId, error)
+    }
+
+    // The source is allowed to come back with a price it can still hold. It is
+    // not allowed to have that price charged without the traveller agreeing to
+    // it, so a change stops checkout instead of quietly re-pricing the booking.
+    if (
+      selection.acceptedPriceMinor !== undefined &&
+      selection.acceptedCurrency !== undefined &&
+      (prepared.priceMinor !== selection.acceptedPriceMinor ||
+        prepared.currency !== selection.acceptedCurrency)
+    ) {
+      throw new AncillaryTermsChangedError(
+        source.sourceId,
+        { priceMinor: selection.acceptedPriceMinor, currency: selection.acceptedCurrency },
+        { priceMinor: prepared.priceMinor, currency: prepared.currency },
+      )
     }
 
     const materialized = await materializeAncillaryPassThroughItem(input.db, {
@@ -247,9 +360,14 @@ export interface FulfillBookingAncillariesResult {
 export async function fulfillBookingAncillaries(
   input: FulfillBookingAncillariesInput,
 ): Promise<FulfillBookingAncillariesResult> {
+  // Deliberately NOT short-circuited on an empty source list. A charged line
+  // whose source is unbound at delivery time — a deployment or configuration
+  // change between the charge and `payment.completed` — would otherwise be
+  // skipped, the saga would complete, `completedAt` would be recorded, and
+  // redelivery after the source came back would return early. The traveller
+  // would have paid for an artifact nobody ever issues, and nothing would say
+  // so. Inspecting the lines anyway turns that into an actionable record.
   const outcomes: FulfilledBookingAncillary[] = []
-  if (input.sources.length === 0) return { outcomes }
-
   const items = await input.listPassThroughItems(input.db, input.bookingId)
   for (const item of items) {
     const marker = readAncillaryItemMarker(item.metadata)
@@ -257,6 +375,22 @@ export async function fulfillBookingAncillaries(
 
     const source = input.sources.find((candidate) => candidate.sourceId === marker.sourceId)
     if (!source) {
+      // On the booking, not merely in the step output: the saga's own record is
+      // not somewhere an operator looks, and this is money already taken.
+      await recordAncillaryActivity(input.db, input.bookingId, {
+        event: "ancillary.fulfillment.unresolved",
+        description:
+          `A paid ancillary could not be issued: no source is bound for ` +
+          `"${marker.sourceId}". It stays unfulfilled until one is.`,
+        metadata: {
+          bookingItemId: item.bookingItemId,
+          applicationRef: marker.applicationRef,
+          sourceId: marker.sourceId,
+          chargedPriceMinor: item.priceMinor,
+          currency: item.currency,
+          retryable: true,
+        },
+      })
       outcomes.push({
         bookingItemId: item.bookingItemId,
         applicationRef: marker.applicationRef,

--- a/packages/commerce/src/checkout/ancillary-commit.ts
+++ b/packages/commerce/src/checkout/ancillary-commit.ts
@@ -27,10 +27,7 @@
  * to stay intact for an operator to act on.
  */
 
-import type {
-  BookingPassThroughItem,
-  listBookingPassThroughItems as listBookingPassThroughItemsFn,
-} from "@voyant-travel/bookings"
+import type { listBookingPassThroughItems as listBookingPassThroughItemsFn } from "@voyant-travel/bookings"
 import {
   type AncillarySelectionV1,
   ancillarySelectionKey,

--- a/packages/commerce/src/checkout/ancillary-commit.ts
+++ b/packages/commerce/src/checkout/ancillary-commit.ts
@@ -1,0 +1,333 @@
+/**
+ * Turning an accepted ancillary offer into a charge, and then into a policy.
+ *
+ * Two halves, on either side of the money, and the split is the whole design:
+ *
+ *  - {@link prepareBookingAncillaries} runs **after the Booking is committed
+ *    and before the traveller pays**. It opens the application at the third
+ *    party and writes the premium onto the Booking, so the amount the payment
+ *    provider is asked for already contains it.
+ *  - {@link fulfillBookingAncillaries} runs **after payment has succeeded**,
+ *    from the checkout-finalize saga, and turns the held application into an
+ *    issued artifact.
+ *
+ * `prepare` is a network call to a third party, so it deliberately does not
+ * run inside the Booking Session commit transaction. That transaction carries
+ * the session state machine and the settlement path (voyant#4733, voyant#4734);
+ * an HTTP round trip inside it either holds it open across the call or fails it
+ * after money has moved. Checkout-start is the first point at which the Booking
+ * exists, nothing has been charged, and a failure is still something the
+ * traveller can see and act on.
+ *
+ * Which is also why the two halves fail in opposite directions. Before the
+ * money: a source that cannot open an application must stop checkout, because
+ * charging a traveller for insurance that was never applied for is worse than
+ * an error page they can retry. After the money: nothing may throw for a
+ * business outcome, because the charge has already happened and the booking has
+ * to stay intact for an operator to act on.
+ */
+
+import type {
+  BookingPassThroughItem,
+  listBookingPassThroughItems as listBookingPassThroughItemsFn,
+} from "@voyant-travel/bookings"
+import {
+  type AncillarySelectionV1,
+  ancillarySelectionKey,
+} from "@voyant-travel/catalog-contracts/booking-engine/ancillary-contracts"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  AncillaryPremiumDriftError,
+  type AncillaryPremiumReconciliation,
+  materializeAncillaryPassThroughItem,
+  readAncillaryItemMarker,
+  reconcileAncillaryPremium,
+} from "./ancillary-materialization.js"
+import type { AncillaryOfferSource } from "./ancillary-ports.js"
+
+/** The contracting party a source needs before it will open an application. */
+export interface AncillaryContact {
+  firstName: string
+  lastName: string
+  email: string
+  phone?: string
+}
+
+/** Raised when an accepted offer could not be turned into a charge. */
+export class AncillaryPreparationError extends Error {
+  readonly code = "ancillary_preparation_failed"
+  constructor(
+    readonly sourceId: string,
+    readonly reason: unknown,
+  ) {
+    super(
+      `Preparing the accepted ancillary offer from source "${sourceId}" failed: ` +
+        (reason instanceof Error ? reason.message : String(reason)),
+    )
+    this.name = "AncillaryPreparationError"
+  }
+}
+
+export interface PrepareBookingAncillariesInput {
+  db: PostgresJsDatabase
+  bookingId: string
+  /** The Session the Booking came from; the source keys its application to it. */
+  bookingSessionId: string
+  /** Whatever the deployment bound. Empty is the normal, silent case. */
+  sources: readonly AncillaryOfferSource[]
+  /** The accepted decisions, read by whoever owns the Session rows. */
+  accepted: readonly AncillarySelectionV1[]
+  /**
+   * The contracting party.
+   *
+   * Passed in rather than read off the selection here, because the caller can
+   * see both the Session's billing step and the Booking's own contact columns —
+   * and a blank name reaching the insurer is an application rejected for a
+   * reason the traveller cannot tell apart from being declined.
+   */
+  contact: AncillaryContact
+  /** Existing pass-through lines, so a re-entered checkout charges once. */
+  existingItems: readonly BookingPassThroughItem[]
+  /**
+   * Namespaced tax treatment for the premium line, e.g. `"insurance/exempt"`.
+   * Resolved by whoever knows the treatment for this source's kind; commerce
+   * writes whatever comes back through untouched.
+   */
+  resolveTaxTreatmentCode?: (source: AncillaryOfferSource) => string | null | undefined
+}
+
+export interface PreparedBookingAncillary {
+  bookingItemId: string
+  sourceId: string
+  providerId: string
+  applicationRef: string
+  priceMinor: number
+  currency: string
+}
+
+export interface PrepareBookingAncillariesResult {
+  /** Lines written by this call. Empty when everything was already charged. */
+  prepared: PreparedBookingAncillary[]
+  /** Accepted selections that already had a line, keyed by selection. */
+  alreadyCharged: string[]
+  /**
+   * Accepted selections whose source is no longer bound.
+   *
+   * Not an error: an operator may disconnect a provider between the offer and
+   * the checkout, and there is then nobody to open the application with. The
+   * traveller is simply not charged for it, which is the only outcome that
+   * cannot leave them paying for nothing.
+   */
+  unresolvedSources: string[]
+}
+
+/**
+ * Open an application per accepted offer and put its premium on the Booking.
+ *
+ * `priceMinor` from `prepare` is what gets charged. It is authoritative by
+ * contract — a source that can no longer hold what it quoted returns the price
+ * it can hold — and nothing between here and the invoice may adjust it.
+ */
+export async function prepareBookingAncillaries(
+  input: PrepareBookingAncillariesInput,
+): Promise<PrepareBookingAncillariesResult> {
+  const result: PrepareBookingAncillariesResult = {
+    prepared: [],
+    alreadyCharged: [],
+    unresolvedSources: [],
+  }
+  const accepted = input.accepted
+  if (input.sources.length === 0 || accepted.length === 0) return result
+
+  const charged = new Set<string>()
+  for (const item of input.existingItems) {
+    const marker = readAncillaryItemMarker(item.metadata)
+    if (marker?.selectionKey) charged.add(marker.selectionKey)
+  }
+
+  const { contact, bookingSessionId } = input
+
+  for (const selection of accepted) {
+    const key = ancillarySelectionKey(selection)
+    if (!key) continue
+    if (charged.has(key)) {
+      result.alreadyCharged.push(key)
+      continue
+    }
+
+    const source = input.sources.find((candidate) => candidate.sourceId === selection.sourceId)
+    if (!source) {
+      result.unresolvedSources.push(key)
+      continue
+    }
+
+    let prepared: Awaited<ReturnType<AncillaryOfferSource["prepare"]>>
+    try {
+      prepared = await source.prepare({
+        bookingSessionId,
+        selection,
+        contact: {
+          firstName: contact.firstName,
+          lastName: contact.lastName,
+          email: contact.email,
+          ...(contact.phone ? { phone: contact.phone } : {}),
+        },
+        // Derived from the Booking and the offer, never random: a customer who
+        // hits Back and resubmits reaches the third party with the same key and
+        // gets the same application rather than a second one.
+        idempotencyKey: `ancillary-prepare:${input.bookingId}:${key}`,
+      })
+    } catch (error) {
+      throw new AncillaryPreparationError(selection.sourceId ?? source.sourceId, error)
+    }
+
+    const materialized = await materializeAncillaryPassThroughItem(input.db, {
+      bookingId: input.bookingId,
+      selection: prepared,
+      taxTreatmentCode: input.resolveTaxTreatmentCode?.(source) ?? null,
+      selectionKey: key,
+    })
+    if (!materialized) {
+      throw new AncillaryPreparationError(
+        source.sourceId,
+        new Error("The prepared ancillary premium produced no booking line."),
+      )
+    }
+
+    charged.add(key)
+    result.prepared.push({
+      bookingItemId: materialized.bookingItemId,
+      sourceId: prepared.sourceId,
+      providerId: prepared.providerId,
+      applicationRef: prepared.applicationRef,
+      priceMinor: prepared.priceMinor,
+      currency: prepared.currency,
+    })
+  }
+
+  return result
+}
+
+export interface FulfillBookingAncillariesInput {
+  db: PostgresJsDatabase
+  bookingId: string
+  sources: readonly AncillaryOfferSource[]
+  listPassThroughItems: typeof listBookingPassThroughItemsFn
+}
+
+export interface FulfilledBookingAncillary {
+  bookingItemId: string
+  applicationRef: string
+  sourceId: string
+  status: "fulfilled" | "not_fulfilled" | "drifted" | "source_not_bound"
+  /** The supplier's reference, for a fulfilment that produced one. */
+  reference?: string
+  /** Documents the source attached through the booking-document path. */
+  documentIds?: string[]
+  code?: string
+  message?: string
+  retryable?: boolean
+}
+
+export interface FulfillBookingAncillariesResult {
+  outcomes: FulfilledBookingAncillary[]
+}
+
+/**
+ * Issue every prepared ancillary on a paid Booking, and reconcile each one.
+ *
+ * Nothing here throws for a supplier outcome. This runs after the traveller has
+ * been charged, so a refusal, an outage or a premium that does not match is a
+ * result to record — `reconcileAncillaryPremium` writes each of them to the
+ * booking's activity log, and the source's own failure path records
+ * `issue_failed` and raises the staff alert. Throwing would re-run an issue
+ * that has already reached the supplier.
+ */
+export async function fulfillBookingAncillaries(
+  input: FulfillBookingAncillariesInput,
+): Promise<FulfillBookingAncillariesResult> {
+  const outcomes: FulfilledBookingAncillary[] = []
+  if (input.sources.length === 0) return { outcomes }
+
+  const items = await input.listPassThroughItems(input.db, input.bookingId)
+  for (const item of items) {
+    const marker = readAncillaryItemMarker(item.metadata)
+    if (!marker) continue
+
+    const source = input.sources.find((candidate) => candidate.sourceId === marker.sourceId)
+    if (!source) {
+      outcomes.push({
+        bookingItemId: item.bookingItemId,
+        applicationRef: marker.applicationRef,
+        sourceId: marker.sourceId,
+        status: "source_not_bound",
+        message: `No ancillary source is bound for "${marker.sourceId}".`,
+        retryable: true,
+      })
+      continue
+    }
+
+    const result = await source.fulfill({
+      bookingId: input.bookingId,
+      applicationRef: marker.applicationRef,
+      sourceId: marker.sourceId,
+      chargedPriceMinor: item.priceMinor,
+      currency: item.currency,
+      // Stable across retries for the same reason `prepare`'s is: a retried
+      // issue that produces a second policy is a second real charge.
+      idempotencyKey: `ancillary-fulfill:${input.bookingId}:${item.bookingItemId}`,
+    })
+
+    let reconciliation: AncillaryPremiumReconciliation | null = null
+    try {
+      reconciliation = await reconcileAncillaryPremium(input.db, {
+        bookingId: input.bookingId,
+        bookingItemId: item.bookingItemId,
+        chargedPriceMinor: item.priceMinor,
+        currency: item.currency,
+        result,
+      })
+    } catch (error) {
+      if (!(error instanceof AncillaryPremiumDriftError)) throw error
+      // Recorded on the booking by `reconcileAncillaryPremium` before it threw,
+      // and carried out of the saga step here. Rethrowing would fail a step
+      // that runs after a captured payment and after an issued policy, and the
+      // retry would ask the supplier to issue again.
+      outcomes.push({
+        bookingItemId: item.bookingItemId,
+        applicationRef: marker.applicationRef,
+        sourceId: marker.sourceId,
+        status: "drifted",
+        code: error.code,
+        message: error.message,
+        retryable: false,
+      })
+      continue
+    }
+
+    if (reconciliation.status === "not_fulfilled") {
+      outcomes.push({
+        bookingItemId: item.bookingItemId,
+        applicationRef: marker.applicationRef,
+        sourceId: marker.sourceId,
+        status: "not_fulfilled",
+        code: reconciliation.code,
+        message: reconciliation.message,
+        retryable: reconciliation.retryable,
+      })
+      continue
+    }
+
+    outcomes.push({
+      bookingItemId: item.bookingItemId,
+      applicationRef: marker.applicationRef,
+      sourceId: marker.sourceId,
+      status: "fulfilled",
+      reference: reconciliation.reference,
+      ...(result.status === "fulfilled" ? { documentIds: result.documentIds } : {}),
+    })
+  }
+
+  return { outcomes }
+}

--- a/packages/commerce/src/checkout/ancillary-materialization.ts
+++ b/packages/commerce/src/checkout/ancillary-materialization.ts
@@ -37,6 +37,15 @@ export interface MaterializeAncillaryPassThroughItemInput {
    * whoever knows the treatment; commerce writes it through untouched.
    */
   taxTreatmentCode?: string | null
+  /**
+   * The offer this line came from, as `sourceId::providerId::offerId`.
+   *
+   * Stamped so re-entering checkout can recognise a selection it has already
+   * charged for. `applicationRef` cannot answer that question: it is minted by
+   * `prepare`, so it only exists once the insurer has already been asked, and
+   * asking twice is the thing being prevented.
+   */
+  selectionKey?: string | null
 }
 
 export interface MaterializedAncillaryItem {
@@ -68,9 +77,49 @@ export async function materializeAncillaryPassThroughItem(
         providerId: selection.providerId,
         applicationRef: selection.applicationRef,
         expiresAt: selection.expiresAt,
+        ...(input.selectionKey ? { selectionKey: input.selectionKey } : {}),
       },
     },
   })
+}
+
+/** What a pass-through line records about the ancillary that produced it. */
+export interface AncillaryItemMarker {
+  sourceId: string
+  providerId: string
+  applicationRef: string
+  selectionKey?: string
+}
+
+/**
+ * Read the marker back off a pass-through line's metadata.
+ *
+ * Returns `null` for a pass-through line that is not an ancillary at all — the
+ * treatment is shared with anything else the operator collects rather than
+ * prices, so the marker, not the treatment, is what identifies these.
+ */
+export function readAncillaryItemMarker(
+  metadata: Record<string, unknown> | null | undefined,
+): AncillaryItemMarker | null {
+  const ancillary = metadata?.ancillary
+  if (ancillary === null || typeof ancillary !== "object") return null
+  const candidate = ancillary as Record<string, unknown>
+  const sourceId = candidate.sourceId
+  const providerId = candidate.providerId
+  const applicationRef = candidate.applicationRef
+  if (
+    typeof sourceId !== "string" ||
+    typeof providerId !== "string" ||
+    typeof applicationRef !== "string"
+  ) {
+    return null
+  }
+  return {
+    sourceId,
+    providerId,
+    applicationRef,
+    ...(typeof candidate.selectionKey === "string" ? { selectionKey: candidate.selectionKey } : {}),
+  }
 }
 
 export type AncillaryPremiumReconciliation =

--- a/packages/commerce/src/checkout/ancillary-materialization.ts
+++ b/packages/commerce/src/checkout/ancillary-materialization.ts
@@ -89,6 +89,15 @@ export interface AncillaryItemMarker {
   providerId: string
   applicationRef: string
   selectionKey?: string
+  /**
+   * When the held application stops being able to become a purchase.
+   *
+   * Read back off the line, not merely written to it: a traveller who returns
+   * to checkout after this instant would otherwise be charged for a premium
+   * nothing can fulfil, and the first anyone hears of it is the failed issue
+   * after the money has moved.
+   */
+  expiresAt?: string
 }
 
 /**
@@ -119,7 +128,21 @@ export function readAncillaryItemMarker(
     providerId,
     applicationRef,
     ...(typeof candidate.selectionKey === "string" ? { selectionKey: candidate.selectionKey } : {}),
+    ...(typeof candidate.expiresAt === "string" ? { expiresAt: candidate.expiresAt } : {}),
   }
+}
+
+/**
+ * Whether a charged line can still become an issued artifact.
+ *
+ * A line with no recorded expiry is treated as live: the field is optional on
+ * the marker, and refusing checkout over a line written before it existed would
+ * strand bookings for a fact nobody recorded.
+ */
+export function isAncillaryItemExpiredAt(marker: AncillaryItemMarker, at: Date): boolean {
+  if (!marker.expiresAt) return false
+  const expiresAt = Date.parse(marker.expiresAt)
+  return Number.isFinite(expiresAt) && expiresAt <= at.getTime()
 }
 
 export type AncillaryPremiumReconciliation =
@@ -248,7 +271,7 @@ export async function reconcileAncillaryPremium(
 }
 
 /** Operator-visible record of an automated outcome, written by bookings. */
-async function recordAncillaryActivity(
+export async function recordAncillaryActivity(
   db: PostgresJsDatabase,
   bookingId: string,
   entry: { event: string; description: string; metadata: Record<string, unknown> },

--- a/packages/commerce/src/checkout/finalize.test.ts
+++ b/packages/commerce/src/checkout/finalize.test.ts
@@ -33,7 +33,10 @@ const tables = vi.hoisted(() => ({
   },
 }))
 
-vi.mock("@voyant-travel/bookings", () => ({ bookingsService: {} }))
+vi.mock("@voyant-travel/bookings", () => ({
+  bookingsService: {},
+  listBookingPassThroughItems: vi.fn(async () => []),
+}))
 vi.mock("@voyant-travel/bookings/schema", () => ({
   bookingItems: { bookingId: "bookingItems.bookingId" },
   bookings: tables.bookings,

--- a/packages/commerce/src/checkout/finalize.ts
+++ b/packages/commerce/src/checkout/finalize.ts
@@ -1,6 +1,7 @@
 // agent-quality: file-size exception -- owner: commerce; checkout finalization
 // (confirm booking, issue invoice, and link payments) is one cohesive
 // domain operation.
+import { listBookingPassThroughItems } from "@voyant-travel/bookings"
 import { bookings } from "@voyant-travel/bookings/schema"
 import {
   type CheckoutFinalizeDeps,
@@ -16,6 +17,8 @@ import {
 import { and, desc, eq, isNull, ne } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { fulfillBookingAncillaries } from "./ancillary-commit.js"
+import type { AncillaryOfferSource } from "./ancillary-ports.js"
 import {
   type CheckoutFinalizationIdentity,
   ensureCheckoutFinalization,
@@ -31,8 +34,29 @@ export function buildCheckoutFinalizeDeps(
   eventBus: EventBus,
   identity: CheckoutFinalizationIdentity,
   _monthlyBookingLimit?: number | null,
+  /**
+   * Whatever the deployment bound to `commerce.ancillary-offer-source`. Empty
+   * — the normal case — leaves the saga's `fulfill_ancillaries` step with no
+   * dep at all, which it treats as "skipped".
+   */
+  ancillaryOfferSources: readonly AncillaryOfferSource[] = [],
 ): CheckoutFinalizeDeps {
+  const fulfillAncillaries: CheckoutFinalizeDeps["fulfillAncillaries"] =
+    ancillaryOfferSources.length > 0
+      ? async ({ bookingId }) => {
+          const result = await fulfillBookingAncillaries({
+            db,
+            bookingId,
+            sources: ancillaryOfferSources,
+            listPassThroughItems: listBookingPassThroughItems,
+          })
+          if (result.outcomes.length === 0) return null
+          return { outcomes: result.outcomes }
+        }
+      : undefined
+
   return {
+    ...(fulfillAncillaries ? { fulfillAncillaries } : {}),
     db,
     eventBus,
     assertBookingCommitted: async (bookingId) => {
@@ -294,6 +318,8 @@ export interface FinalizeCheckoutParams {
   eventBus: EventBus
   input: CheckoutFinalizeInput
   monthlyBookingLimit?: number | null
+  /** Bound ancillary sources, so a paid premium can become an issued artifact. */
+  ancillaryOfferSources?: readonly AncillaryOfferSource[]
 }
 
 /**
@@ -316,6 +342,7 @@ export async function finalizeCheckout(params: FinalizeCheckoutParams): Promise<
     params.eventBus,
     identity,
     params.monthlyBookingLimit,
+    params.ancillaryOfferSources ?? [],
   )
   await runCheckoutFinalize(params.input, deps)
   await withCheckoutFinalizationLock(params.db, identity, async (tx) => {

--- a/packages/commerce/src/checkout/finalize.ts
+++ b/packages/commerce/src/checkout/finalize.ts
@@ -41,22 +41,25 @@ export function buildCheckoutFinalizeDeps(
    */
   ancillaryOfferSources: readonly AncillaryOfferSource[] = [],
 ): CheckoutFinalizeDeps {
-  const fulfillAncillaries: CheckoutFinalizeDeps["fulfillAncillaries"] =
-    ancillaryOfferSources.length > 0
-      ? async ({ bookingId }) => {
-          const result = await fulfillBookingAncillaries({
-            db,
-            bookingId,
-            sources: ancillaryOfferSources,
-            listPassThroughItems: listBookingPassThroughItems,
-          })
-          if (result.outcomes.length === 0) return null
-          return { outcomes: result.outcomes }
-        }
-      : undefined
+  // Bound unconditionally, including when nothing is connected. Making the dep
+  // conditional on a non-empty source list is what let a paid ancillary vanish:
+  // the step was skipped, the saga completed, `completedAt` was written, and
+  // redelivery after the source came back returned early. With the dep always
+  // present, the charged lines are inspected and an unbound source becomes an
+  // `ancillary.fulfillment.unresolved` record on the booking instead of silence.
+  const fulfillAncillaries: CheckoutFinalizeDeps["fulfillAncillaries"] = async ({ bookingId }) => {
+    const result = await fulfillBookingAncillaries({
+      db,
+      bookingId,
+      sources: ancillaryOfferSources,
+      listPassThroughItems: listBookingPassThroughItems,
+    })
+    if (result.outcomes.length === 0) return null
+    return { outcomes: result.outcomes }
+  }
 
   return {
-    ...(fulfillAncillaries ? { fulfillAncillaries } : {}),
+    fulfillAncillaries,
     db,
     eventBus,
     assertBookingCommitted: async (bookingId) => {

--- a/packages/commerce/src/checkout/index.ts
+++ b/packages/commerce/src/checkout/index.ts
@@ -22,12 +22,26 @@ export {
   persistAcceptanceSignature,
 } from "./acceptance-signature.js"
 export {
+  type AncillaryContact,
+  AncillaryPreparationError,
+  type FulfillBookingAncillariesInput,
+  type FulfillBookingAncillariesResult,
+  type FulfilledBookingAncillary,
+  fulfillBookingAncillaries,
+  type PrepareBookingAncillariesInput,
+  type PrepareBookingAncillariesResult,
+  type PreparedBookingAncillary,
+  prepareBookingAncillaries,
+} from "./ancillary-commit.js"
+export {
+  type AncillaryItemMarker,
   AncillaryPremiumDriftError,
   type AncillaryPremiumReconciliation,
   type MaterializeAncillaryPassThroughItemInput,
   type MaterializedAncillaryItem,
   materializeAncillaryPassThroughItem,
   type ReconcileAncillaryPremiumInput,
+  readAncillaryItemMarker,
   reconcileAncillaryPremium,
 } from "./ancillary-materialization.js"
 export {

--- a/packages/commerce/src/checkout/options.ts
+++ b/packages/commerce/src/checkout/options.ts
@@ -147,4 +147,18 @@ export interface CheckoutStartOptions extends CheckoutModuleOptions {
     description: string
     returnUrl?: string
   }): Promise<{ redirectUrl: string | null } | null>
+  /**
+   * The tax treatment to stamp on a third-party premium line, per source.
+   *
+   * Injected because commerce does not know what an ancillary is. Travel
+   * insurance is VAT-exempt in most of the EU and taxed elsewhere; the module
+   * that binds the source knows which, and the treatment travels on the row
+   * rather than being resolved from the operator's own tax policy — a
+   * pass-through line is not the operator's supply. Absent, or returning
+   * `null`, means the line simply carries no tax row.
+   */
+  resolveAncillaryTaxTreatmentCode?(source: {
+    sourceId: string
+    kind: string
+  }): string | null | undefined
 }

--- a/packages/commerce/src/checkout/routes.ts
+++ b/packages/commerce/src/checkout/routes.ts
@@ -278,9 +278,13 @@ export function createCatalogCheckoutApiExtension(
           CATALOG_CHECKOUT_API_RUNTIME_KEY,
           typeof options === "function" ? options : () => options,
         )
+        // The list itself, not a factory that returns it. The container hands
+        // back whatever was registered without calling anything, so a thunk
+        // here reads as "not an array" at every consumer — which is how the
+        // key stayed registered and unread (voyant#4756).
         container.register(
           ANCILLARY_OFFER_SOURCES_RUNTIME_KEY,
-          () => bindings.ancillaryOfferSources ?? [],
+          bindings.ancillaryOfferSources ?? [],
         )
       },
     },

--- a/packages/commerce/src/checkout/start-service.ts
+++ b/packages/commerce/src/checkout/start-service.ts
@@ -22,7 +22,12 @@ import {
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { z } from "zod"
-import { AncillaryPreparationError, prepareBookingAncillaries } from "./ancillary-commit.js"
+import {
+  AncillaryApplicationExpiredError,
+  AncillaryPreparationError,
+  AncillaryTermsChangedError,
+  prepareBookingAncillaries,
+} from "./ancillary-commit.js"
 import type { AncillaryOfferSource } from "./ancillary-ports.js"
 import type { CheckoutStartOptions } from "./options.js"
 import { ANCILLARY_OFFER_SOURCES_RUNTIME_KEY } from "./runtime-ports.js"
@@ -232,13 +237,26 @@ async function chargeAcceptedAncillaries(
           ? { phone: committed.contact.phone || (booking.contactPhone ?? "") }
           : {}),
       },
-      existingItems: await listBookingPassThroughItems(context.db, booking.id),
+      listPassThroughItems: listBookingPassThroughItems,
       ...(context.options.resolveAncillaryTaxTreatmentCode
         ? { resolveTaxTreatmentCode: context.options.resolveAncillaryTaxTreatmentCode }
         : {}),
     })
-    return result.prepared.length
+    // Newly prepared AND already-charged both count. If a previous attempt
+    // committed the line and then died before the total was re-rolled, the
+    // retry finds the marker, prepares nothing, and would skip the recompute
+    // for good — leaving the card path collecting a `sellAmountCents` that
+    // omits a premium the invoice still bills.
+    return result.prepared.length + result.alreadyCharged.length
   } catch (error) {
+    if (error instanceof AncillaryApplicationExpiredError) {
+      console.error("[catalog-checkout] ancillary application expired", error)
+      throw new CatalogCheckoutStartError("ancillary_application_expired", 409)
+    }
+    if (error instanceof AncillaryTermsChangedError) {
+      console.error("[catalog-checkout] ancillary terms changed", error)
+      throw new CatalogCheckoutStartError("ancillary_terms_changed", 409)
+    }
     if (error instanceof AncillaryPreparationError) {
       console.error("[catalog-checkout] ancillary preparation failed", error)
       throw new CatalogCheckoutStartError("ancillary_preparation_failed", 502)

--- a/packages/commerce/src/checkout/start-service.ts
+++ b/packages/commerce/src/checkout/start-service.ts
@@ -1,8 +1,13 @@
 // agent-quality: file-size exception -- owner: commerce; the checkout-start
 // service (card / bank-transfer collection intents) is one cohesive
 // entry point; splitting it would scatter a single request lifecycle.
-import { getBookingOriginByBookingId } from "@voyant-travel/bookings"
+import {
+  bookingsService,
+  getBookingOriginByBookingId,
+  listBookingPassThroughItems,
+} from "@voyant-travel/bookings"
 import { bookingActivityLog, bookingItems, bookings } from "@voyant-travel/bookings/schema"
+import { loadCommittedAncillarySelections } from "@voyant-travel/catalog/booking-engine"
 import type { EventBus } from "@voyant-travel/core"
 import {
   type CreateInvoiceFromBookingInput,
@@ -17,7 +22,10 @@ import {
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { z } from "zod"
+import { AncillaryPreparationError, prepareBookingAncillaries } from "./ancillary-commit.js"
+import type { AncillaryOfferSource } from "./ancillary-ports.js"
 import type { CheckoutStartOptions } from "./options.js"
+import { ANCILLARY_OFFER_SOURCES_RUNTIME_KEY } from "./runtime-ports.js"
 
 export const checkoutStartSchema = z.object({
   bookingId: z.string().min(1),
@@ -110,7 +118,7 @@ export async function startCatalogCheckout(
 ): Promise<CatalogCheckoutStartResult> {
   const publicChannel = requireActivePublicApiChannel(context)
   const db = context.db
-  const booking: typeof bookings.$inferSelect | null =
+  let booking: typeof bookings.$inferSelect | null =
     (await db.select().from(bookings).where(eq(bookings.id, body.bookingId)).limit(1))[0] ?? null
   if (!booking) throw new CatalogCheckoutStartError("booking_not_found", 404)
   if (!["confirmed", "in_progress", "completed"].includes(booking.status)) {
@@ -159,12 +167,106 @@ export async function startCatalogCheckout(
     }
   }
 
+  // The post-commit, pre-payment seam for anything quoted live from a third
+  // party. It sits here and not in the Booking Session commit because
+  // `prepare` is an HTTP call to that third party, and the commit transaction
+  // carries the session state machine and the settlement path — a round trip
+  // inside it either holds it open across the call or fails it after money has
+  // moved (voyant#4733, voyant#4734). Here the Booking exists, nothing has been
+  // charged, and the amount the payment provider is about to be asked for is
+  // still being assembled.
+  const chargedAncillaries = await chargeAcceptedAncillaries(context, booking)
+  if (chargedAncillaries > 0) {
+    // The premium is a Booking line, so the Booking total has to be re-rolled
+    // before anything reads an amount off it. The card path charges
+    // `sellAmountCents` and the bank-transfer path bills the item rows; both
+    // would otherwise collect a total that omits what the traveller bought.
+    await bookingsService.recomputeBookingTotal(db, booking.id)
+    booking =
+      (await db.select().from(bookings).where(eq(bookings.id, body.bookingId)).limit(1))[0] ??
+      booking
+  }
+
   switch (body.paymentIntent) {
     case "card":
       return startCardCheckout(context, booking, body)
     case "bank_transfer":
       return startBankTransferCheckout(context, booking, body)
   }
+}
+
+/**
+ * Open an application at every source the traveller accepted an offer from,
+ * and put each premium on the Booking. Returns how many lines were written.
+ *
+ * A failure here is a `502`, deliberately. The alternative — dropping the
+ * offer and letting checkout continue — charges a traveller who chose travel
+ * insurance for a trip without it, and nothing downstream ever says so.
+ */
+async function chargeAcceptedAncillaries(
+  context: CatalogCheckoutStartContext,
+  booking: typeof bookings.$inferSelect,
+): Promise<number> {
+  const sources = resolveAncillaryOfferSources(context)
+  if (sources.length === 0) return 0
+
+  const committed = await loadCommittedAncillarySelections(context.db, booking.id)
+  if (!committed || committed.accepted.length === 0) return 0
+
+  try {
+    const result = await prepareBookingAncillaries({
+      db: context.db,
+      bookingId: booking.id,
+      bookingSessionId: committed.bookingSessionId,
+      sources,
+      accepted: committed.accepted,
+      // The Session's billing step first, the Booking's own contact columns
+      // when it left one blank. They are the same fact recorded twice, and a
+      // third party that refuses a nameless application would otherwise fail a
+      // checkout over which copy was consulted.
+      contact: {
+        firstName: committed.contact.firstName || (booking.contactFirstName ?? ""),
+        lastName: committed.contact.lastName || (booking.contactLastName ?? ""),
+        email: committed.contact.email || (booking.contactEmail ?? ""),
+        ...(committed.contact.phone || booking.contactPhone
+          ? { phone: committed.contact.phone || (booking.contactPhone ?? "") }
+          : {}),
+      },
+      existingItems: await listBookingPassThroughItems(context.db, booking.id),
+      ...(context.options.resolveAncillaryTaxTreatmentCode
+        ? { resolveTaxTreatmentCode: context.options.resolveAncillaryTaxTreatmentCode }
+        : {}),
+    })
+    return result.prepared.length
+  } catch (error) {
+    if (error instanceof AncillaryPreparationError) {
+      console.error("[catalog-checkout] ancillary preparation failed", error)
+      throw new CatalogCheckoutStartError("ancillary_preparation_failed", 502)
+    }
+    throw error
+  }
+}
+
+/**
+ * The bound sources, or none.
+ *
+ * Zero is the normal state and stays silent all the way down: a deployment
+ * that has connected nothing registers an empty list, and one that has not
+ * composed the checkout extension at all resolves to nothing.
+ */
+function resolveAncillaryOfferSources(
+  context: CatalogCheckoutStartContext,
+): readonly AncillaryOfferSource[] {
+  let resolved: unknown
+  try {
+    resolved = context.resolveRuntime?.(ANCILLARY_OFFER_SOURCES_RUNTIME_KEY)
+  } catch {
+    // The container throws for an unregistered key, and a deployment that
+    // mounted these routes without the checkout extension's bootstrap has none
+    // bound. That is the same silence as binding zero sources.
+    return []
+  }
+  return Array.isArray(resolved) ? (resolved as readonly AncillaryOfferSource[]) : []
 }
 
 function requireActivePublicApiChannel(

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -16,6 +16,7 @@ import {
   type AcceptanceSignatureLegalPort,
   persistAcceptanceSignature,
 } from "./acceptance-signature.js"
+import { type AncillaryOfferSource, ancillaryOfferSourceRuntimePort } from "./ancillary-ports.js"
 import { finalizeCheckout } from "./finalize.js"
 import {
   type CatalogCheckoutDatabaseRuntime,
@@ -68,6 +69,14 @@ export interface CheckoutFinalizeSubscriberRuntimeOptions<TBindings = unknown>
    * path consumes the same quota as the booking and finance routes.
    */
   resolveMonthlyBookingLimit?: MonthlyBookingLimitResolver
+  /**
+   * Sources bound to `commerce.ancillary-offer-source`.
+   *
+   * The half of the checkout seam that runs after the money: a premium was put
+   * on the booking before payment, and this is what turns it into an issued
+   * artifact. Empty — the normal case — leaves the saga step skipped.
+   */
+  ancillaryOfferSources?: readonly AncillaryOfferSource[]
 }
 
 interface ContractDocumentGeneratedPayload {
@@ -239,6 +248,7 @@ export function createCheckoutFinalizeSubscriberRuntime<TBindings = unknown>(
                   paymentIntent: data.paymentIntent,
                 },
                 monthlyBookingLimit,
+                ancillaryOfferSources: options.ancillaryOfferSources ?? [],
               })
               if (!options.legal) return
               await options.legal.recordBookingPaymentConfirmation(
@@ -327,10 +337,13 @@ export const createAcceptanceSignatureSubscriberGraphRuntime = defineGraphRuntim
 
 /** Selected-graph factory for inline payment finalization. */
 export const createCheckoutFinalizeSubscriberGraphRuntime = defineGraphRuntimeFactory(
-  async ({ getPort, hostOptions }) => {
+  async ({ getPort, getPorts, hostOptions }) => {
     const database = await getPort(catalogCheckoutDatabaseRuntimePort)
     const settlement = await getPort(catalogBookingSessionSettlementRuntimePort)
     const legal = await getPort(catalogCheckoutLegalRuntimePort)
+    // Many-valued and optional, like the checkout API extension's own read of
+    // it: zero bound sources is a supported, silent state, not a degraded one.
+    const ancillaryOfferSources = await getPorts(ancillaryOfferSourceRuntimePort)
     return {
       id: COMMERCE_CHECKOUT_FINALIZE_SUBSCRIBER_ID,
       eventType: "payment.completed",
@@ -338,6 +351,7 @@ export const createCheckoutFinalizeSubscriberGraphRuntime = defineGraphRuntimeFa
         const descriptor = createCheckoutFinalizeSubscriberRuntime({
           ...database,
           legal,
+          ancillaryOfferSources,
           settleBookingSession: (input) => settlement.commitPaidSession(input),
           // Finalizing a checkout accepts a booking, so this path draws on the
           // same monthly quota as the booking and finance routes. Before host

--- a/packages/commerce/tests/integration/ancillary-checkout-fulfilment.test.ts
+++ b/packages/commerce/tests/integration/ancillary-checkout-fulfilment.test.ts
@@ -1,0 +1,552 @@
+/**
+ * The evidence that an accepted ancillary offer is actually charged and issued.
+ *
+ * voyant#4756: both halves of the seam existed and nothing crossed it — a
+ * traveller could accept travel insurance, answer the insurer's questions and
+ * acknowledge its disclosures, and then the premium never reached the booking
+ * and no policy was ever issued. Every assertion here is on a production entry
+ * point (`startCatalogCheckout`, `finalizeCheckout`) rather than on the
+ * building blocks, because "the pieces work" was already true when the bug was
+ * filed.
+ *
+ * The route it drives, end to end:
+ *
+ *   quote → accept  (the accepted selection on the committed Booking Session)
+ *   commit          (the `booking_session_commits` row that names the Booking)
+ *   checkout-start  (`prepare` at the source, premium onto the Booking)
+ *   pay             (the paid `payment_sessions` row)
+ *   issue           (`fulfill` at the source, reconciled against the charge)
+ *
+ * The source is a scripted `AncillaryOfferSource` and not the insurance module,
+ * deliberately: that port IS the boundary commerce owns, and commerce may not
+ * depend on a module that binds it. What happens on the far side of it — the
+ * application row, the issued policy, the certificate on the booking, the
+ * `issue_failed` staff alert — is insurance's own integration test.
+ */
+
+import {
+  bookingActivityLog,
+  bookingItems,
+  bookingOrigins,
+  bookings,
+} from "@voyant-travel/bookings/schema"
+import {
+  bookingSessionCommitsTable,
+  bookingSessionsTable,
+} from "@voyant-travel/catalog/booking-engine/sessions-schema"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { invoiceNumberSeries, invoices, paymentSessions } from "@voyant-travel/finance/schema"
+import { and, eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import type {
+  AncillaryFulfillmentResult,
+  AncillaryOfferSource,
+  AncillaryPreparedSelection,
+  AncillaryPrepareInput,
+} from "../../src/checkout/ancillary-ports.js"
+import { finalizeCheckout } from "../../src/checkout/finalize.js"
+import type { CheckoutStartOptions } from "../../src/checkout/options.js"
+import { ANCILLARY_OFFER_SOURCES_RUNTIME_KEY } from "../../src/checkout/runtime-ports.js"
+import {
+  CatalogCheckoutStartError,
+  startCatalogCheckout,
+} from "../../src/checkout/start-service.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+/** Cleanup truncates the whole operator schema; 5s is not a realistic budget. */
+const DB_TEST_TIMEOUT = 60_000
+
+const CHANNEL_ID = "chn_ancillary_storefront"
+const PRODUCT_ID = "prod_ancillary_fixture"
+const BASE_FARE_MINOR = 120_000
+const PREMIUM_MINOR = 4_200
+
+/** Nothing on the bus for this path; a no-op keeps the assertions on the rows. */
+const eventBus = {
+  emit: async () => undefined,
+  subscribe: () => undefined,
+} as never
+
+interface ScriptedSource {
+  source: AncillaryOfferSource
+  prepareCalls: AncillaryPrepareInput[]
+  fulfillCalls: string[]
+}
+
+/**
+ * A source that does exactly what the test tells it to, one call at a time.
+ *
+ * `prepare` answers with a fixed price so the charge can be asserted against a
+ * number the test chose; `fulfill` is scripted per outcome so a refusal, a
+ * drift and a success are all reachable from the same shape.
+ */
+function scriptedSource(options: {
+  sourceId?: string
+  preparedPriceMinor?: number
+  prepareRejects?: Error
+  fulfillment?: AncillaryFulfillmentResult
+}): ScriptedSource {
+  const sourceId = options.sourceId ?? "test-ancillary"
+  const prepareCalls: AncillaryPrepareInput[] = []
+  const fulfillCalls: string[] = []
+
+  const source: AncillaryOfferSource = {
+    sourceId,
+    kind: "insurance",
+    label: "Travel insurance",
+    async quote() {
+      return { kind: "insurance", label: "Travel insurance", offers: [], diagnostics: [] }
+    },
+    async prepare(input): Promise<AncillaryPreparedSelection> {
+      prepareCalls.push(input)
+      if (options.prepareRejects) throw options.prepareRejects
+      return {
+        sourceId,
+        providerId: input.selection.providerId ?? "test-provider",
+        applicationRef: `app_${prepareCalls.length}`,
+        priceMinor: options.preparedPriceMinor ?? PREMIUM_MINOR,
+        currency: "EUR",
+        title: "Comprehensive travel insurance",
+        expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      }
+    },
+    async fulfill(input): Promise<AncillaryFulfillmentResult> {
+      fulfillCalls.push(input.applicationRef)
+      return (
+        options.fulfillment ?? {
+          status: "fulfilled",
+          reference: "POL-1",
+          settledPriceMinor: input.chargedPriceMinor,
+          currency: input.currency,
+          documentIds: ["bdoc_certificate_1"],
+        }
+      )
+    },
+    async cancel() {
+      // Nothing here unwinds; the tests assert on the forward path only.
+    },
+  }
+
+  return { source, prepareCalls, fulfillCalls }
+}
+
+function acceptedSelection(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: "insurance",
+    decision: "accepted",
+    offerId: "offer-1",
+    sourceId: "test-ancillary",
+    providerId: "test-provider",
+    quoteRef: "quote-ref-1",
+    travelers: [
+      {
+        ref: "traveler-0",
+        fields: { given_name: "Ana", family_name: "Popescu", date_of_birth: "1990-04-02" },
+      },
+    ],
+    selectedOptionIds: [],
+    acceptedDisclosures: [{ kind: "ipid", versionId: "v1", acceptedAt: new Date().toISOString() }],
+    ...overrides,
+  }
+}
+
+function declinedSelection() {
+  return {
+    kind: "insurance",
+    decision: "declined",
+    travelers: [],
+    selectedOptionIds: [],
+    acceptedDisclosures: [],
+  }
+}
+
+function checkoutOptions(): CheckoutStartOptions {
+  return {
+    resolveBookingTaxSettings: async () =>
+      ({ taxPriceMode: "inclusive", taxPolicyProfileId: null }) as never,
+    getOwnedProductName: async () => "Fixture product",
+    resolveBankTransferInstructions: async () => ({
+      beneficiary: "Voyant SRL",
+      iban: "RO49AAAA1B31007593840000",
+      bankName: "Test Bank",
+    }),
+    publication: { isProductPublished: async () => true },
+    resolveAncillaryTaxTreatmentCode: () => "insurance/exempt",
+  }
+}
+
+describe.skipIf(!DB_AVAILABLE)("ancillary checkout charge and fulfilment", () => {
+  let db: PostgresJsDatabase
+  let sequence = 0
+
+  beforeAll(async () => {
+    const { createTestDb } = await import("@voyant-travel/db/test-utils")
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    await cleanupTestDb(db)
+  }, DB_TEST_TIMEOUT)
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyant-travel/db/test-utils")
+    await closeTestDb()
+  })
+
+  /**
+   * A Booking as the Booking Session commit leaves it: confirmed, on a
+   * storefront channel, with the Session that produced it still holding the
+   * traveller's ancillary decision.
+   */
+  async function seedCommittedBooking(ancillaries: unknown[]): Promise<{
+    bookingId: string
+    bookingSessionId: string
+  }> {
+    sequence += 1
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        status: "confirmed",
+        bookingNumber: `BKG-ANC-${sequence}-${Math.floor(Math.random() * 1_000_000)}`,
+        sellCurrency: "EUR",
+        sellAmountCents: BASE_FARE_MINOR,
+        startDate: "2026-09-01",
+      })
+      .returning()
+    const bookingId = booking!.id
+
+    await db.insert(bookingItems).values({
+      bookingId,
+      title: "Fixture product",
+      itemType: "unit",
+      status: "confirmed",
+      quantity: 1,
+      sellCurrency: "EUR",
+      unitSellAmountCents: BASE_FARE_MINOR,
+      totalSellAmountCents: BASE_FARE_MINOR,
+      productId: PRODUCT_ID,
+    })
+
+    await db.insert(bookingOrigins).values({
+      bookingId,
+      originSource: "direct_b2c",
+      channelId: CHANNEL_ID,
+    })
+
+    const bookingSessionId = newId("booking_sessions")
+    await db.insert(bookingSessionsTable).values({
+      id: bookingSessionId,
+      createIdempotencyKey: `create-${bookingSessionId}`,
+      createRequestFingerprint: "fingerprint",
+      actorKind: "customer",
+      ownerPrincipalId: "usr_fixture",
+      channelId: CHANNEL_ID,
+      locale: "en",
+      market: "RO",
+      currency: "EUR",
+      targetKind: "product",
+      productId: PRODUCT_ID,
+      state: "consumed",
+      revision: 2,
+      statePayload: {
+        billing: {
+          buyerType: "B2C",
+          contact: {
+            firstName: "Ana",
+            lastName: "Popescu",
+            email: "ana@example.com",
+            phone: "+40700000000",
+          },
+          address: {},
+        },
+        ancillaries,
+      },
+      expiresAt: new Date(Date.now() + 3_600_000),
+      consumedAt: new Date(),
+    })
+
+    await db.insert(bookingSessionCommitsTable).values({
+      id: newId("booking_session_commits"),
+      sessionId: bookingSessionId,
+      idempotencyKey: `commit-${bookingSessionId}`,
+      requestFingerprint: "fingerprint",
+      outcome: { kind: "committed" },
+      bookingId,
+    })
+
+    return { bookingId, bookingSessionId }
+  }
+
+  async function startCheckout(bookingId: string, source: AncillaryOfferSource) {
+    return startCatalogCheckout(
+      {
+        db,
+        env: {},
+        eventBus,
+        resolveRuntime: (key) =>
+          key === ANCILLARY_OFFER_SOURCES_RUNTIME_KEY ? [source] : undefined,
+        publicChannel: { channelId: CHANNEL_ID, channelStatus: "active" },
+        options: checkoutOptions(),
+      },
+      { bookingId, paymentIntent: "card", payerEmail: "ana@example.com", payerName: "Ana Popescu" },
+    )
+  }
+
+  /** Money in: the storefront's paid session, as the provider callback leaves it. */
+  async function markPaid(bookingId: string, paymentSessionId: string): Promise<void> {
+    await db
+      .update(paymentSessions)
+      .set({ status: "paid", completedAt: new Date(), providerPaymentId: "pi_test" })
+      .where(eq(paymentSessions.id, paymentSessionId))
+    await db.insert(invoiceNumberSeries).values({
+      code: `INV-${sequence}`,
+      name: "Invoices",
+      scope: "invoice",
+      prefix: "INV",
+      separator: "-",
+      padLength: 4,
+      isDefault: true,
+      active: true,
+    })
+    void bookingId
+  }
+
+  async function activityEvents(bookingId: string): Promise<string[]> {
+    const rows = await db
+      .select({ metadata: bookingActivityLog.metadata })
+      .from(bookingActivityLog)
+      .where(eq(bookingActivityLog.bookingId, bookingId))
+    return rows
+      .map((row) => (row.metadata as { event?: unknown } | null)?.event)
+      .filter((event): event is string => typeof event === "string")
+  }
+
+  async function passThroughItems(bookingId: string) {
+    return db
+      .select()
+      .from(bookingItems)
+      .where(
+        and(
+          eq(bookingItems.bookingId, bookingId),
+          eq(bookingItems.pricingTreatment, "pass_through"),
+        ),
+      )
+  }
+
+  it(
+    "charges an accepted offer at the prepared price and issues it once paid",
+    async () => {
+      const { bookingId, bookingSessionId } = await seedCommittedBooking([acceptedSelection()])
+      const scripted = scriptedSource({})
+
+      const started = await startCheckout(bookingId, scripted.source)
+
+      // The application was opened against the Session the Booking came from,
+      // with the billing step's contact and a key derived from the Booking.
+      expect(scripted.prepareCalls).toHaveLength(1)
+      expect(scripted.prepareCalls[0]).toMatchObject({
+        bookingSessionId,
+        contact: { firstName: "Ana", lastName: "Popescu", email: "ana@example.com" },
+      })
+      expect(scripted.prepareCalls[0]?.idempotencyKey).toContain(bookingId)
+
+      // The premium is on the Booking as a pass-through line: sell equals cost,
+      // treatment stamped on the row, priced at what `prepare` committed to.
+      const premiumItems = await passThroughItems(bookingId)
+      expect(premiumItems).toHaveLength(1)
+      expect(premiumItems[0]).toMatchObject({
+        totalSellAmountCents: PREMIUM_MINOR,
+        totalCostAmountCents: PREMIUM_MINOR,
+        pricingTreatment: "pass_through",
+        taxTreatmentCode: "insurance/exempt",
+        sourceOfferId: "app_1",
+      })
+
+      // And the amount the payment provider is asked for contains it, which is
+      // the whole point: a premium the traveller is never charged for is the
+      // bug this test exists for.
+      const [booking] = await db.select().from(bookings).where(eq(bookings.id, bookingId))
+      expect(booking?.sellAmountCents).toBe(BASE_FARE_MINOR + PREMIUM_MINOR)
+      expect(started.kind).toBe("card_redirect")
+      if (started.kind !== "card_redirect") return
+      const [session] = await db
+        .select()
+        .from(paymentSessions)
+        .where(eq(paymentSessions.id, started.paymentSessionId))
+      expect(session?.amountCents).toBe(BASE_FARE_MINOR + PREMIUM_MINOR)
+
+      await markPaid(bookingId, started.paymentSessionId)
+      await finalizeCheckout({
+        db,
+        eventBus,
+        input: { bookingId, paymentSessionId: started.paymentSessionId, paymentIntent: "card" },
+        ancillaryOfferSources: [scripted.source],
+      })
+
+      // Issued after the money, against the application that was charged.
+      expect(scripted.fulfillCalls).toEqual(["app_1"])
+
+      // The invoice the traveller receives carries the premium too.
+      const invoiceRows = await db.select().from(invoices).where(eq(invoices.bookingId, bookingId))
+      expect(invoiceRows).toHaveLength(1)
+      expect(invoiceRows[0]?.totalCents).toBe(BASE_FARE_MINOR + PREMIUM_MINOR)
+
+      // A matched premium is not noise: no drift and no failure was recorded.
+      const events = await activityEvents(bookingId)
+      expect(events).not.toContain("ancillary.premium.drift")
+      expect(events).not.toContain("ancillary.fulfillment.failed")
+    },
+    DB_TEST_TIMEOUT,
+  )
+
+  it(
+    "charges nothing for a declined offer",
+    async () => {
+      const { bookingId } = await seedCommittedBooking([declinedSelection()])
+      const scripted = scriptedSource({})
+
+      const started = await startCheckout(bookingId, scripted.source)
+
+      expect(scripted.prepareCalls).toHaveLength(0)
+      expect(await passThroughItems(bookingId)).toHaveLength(0)
+      const [booking] = await db.select().from(bookings).where(eq(bookings.id, bookingId))
+      expect(booking?.sellAmountCents).toBe(BASE_FARE_MINOR)
+
+      if (started.kind !== "card_redirect") throw new Error("expected a card checkout")
+      await markPaid(bookingId, started.paymentSessionId)
+      await finalizeCheckout({
+        db,
+        eventBus,
+        input: { bookingId, paymentSessionId: started.paymentSessionId, paymentIntent: "card" },
+        ancillaryOfferSources: [scripted.source],
+      })
+      expect(scripted.fulfillCalls).toHaveLength(0)
+    },
+    DB_TEST_TIMEOUT,
+  )
+
+  it(
+    "charges an accepted offer once when checkout is re-entered",
+    async () => {
+      const { bookingId } = await seedCommittedBooking([acceptedSelection()])
+      const scripted = scriptedSource({})
+
+      await startCheckout(bookingId, scripted.source)
+      await startCheckout(bookingId, scripted.source)
+
+      // A customer who hits Back and resubmits must not end up with two
+      // applications and two premiums on one booking.
+      expect(scripted.prepareCalls).toHaveLength(1)
+      expect(await passThroughItems(bookingId)).toHaveLength(1)
+      const [booking] = await db.select().from(bookings).where(eq(bookings.id, bookingId))
+      expect(booking?.sellAmountCents).toBe(BASE_FARE_MINOR + PREMIUM_MINOR)
+    },
+    DB_TEST_TIMEOUT,
+  )
+
+  it(
+    "refuses to start checkout when the offer cannot be prepared",
+    async () => {
+      const { bookingId } = await seedCommittedBooking([acceptedSelection()])
+      const scripted = scriptedSource({ prepareRejects: new Error("insurer unreachable") })
+
+      // Before the money, so the honest outcome is to stop. Continuing would
+      // charge a traveller who chose insurance for a trip without it.
+      await expect(startCheckout(bookingId, scripted.source)).rejects.toBeInstanceOf(
+        CatalogCheckoutStartError,
+      )
+      expect(await passThroughItems(bookingId)).toHaveLength(0)
+      const [session] = await db
+        .select()
+        .from(paymentSessions)
+        .where(eq(paymentSessions.bookingId, bookingId))
+      expect(session).toBeUndefined()
+    },
+    DB_TEST_TIMEOUT,
+  )
+
+  it(
+    "records a failed issue after payment instead of losing it",
+    async () => {
+      const { bookingId } = await seedCommittedBooking([acceptedSelection()])
+      const scripted = scriptedSource({
+        fulfillment: {
+          status: "failed",
+          code: "provider_declined",
+          message: "The insurer refused the risk.",
+          retryable: false,
+        },
+      })
+
+      const started = await startCheckout(bookingId, scripted.source)
+      if (started.kind !== "card_redirect") throw new Error("expected a card checkout")
+      await markPaid(bookingId, started.paymentSessionId)
+
+      // The saga completes. A failure after a captured payment is a recorded
+      // outcome, not a thrown error that unwinds the payment linkage above it.
+      await expect(
+        finalizeCheckout({
+          db,
+          eventBus,
+          input: { bookingId, paymentSessionId: started.paymentSessionId, paymentIntent: "card" },
+          ancillaryOfferSources: [scripted.source],
+        }),
+      ).resolves.toBeUndefined()
+
+      expect(await activityEvents(bookingId)).toContain("ancillary.fulfillment.failed")
+      // The booking stays intact and still carries what was charged, so an
+      // operator has something to act on.
+      expect(await passThroughItems(bookingId)).toHaveLength(1)
+    },
+    DB_TEST_TIMEOUT,
+  )
+
+  it(
+    "records drift between the charged premium and the issued one",
+    async () => {
+      const { bookingId } = await seedCommittedBooking([acceptedSelection()])
+      const scripted = scriptedSource({
+        fulfillment: {
+          status: "fulfilled",
+          reference: "POL-2",
+          settledPriceMinor: PREMIUM_MINOR + 100,
+          currency: "EUR",
+          documentIds: ["bdoc_certificate_2"],
+        },
+      })
+
+      const started = await startCheckout(bookingId, scripted.source)
+      if (started.kind !== "card_redirect") throw new Error("expected a card checkout")
+      await markPaid(bookingId, started.paymentSessionId)
+
+      await finalizeCheckout({
+        db,
+        eventBus,
+        input: { bookingId, paymentSessionId: started.paymentSessionId, paymentIntent: "card" },
+        ancillaryOfferSources: [scripted.source],
+      })
+
+      // Recorded where an operator will see it, and never absorbed by silently
+      // adjusting what the traveller already paid.
+      const rows = await db
+        .select({ metadata: bookingActivityLog.metadata })
+        .from(bookingActivityLog)
+        .where(eq(bookingActivityLog.bookingId, bookingId))
+      const drift = rows
+        .map((row) => row.metadata as Record<string, unknown> | null)
+        .find((metadata) => metadata?.event === "ancillary.premium.drift")
+      expect(drift).toMatchObject({
+        chargedPriceMinor: PREMIUM_MINOR,
+        settledPriceMinor: PREMIUM_MINOR + 100,
+        differenceMinor: 100,
+      })
+      const premiumItems = await passThroughItems(bookingId)
+      expect(premiumItems[0]?.totalSellAmountCents).toBe(PREMIUM_MINOR)
+    },
+    DB_TEST_TIMEOUT,
+  )
+})

--- a/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
+++ b/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
@@ -423,6 +423,9 @@ describe("catalog-checkout subscriber runtimes", () => {
       hostOptions: { finalize, resolveMonthlyBookingLimit: () => live },
       getPort: async (port: { id: string }) =>
         port.id === catalogCheckoutLegalRuntimePort.id ? legalPort : { withDb },
+      // Many-valued and optional: a deployment with no ancillary source bound
+      // resolves to an empty list, which is the normal case.
+      getPorts: async () => [],
     } as never)
 
     await (descriptor as SubscriberRuntimeDescriptor).register({

--- a/packages/insurance/src/ancillary-source.ts
+++ b/packages/insurance/src/ancillary-source.ts
@@ -632,6 +632,23 @@ export function createInsuranceAncillaryOfferSource(
         await attachInsuranceApplicationToBooking(db, application.id, input.bookingId)
       }
 
+      // A re-delivered `payment.completed` re-runs the finalize saga from its
+      // first step, so this is reached again for a policy that already exists.
+      // Answering from the row rather than asking the insurer again is what
+      // makes the second run free: `issue` is idempotent at the provider by
+      // key, but a second call still costs a round trip and a second
+      // `issueAttempts` bump that reads like a retry after a failure.
+      const existing = await getInsurancePolicyForApplication(db, application.id)
+      if (existing?.issueState === "issued") {
+        return {
+          status: "fulfilled",
+          reference: existing.policyNumber ?? existing.id,
+          settledPriceMinor: existing.premiumAmountMinor,
+          currency: existing.premiumCurrency,
+          documentIds: [],
+        }
+      }
+
       const provider = await resolveProvider(application.providerId)
       if (!provider) {
         return {

--- a/packages/insurance/tests/integration/ancillary-source-fulfilment.test.ts
+++ b/packages/insurance/tests/integration/ancillary-source-fulfilment.test.ts
@@ -115,7 +115,10 @@ function insurer(options: { script: readonly IssueStep[] }) {
           email: "ana@example.test",
         },
         covers: [],
-      } as const
+        // Deliberately NOT `as const`: it makes `covers` a `readonly []`, and a
+        // readonly array is not assignable to the mutable one `InsurancePolicy`
+        // declares. `build` never sees this — only `typecheck` reads `tests/**`.
+      } satisfies Partial<InsurancePolicy>
 
       if (step.kind === "refuses") {
         return {

--- a/packages/insurance/tests/integration/ancillary-source-fulfilment.test.ts
+++ b/packages/insurance/tests/integration/ancillary-source-fulfilment.test.ts
@@ -1,0 +1,483 @@
+/**
+ * The far side of the checkout ancillary seam, driven as checkout drives it.
+ *
+ * `packages/commerce`'s own integration test proves that an accepted offer is
+ * prepared at commit, charged onto the booking, and fulfilled after payment —
+ * against a scripted `AncillaryOfferSource`, because commerce may not depend on
+ * a module that binds one. This is the other half: the same two calls, in the
+ * same order, made on the real insurance source with a scripted insurer behind
+ * it, so the things only this module can show are actually shown:
+ *
+ *  - `prepare` opens a real application row against the Booking Session.
+ *  - `fulfill` issues, and the certificate reaches the booking through the
+ *    booking-document path rather than being left at the insurer.
+ *  - an issue that fails *after* payment leaves `issue_failed` with the reason
+ *    and the retryable flag, and raises the staff alert — the path that was
+ *    unreachable until something started calling `fulfill` (voyant#4756).
+ *  - a second `fulfill` for the same application does not ask the insurer to
+ *    issue again, because a redelivered `payment.completed` re-runs the saga.
+ */
+
+import { bookings } from "@voyant-travel/bookings"
+import type {
+  InsuranceApplication,
+  InsuranceApplicationInput,
+  InsuranceDocument,
+  InsurancePolicy,
+  InsuranceProviderAdapter,
+  InsuranceQuote,
+} from "@voyant-travel/insurance-contracts"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { createInsuranceAncillaryOfferSource } from "../../src/ancillary-source.js"
+import type {
+  InsuranceBookingIntegration,
+  InsuranceIssueFailedAlertContext,
+} from "../../src/booking-integration.js"
+import { createInsurancePiiService } from "../../src/pii.js"
+import { insuranceApplications } from "../../src/schema-applications.js"
+import { insurancePolicies } from "../../src/schema-policies.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+/** Cleanup truncates the whole operator schema; 5s is not a realistic budget. */
+const DB_TEST_TIMEOUT = 60_000
+
+const PREMIUM = { amountMinor: 4_200, currency: "EUR" } as const
+const BOOKING_SESSION_ID = "bses_ancillary_fixture"
+
+const CERTIFICATE: InsuranceDocument = {
+  documentId: "doc-cert-1",
+  kind: "policy_certificate",
+  filename: "certificate.pdf",
+  mimeType: "application/pdf",
+  source: { kind: "url", url: "https://insurer.test/certificate.pdf" },
+}
+
+type IssueStep =
+  | { kind: "issues"; policyNumber: string; premiumMinor?: number }
+  | { kind: "refuses"; code: string; message: string; retryable: boolean }
+
+function insurer(options: { script: readonly IssueStep[] }) {
+  const applyCalls: InsuranceApplicationInput[] = []
+  const issueCalls: string[] = []
+  let issued = 0
+
+  const provider: InsuranceProviderAdapter = {
+    providerId: "test-insurer",
+    displayName: "Test Insurer",
+    async quote(): Promise<InsuranceQuote[]> {
+      return []
+    },
+    async apply(input, context): Promise<InsuranceApplication> {
+      applyCalls.push(input)
+      return {
+        applicationId: `app-provider-${applyCalls.length}`,
+        providerId: "test-insurer",
+        quoteId: input.quoteId,
+        status: "open",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        premium: PREMIUM,
+        insuredPersons: input.insuredPersons,
+        contractingParty: input.contractingParty,
+        outstandingQuestions: [],
+        answers: [],
+        eligibility: { status: "eligible", reasons: [] },
+        createdAt: new Date().toISOString(),
+        metadata: { idempotencyKey: context.idempotencyKey ?? null },
+      }
+    },
+    async issue(_input, context): Promise<InsurancePolicy> {
+      issueCalls.push(context.idempotencyKey ?? "")
+      const step = options.script[Math.min(issued, options.script.length - 1)]
+      issued += 1
+      if (!step) throw new Error("insurer script exhausted")
+      const base = {
+        policyId: "pol-provider-1",
+        providerId: "test-insurer",
+        applicationId: "app-provider-1",
+        effectiveFrom: "2026-09-01",
+        effectiveTo: "2026-09-08",
+        insuredPersons: [
+          {
+            ref: "traveler-0",
+            givenName: "Ana",
+            familyName: "Popescu",
+            dateOfBirth: "1990-04-02",
+            identityDocuments: [],
+          },
+        ],
+        contractingParty: {
+          givenName: "Ana",
+          familyName: "Popescu",
+          email: "ana@example.test",
+        },
+        covers: [],
+      } as const
+
+      if (step.kind === "refuses") {
+        return {
+          ...base,
+          issueState: "issue_failed",
+          premium: PREMIUM,
+          documents: [],
+          failure: {
+            code: step.code,
+            message: step.message,
+            retryable: step.retryable,
+            occurredAt: "2026-08-16T10:00:00.000Z",
+          },
+        }
+      }
+
+      return {
+        ...base,
+        policyNumber: step.policyNumber,
+        issueState: "issued",
+        issuedAt: "2026-08-16T10:00:00.000Z",
+        premium: { amountMinor: step.premiumMinor ?? PREMIUM.amountMinor, currency: "EUR" },
+        documents: [CERTIFICATE],
+        providerReference: "PRV-1",
+      }
+    },
+    async document(): Promise<InsuranceDocument> {
+      return CERTIFICATE
+    },
+    async cancel() {
+      throw new Error("cancel is not exercised by this test")
+    },
+  }
+
+  return { provider, applyCalls, issueCalls }
+}
+
+describe.skipIf(!DB_AVAILABLE)("insurance as a checkout ancillary source", () => {
+  let db: PostgresJsDatabase
+  let sequence = 0
+
+  beforeAll(async () => {
+    const { createTestDb } = await import("@voyant-travel/db/test-utils")
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    await cleanupTestDb(db)
+  }, DB_TEST_TIMEOUT)
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyant-travel/db/test-utils")
+    await closeTestDb()
+  })
+
+  async function pii() {
+    const { generateEnvKmsKey, EnvKmsProvider } = await import("@voyant-travel/utils")
+    return createInsurancePiiService({ kms: new EnvKmsProvider({ key: generateEnvKmsKey() }) })
+  }
+
+  async function seedBooking() {
+    sequence += 1
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: `BK-ANC-${sequence}-${Math.floor(Math.random() * 1_000_000)}`,
+        status: "confirmed",
+        contactFirstName: "Ana",
+        contactLastName: "Popescu",
+        contactEmail: "ana@example.test",
+        sellCurrency: "EUR",
+        sellAmountCents: 120_00,
+        startDate: "2026-09-01",
+        endDate: "2026-09-07",
+      })
+      .returning()
+    return booking!
+  }
+
+  /** What checkout hands the source once the traveller has accepted an offer. */
+  function acceptedSelection(quoteRef: string) {
+    return {
+      kind: "insurance",
+      decision: "accepted" as const,
+      offerId: "quote-1",
+      sourceId: "insurance",
+      providerId: "test-insurer",
+      quoteRef,
+      travelers: [
+        {
+          ref: "traveler-0",
+          fields: {
+            given_name: "Ana",
+            family_name: "Popescu",
+            date_of_birth: "1990-04-02",
+          },
+        },
+      ],
+      selectedOptionIds: [],
+      acceptedDisclosures: [
+        { kind: "ipid", versionId: "v1", acceptedAt: "2026-08-16T09:00:00.000Z" },
+      ],
+    }
+  }
+
+  async function sourceFor(
+    provider: InsuranceProviderAdapter,
+    integration?: InsuranceBookingIntegration,
+  ) {
+    const piiService = await pii()
+    return createInsuranceAncillaryOfferSource({
+      resolveProviders: async () => [provider],
+      resolveDb: () => db,
+      resolvePii: () => piiService,
+      ...(integration ? { resolveIntegration: () => integration } : {}),
+    })
+  }
+
+  function documentRecorder() {
+    const recorded: Array<{ bookingId: string; fileName: string; issuedNumber: string | null }> = []
+    return {
+      recorded,
+      integration: {
+        documents: {
+          async record(input: {
+            bookingId: string
+            fileName: string
+            issuedNumber: string | null
+          }) {
+            recorded.push({
+              bookingId: input.bookingId,
+              fileName: input.fileName,
+              issuedNumber: input.issuedNumber,
+            })
+            return { documentId: `bdoc_${recorded.length}`, replayed: false }
+          },
+        },
+      } satisfies InsuranceBookingIntegration,
+    }
+  }
+
+  it(
+    "opens an application at prepare and issues a certificate at fulfil",
+    async () => {
+      const booking = await seedBooking()
+      const { provider, applyCalls, issueCalls } = insurer({
+        script: [{ kind: "issues", policyNumber: "POL-1" }],
+      })
+      const { recorded, integration } = documentRecorder()
+      const source = await sourceFor(provider, integration)
+
+      // Pre-payment: the accepted offer becomes a held application, and the
+      // price it hands back is what the booking will charge.
+      const prepared = await source.prepare({
+        bookingSessionId: BOOKING_SESSION_ID,
+        selection: acceptedSelection(encodeQuoteRef("test-insurer", "quote-1")),
+        contact: {
+          firstName: "Ana",
+          lastName: "Popescu",
+          email: "ana@example.test",
+        },
+        idempotencyKey: `ancillary-prepare:${booking.id}:insurance::test-insurer::quote-1`,
+      })
+
+      expect(applyCalls).toHaveLength(1)
+      expect(prepared.priceMinor).toBe(PREMIUM.amountMinor)
+      const [application] = await db
+        .select()
+        .from(insuranceApplications)
+        .where(eq(insuranceApplications.id, prepared.applicationRef))
+      expect(application).toMatchObject({
+        bookingSessionId: BOOKING_SESSION_ID,
+        providerId: "test-insurer",
+        premiumAmountMinor: PREMIUM.amountMinor,
+      })
+      // Not attached to a booking yet — there is no booking on a Session.
+      expect(application?.bookingId).toBeNull()
+
+      // Post-payment: issue, attach, and report what was settled.
+      const result = await source.fulfill({
+        bookingId: booking.id,
+        applicationRef: prepared.applicationRef,
+        sourceId: prepared.sourceId,
+        chargedPriceMinor: prepared.priceMinor,
+        currency: prepared.currency,
+        idempotencyKey: `ancillary-fulfill:${booking.id}:bitm_1`,
+      })
+
+      expect(result).toMatchObject({
+        status: "fulfilled",
+        reference: "POL-1",
+        settledPriceMinor: PREMIUM.amountMinor,
+        currency: "EUR",
+      })
+      expect(result.status === "fulfilled" && result.documentIds).toEqual(["bdoc_1"])
+
+      // The certificate went onto the booking through the sanctioned path, not
+      // into a column this module invented.
+      expect(recorded).toEqual([
+        { bookingId: booking.id, fileName: "certificate.pdf", issuedNumber: "POL-1" },
+      ])
+
+      const [policy] = await db
+        .select()
+        .from(insurancePolicies)
+        .where(eq(insurancePolicies.applicationId, prepared.applicationRef))
+      expect(policy).toMatchObject({
+        issueState: "issued",
+        policyNumber: "POL-1",
+        bookingId: booking.id,
+      })
+      expect(issueCalls).toHaveLength(1)
+    },
+    DB_TEST_TIMEOUT,
+  )
+
+  it(
+    "leaves issue_failed with the reason and raises the staff alert after payment",
+    async () => {
+      const booking = await seedBooking()
+      const { provider } = insurer({
+        script: [
+          {
+            kind: "refuses",
+            code: "underwriting_declined",
+            message: "The insurer refused the risk.",
+            retryable: false,
+          },
+        ],
+      })
+      const alerts: InsuranceIssueFailedAlertContext[] = []
+      const source = await sourceFor(provider, {
+        staffAlerts: { raiseIssueFailed: async (context) => void alerts.push(context) },
+      })
+
+      const prepared = await source.prepare({
+        bookingSessionId: BOOKING_SESSION_ID,
+        selection: acceptedSelection(encodeQuoteRef("test-insurer", "quote-1")),
+        contact: { firstName: "Ana", lastName: "Popescu", email: "ana@example.test" },
+        idempotencyKey: `ancillary-prepare:${booking.id}:key`,
+      })
+
+      const result = await source.fulfill({
+        bookingId: booking.id,
+        applicationRef: prepared.applicationRef,
+        sourceId: prepared.sourceId,
+        chargedPriceMinor: prepared.priceMinor,
+        currency: prepared.currency,
+        idempotencyKey: `ancillary-fulfill:${booking.id}:bitm_1`,
+      })
+
+      // A refusal after the money is a result, never a thrown error.
+      expect(result).toMatchObject({
+        status: "failed",
+        code: "underwriting_declined",
+        retryable: false,
+      })
+
+      const [policy] = await db
+        .select()
+        .from(insurancePolicies)
+        .where(eq(insurancePolicies.applicationId, prepared.applicationRef))
+      expect(policy).toMatchObject({
+        issueState: "issue_failed",
+        failureCode: "underwriting_declined",
+        failureMessage: "The insurer refused the risk.",
+        failureRetryable: false,
+      })
+
+      // The alert exists for exactly this state: charged, and no policy.
+      expect(alerts).toHaveLength(1)
+      expect(alerts[0]).toMatchObject({
+        bookingId: booking.id,
+        paid: true,
+        failureCode: "underwriting_declined",
+        retryable: false,
+        premium: { amountMinor: PREMIUM.amountMinor, currency: "EUR" },
+      })
+    },
+    DB_TEST_TIMEOUT,
+  )
+
+  it(
+    "does not ask the insurer to issue twice when fulfilment is redelivered",
+    async () => {
+      const booking = await seedBooking()
+      const { provider, issueCalls } = insurer({
+        script: [{ kind: "issues", policyNumber: "POL-1" }],
+      })
+      const source = await sourceFor(provider)
+
+      const prepared = await source.prepare({
+        bookingSessionId: BOOKING_SESSION_ID,
+        selection: acceptedSelection(encodeQuoteRef("test-insurer", "quote-1")),
+        contact: { firstName: "Ana", lastName: "Popescu", email: "ana@example.test" },
+        idempotencyKey: `ancillary-prepare:${booking.id}:key`,
+      })
+
+      const fulfilment = {
+        bookingId: booking.id,
+        applicationRef: prepared.applicationRef,
+        sourceId: prepared.sourceId,
+        chargedPriceMinor: prepared.priceMinor,
+        currency: prepared.currency,
+        idempotencyKey: `ancillary-fulfill:${booking.id}:bitm_1`,
+      }
+      const first = await source.fulfill(fulfilment)
+      const second = await source.fulfill(fulfilment)
+
+      expect(issueCalls).toHaveLength(1)
+      expect(first.status).toBe("fulfilled")
+      expect(second).toMatchObject({ status: "fulfilled", reference: "POL-1" })
+      const policies = await db
+        .select()
+        .from(insurancePolicies)
+        .where(eq(insurancePolicies.applicationId, prepared.applicationRef))
+      expect(policies).toHaveLength(1)
+    },
+    DB_TEST_TIMEOUT,
+  )
+
+  it(
+    "reports what the insurer settled when it differs from what was charged",
+    async () => {
+      const booking = await seedBooking()
+      const { provider } = insurer({
+        script: [
+          { kind: "issues", policyNumber: "POL-3", premiumMinor: PREMIUM.amountMinor + 100 },
+        ],
+      })
+      const source = await sourceFor(provider)
+
+      const prepared = await source.prepare({
+        bookingSessionId: BOOKING_SESSION_ID,
+        selection: acceptedSelection(encodeQuoteRef("test-insurer", "quote-1")),
+        contact: { firstName: "Ana", lastName: "Popescu", email: "ana@example.test" },
+        idempotencyKey: `ancillary-prepare:${booking.id}:key`,
+      })
+
+      const result = await source.fulfill({
+        bookingId: booking.id,
+        applicationRef: prepared.applicationRef,
+        sourceId: prepared.sourceId,
+        chargedPriceMinor: prepared.priceMinor,
+        currency: prepared.currency,
+        idempotencyKey: `ancillary-fulfill:${booking.id}:bitm_1`,
+      })
+
+      // The source reports the settled amount honestly; deciding what to do
+      // about the gap is the caller's, and `reconcileAncillaryPremium` records
+      // it rather than quietly adjusting the booking.
+      expect(result).toMatchObject({
+        status: "fulfilled",
+        settledPriceMinor: PREMIUM.amountMinor + 100,
+      })
+    },
+    DB_TEST_TIMEOUT,
+  )
+})
+
+/** Local mirror of the source's own opaque handle, so the test builds a real one. */
+function encodeQuoteRef(providerId: string, quoteId: string): string {
+  return Buffer.from(JSON.stringify({ p: providerId, q: quoteId }), "utf8").toString("base64url")
+}


### PR DESCRIPTION
An accepted ancillary offer is now charged and issued. Until this, the seam was
complete on both sides and nothing crossed it: `prepare`/`fulfill`,
`materializeAncillaryPassThroughItem` and `reconcileAncillaryPremium` had no
production caller, and the `commerce.ancillary-offer-sources` container key was
registered and read by nobody. A traveller could be offered insurance, accept
it, answer the insurer's questions and acknowledge the disclosures — and the
premium never reached the booking and no policy was ever issued.

Closes #4756

Completes the delivery of #4728, #4729 and #4731, which #4750 took as far as
the traveller's decision.

## Where `prepare` runs, and why not where you'd expect

**`startCatalogCheckout`** (`packages/commerce/src/checkout/start-service.ts`),
after the booking-committed and publication guards and before the card /
bank-transfer branch. Post-commit, pre-payment, and **outside**
`consumeCommittedSources` entirely.

That last part is the constraint the whole design turns on. `prepare` calls the
insurer over the network, and the obvious-looking home for it —
`consumeCommittedSources` — is the booking-session commit transaction carrying
the state machine and the settlement path, where #4733 and #4734 were found. An
HTTP round trip inside it either holds it open across the call or fails it after
money has moved.

The chosen point works because the Booking already exists (the handler refuses
anything not `confirmed`/`in_progress`/`completed`), and nothing has been
charged yet — the card path reads `booking.sellAmountCents` and the bank path
bills `booking_items`, both *after* this point, so the amount the provider is
asked for already includes the premium.

A `prepare` failure is a hard `502` (`ancillary_preparation_failed`), not a
silent drop. Dropping it charges someone who chose insurance for a trip without
it, and nothing downstream would ever say so.

## After payment

A `fulfill_ancillaries` step at the end of `checkoutFinalizeSaga`, after
`link_payment_to_invoice`, with an optional `fulfillAncillaries` dep that
returns `null` for "skipped" like its siblings.

**Drift and issue failure never throw out of the saga.**
`reconcileAncillaryPremium` records the activity row and then throws for drift;
the step catches it and carries it out in the step output. Rethrowing would fail
a step that runs *after* a captured payment and an issued policy, and the retry
would ask the insurer to issue a second one.

`fulfill` also short-circuits on an already-`issued` policy, so a redelivered
`payment.completed` does not re-call the insurer.

## A latent bug this found

`container.register(KEY, () => bindings.ancillaryOfferSources ?? [])` registered
a **thunk**. `ModuleContainer.register` stores the value and `resolve` returns it
verbatim — neither invokes a factory — so every consumer would have read a
function where it expected an array. It never surfaced precisely because nothing
read the key yet, which is the dead-seam condition this PR exists to end.

## Idempotency

Keys are derived, never random:
`ancillary-prepare:<bookingId>:<sourceId::providerId::offerId>`. The
pass-through line carries a `selectionKey` in `metadata.ancillary` so a
re-entered checkout recognises a selection it has already charged for —
`applicationRef` cannot answer that, since it only exists after the insurer has
been asked.

## Boundaries

`loadCommittedAncillarySelections` lives in **catalog**, because
`booking_session_commits` and `booking_sessions` are catalog's tables and
commerce must not read them — there is no `commerce->catalog` pair in the
table-privacy baseline and this does not add one. `listBookingPassThroughItems`
is likewise a **bookings**-owned read, so commerce finds its own lines back
without touching `booking_items`.

## Tests

Two integration files, **both listed by name in the `db-integration` lane** in
`ci.yml` — that lane names files individually, so an unlisted test is green by
never running.

- `commerce/tests/integration/ancillary-checkout-fulfilment.test.ts` — drives
  the real entry points (`startCatalogCheckout`, `finalizeCheckout`) over real
  session/commit/booking rows: accepted → pass-through line at the prepared
  price, reflected in booking total, payment-session amount and invoice total;
  declined → nothing; re-entered checkout charges once; `prepare` failure blocks
  checkout with no payment session; failed issue after payment records
  `ancillary.fulfillment.failed` and the saga still completes; drift records
  `ancillary.premium.drift` without adjusting the charged line.
- `insurance/tests/integration/ancillary-source-fulfilment.test.ts` — the real
  insurance source against a scripted provider: application opened at `prepare`;
  policy issued and certificate recorded through the booking-document path;
  `issue_failed` with reason and retryable plus the staff alert with
  `paid: true`; no second insurer call on redelivery; settled-premium drift
  reported.

The split is deliberate: commerce may not depend on a module that binds its own
port, so `AncillaryOfferSource` is the seam between the two files.

## Verification

| Check | Result |
|---|---|
| `turbo run build` (bookings, catalog, commerce, insurance) | **exit 0**, 0 `error TS` |
| `turbo run typecheck` (same four) | **exit 0** |
| `biome check .` from the root | **exit 0**, 0 errors |
| Both integration files executed against Postgres | pass on assertions |

The typecheck run caught two `TS2322`s in the insurance integration fixture that
`build` structurally cannot see — it compiles `src`, and the fixture is in
`tests/**`. `as const` on a shared fixture makes `covers` a `readonly []`, which
is not assignable to the mutable array `InsurancePolicy` declares.

`verify:architecture` has **not** completed locally — it was killed twice under
load without an exit code. Nothing here adds a table reach-in, a route, an
OpenAPI response or a checker, so it is expected green, but CI is the evidence,
not this note.

## Known gaps, deliberate

- **`resolveAncillaryTaxTreatmentCode` is unwired in `apps/operator`**, so
  premium lines carry `taxTreatmentCode: null`. The option exists and commerce
  cannot fill it — it does not know what an ancillary is — so whoever binds the
  source supplies the treatment (e.g. `insurance/exempt`). Harmless today (no
  tax row), but a loose end rather than an oversight.
- **The `payment_required` booking-session path is not covered.** Where payment
  precedes commit (`commitPaidSession`), nothing is charged or issued for
  ancillaries. That path needs its own seam decision and did not seem safe to
  invent alongside this one.
