### PR TITLE
Guard the five OpenAPI generators that were never registered

### DIFF
--- a/scripts/checks/openapi/generated-specs.json
+++ b/scripts/checks/openapi/generated-specs.json
@@ -16,15 +16,11 @@
       ]
     },
     {
-      "command": "pnpm --filter @voyant-travel/trips generate:openapi",
+      "command": "pnpm --filter @voyant-travel/finance generate:openapi",
       "files": [
-        "packages/trips/openapi/admin/trips.json",
-        "packages/trips/openapi/public-api/trips.json"
+        "packages/finance/openapi/admin/finance.json",
+        "packages/finance/openapi/public-api/finance.json"
       ]
-    },
-    {
-      "command": "pnpm --filter @voyant-travel/legal generate:openapi",
-      "files": ["packages/legal/openapi/admin/legal.json"]
     },
     {
       "command": "pnpm --filter @voyant-travel/flights generate:openapi",
@@ -33,6 +29,37 @@
     {
       "command": "pnpm --filter @voyant-travel/insurance generate:openapi",
       "files": ["packages/insurance/openapi/admin/insurance.json"]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/inventory generate:openapi",
+      "files": [
+        "packages/inventory/openapi/admin/inventory-authoring.json",
+        "packages/inventory/openapi/admin/products.json",
+        "packages/inventory/openapi/public-api/products.json"
+      ]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/legal generate:openapi",
+      "files": ["packages/legal/openapi/admin/legal.json"]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/media generate:openapi",
+      "files": ["packages/media/openapi/admin/media-library.json"]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/operations generate:openapi",
+      "files": ["packages/operations/openapi/admin/operations.json"]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/trips generate:openapi",
+      "files": [
+        "packages/trips/openapi/admin/trips.json",
+        "packages/trips/openapi/public-api/trips.json"
+      ]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/webhook-delivery generate:openapi",
+      "files": ["packages/webhook-delivery/openapi/admin/operator-webhooks.json"]
     }
   ]
 }


### PR DESCRIPTION
Ten packages ship a `generate:openapi` script. Only five were in
`scripts/checks/openapi/generated-specs.json`, so **finance, inventory, media,
operations and webhook-delivery** could regenerate to something different from
what is checked in and nothing would say so.

That is precisely the defect `verify:openapi-drift` was added for — it went in
after #4193, #4204 and #4210 merged green against stale specs, and then guarded
2.5% of the corpus.

`verify:openapi-drift` now diffs **15 generated documents** against their
routes, up from 7.

## The file lists are observed, not parsed

Reading the filenames out of the `generate:openapi` script line would have been
wrong for finance: its script only names `openapi/public-api/finance.json` in
the trailing `biome format` call, but the generator also writes
`openapi/admin/finance.json`. A registry that under-lists is a registry that
silently under-guards.

So each generator was run with its spec mtimes back-dated, and the files it
actually rewrote were recorded:

| generator | writes |
|---|---|
| finance | `admin/finance.json`, `public-api/finance.json` |
| inventory | `admin/inventory-authoring.json`, `admin/products.json`, `public-api/products.json` |
| media | `admin/media-library.json` |
| operations | `admin/operations.json` |
| webhook-delivery | `admin/operator-webhooks.json` |

All eight are currently in sync — running every generator left the tree clean —
so this locks in a correct state rather than papering over existing drift.

## Deliberately not registered

The other 24 spec-carrying packages hand-write their documents. Per the
registry's own note, a spec belongs there *"as soon as it is generated rather
than hand-written"*, so registering a hand-written document would assert a
generator that does not exist.

Closing the rest of that gap means writing generators, which is the larger half
of #4256 and not this PR.

Part of #4256