### PR TITLE
Give a shimmed cruise its itinerary back

### DIFF
--- a/.changeset/cruise-shim-representative-itinerary.md
+++ b/.changeset/cruise-shim-representative-itinerary.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/cruises": patch
+"@voyant-travel/catalog-react": patch
+---
+
+Publish a representative itinerary for cruises served through the source-adapter shim. The shim fetched every sailing's stops and then discarded them at the cruise level, so the Itinerary section was missing from the detail page; it now carries the first sailing that has a route, matching the Connect adapter. The storefront cruise mapper falls back to the first sailing's stops as well, so a payload without cruise-level stops still renders the section.

--- a/packages/catalog-react/src/catalog-enrichment-mappers.ts
+++ b/packages/catalog-react/src/catalog-enrichment-mappers.ts
@@ -307,11 +307,11 @@ function mapCruiseContentToEnrichment(content: CruiseContentPayload): CatalogDet
       : null,
     // Cruise itinerary lives per-sailing in the content payload; the cruise-level
     // `itinerary_stops` is a representative copy an adapter may leave empty. Fall
-    // back to the first sailing's stops so the Itinerary tab shows the route.
+    // back to the first sailing that has a route so the Itinerary tab shows it.
     itinerary: mapCruiseItineraryStops(
       content.itinerary_stops?.length
         ? content.itinerary_stops
-        : (content.sailings?.[0]?.itinerary_stops ?? []),
+        : firstSailingItineraryStops(content.sailings ?? []),
     ),
     media: [],
     options: (content.cabin_categories ?? []).map((c) => ({
@@ -343,6 +343,15 @@ function mapCruiseContentToEnrichment(content: CruiseContentPayload): CatalogDet
       itinerary: mapCruiseItineraryStops(s.itinerary_stops ?? []),
     })),
   }
+}
+
+function firstSailingItineraryStops(
+  sailings: NonNullable<CruiseContentPayload["sailings"]>,
+): CruiseItineraryStopPayload[] {
+  for (const sailing of sailings) {
+    if (sailing.itinerary_stops?.length) return sailing.itinerary_stops
+  }
+  return []
 }
 
 function mapCruiseItineraryStops(

--- a/packages/catalog-react/src/catalog-enrichment-mappers.ts
+++ b/packages/catalog-react/src/catalog-enrichment-mappers.ts
@@ -306,8 +306,8 @@ function mapCruiseContentToEnrichment(content: CruiseContentPayload): CatalogDet
         }
       : null,
     // Cruise itinerary lives per-sailing in the content payload; the cruise-level
-    // `itinerary_stops` is empty for sourced cruises. Fall back to the first
-    // sailing's stops so the Itinerary tab shows the representative route.
+    // `itinerary_stops` is a representative copy an adapter may leave empty. Fall
+    // back to the first sailing's stops so the Itinerary tab shows the route.
     itinerary: mapCruiseItineraryStops(
       content.itinerary_stops?.length
         ? content.itinerary_stops

--- a/packages/catalog-react/src/components/catalog-enrichment-fetchers.test.ts
+++ b/packages/catalog-react/src/components/catalog-enrichment-fetchers.test.ts
@@ -284,8 +284,8 @@ describe("createCatalogEnrichmentFetchers", () => {
         deckPlans: [{ name: "Upper Deck", level: 3, imageUrl: "https://example.com/d3.jpg" }],
         images: ["https://example.com/ship.jpg"],
       },
-      // Cruise-level itinerary is empty for sourced cruises, so the Itinerary
-      // tab falls back to the first sailing's stops.
+      // The cruise-level itinerary may be empty, so the Itinerary tab falls
+      // back to the first sailing that has a route.
       itinerary: [
         { dayNumber: 1, title: "Athens", location: "Athens", date: "2026-06-01" },
         { dayNumber: 2, title: "Mykonos", location: "Mykonos", date: "2026-06-02" },
@@ -335,6 +335,54 @@ describe("createCatalogEnrichmentFetchers", () => {
         },
       ],
     })
+  })
+
+  test("skips a sailing with no stops when falling back to a cruise itinerary", async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(async () =>
+      ok({
+        data: {
+          content: {
+            cruise: { id: "crus_1", name: "Greek Isles" },
+            sailings: [
+              {
+                id: "sail_1",
+                start_date: "2026-06-01",
+                end_date: "2026-06-08",
+                itinerary_stops: [],
+                lowest_price_cents: null,
+                currency: null,
+              },
+              {
+                id: "sail_2",
+                start_date: "2026-07-01",
+                end_date: "2026-07-08",
+                itinerary_stops: [
+                  { day_number: 1, port_name: "Athens", date: "2026-07-01" },
+                  { day_number: 2, port_name: "Mykonos", date: "2026-07-02" },
+                ],
+                lowest_price_cents: null,
+                currency: null,
+              },
+            ],
+            policies: [],
+          },
+          served_locale: "en-GB",
+          match_kind: "exact",
+          source: "sourced-fresh",
+          served_stale: false,
+          synthesized: false,
+          machine_translated: false,
+        },
+      }),
+    )
+    const fetchers = createCatalogEnrichmentFetchers({ baseUrl: "/api", fetch: fetchImpl })
+
+    const result = await fetchers.loadProductDetail(hit("crus_1"))
+
+    expect(result?.itinerary).toMatchObject([
+      { dayNumber: 1, title: "Athens", date: "2026-07-01" },
+      { dayNumber: 2, title: "Mykonos", date: "2026-07-02" },
+    ])
   })
 
   test("sanitizes cruise cabin names (strips HTML, dedupes name===code grades)", async () => {

--- a/packages/catalog-react/src/components/cruise-detail-page-parts.ts
+++ b/packages/catalog-react/src/components/cruise-detail-page-parts.ts
@@ -80,7 +80,12 @@ export function mapCruiseContent(content: unknown): CruiseDetail | null {
   const ship = asRecord(c?.ship)
   const sailingsRaw = Array.isArray(c?.sailings) ? c.sailings : []
   const cabinsRaw = Array.isArray(c?.cabin_categories) ? c.cabin_categories : []
-  const stopsRaw = Array.isArray(c?.itinerary_stops) ? c.itinerary_stops : []
+  // The route is per-sailing; the cruise-level array is a representative copy
+  // an adapter may leave empty. Fall back to the first sailing that has one so
+  // the Itinerary section still renders, matching the operator-side mapper.
+  const cruiseStopsRaw = Array.isArray(c?.itinerary_stops) ? c.itinerary_stops : []
+  const stopsRaw =
+    cruiseStopsRaw.length > 0 ? cruiseStopsRaw : firstSailingItineraryStops(sailingsRaw)
   return {
     name: asStr(cruise.name),
     description: asStr(cruise.description),
@@ -147,6 +152,14 @@ export function mapCruiseContent(content: unknown): CruiseDetail | null {
       }
     }),
   }
+}
+
+function firstSailingItineraryStops(sailings: readonly unknown[]): unknown[] {
+  for (const sailing of sailings) {
+    const stops = asRecord(sailing)?.itinerary_stops
+    if (Array.isArray(stops) && stops.length > 0) return stops
+  }
+  return []
 }
 
 export function formatCruiseType(type: string | null, s: SearchMessages): string | null {

--- a/packages/catalog-react/tests/cruise-detail-page-parts.test.ts
+++ b/packages/catalog-react/tests/cruise-detail-page-parts.test.ts
@@ -91,3 +91,47 @@ describe("cabin rate row join", () => {
     expect(findCabinForPrice(detail?.cabins ?? [], price("88-from-2027_CLASSIC"))).toBeUndefined()
   })
 })
+
+/**
+ * The route is per-sailing, so an adapter may publish it only there. #4782: the
+ * source-adapter shim left the cruise-level array empty and the Itinerary
+ * section disappeared entirely, though every sailing carried its stops.
+ */
+describe("itinerary mapping", () => {
+  const stops = [
+    { day_number: 1, port_name: "Paris", departure_time: "18:00", is_at_sea: false },
+    { day_number: 2, port_name: "Reims", arrival_time: "08:00" },
+  ]
+
+  it("reads the cruise-level stops when the payload has them", () => {
+    const detail = mapCruiseContent({
+      cruise: { name: "Rhine" },
+      itinerary_stops: stops,
+      sailings: [{ id: "s1", itinerary_stops: [{ day_number: 1, port_name: "Basel" }] }],
+    })
+    expect(detail?.itinerary.map((s) => s.portName)).toEqual(["Paris", "Reims"])
+  })
+
+  it("falls back to the first sailing that has stops", () => {
+    const detail = mapCruiseContent({
+      cruise: { name: "Rhine" },
+      itinerary_stops: [],
+      sailings: [
+        { id: "s1", itinerary_stops: [] },
+        { id: "s2", itinerary_stops: stops },
+      ],
+    })
+    expect(detail?.itinerary).toMatchObject([
+      { dayNumber: 1, portName: "Paris", departureTime: "18:00", isAtSea: false },
+      { dayNumber: 2, portName: "Reims", arrivalTime: "08:00" },
+    ])
+  })
+
+  it("has no itinerary when neither the cruise nor any sailing carries one", () => {
+    const detail = mapCruiseContent({
+      cruise: { name: "Rhine" },
+      sailings: [{ id: "s1" }],
+    })
+    expect(detail?.itinerary).toEqual([])
+  })
+})

--- a/packages/cruises/src/adapters/source-adapter-shim.ts
+++ b/packages/cruises/src/adapters/source-adapter-shim.ts
@@ -275,7 +275,8 @@ export function cruiseAdapterToSourceAdapter(
     ): Promise<GetContentResult> {
       // Compose the cruise adapter's per-aspect fetches into one
       // `CruiseContent` payload. Itinerary is per-sailing, so it stays
-      // attached to each sailing instead of being flattened onto the cruise.
+      // attached to each sailing; the cruise-level array carries a
+      // representative copy for consumers that render one route.
       const sourceRef = entityIdToSourceRef(request.entity_id)
       const cruise = await cruiseAdapter.fetchCruise(sourceRef)
       if (!cruise) {
@@ -294,12 +295,21 @@ export function cruiseAdapterToSourceAdapter(
         ),
       )
 
+      // A cruise's route genuinely varies per sailing (reverse directions,
+      // seasonal variants), so the cruise-level array is the first sailing
+      // that has one rather than a merge — the same representative itinerary
+      // `@voyant-travel/connect-adapter` publishes. Consumers that care about
+      // an exact route read the selected sailing's `itinerary_stops`.
+      const representativeItinerary =
+        sailingsWithItinerary.find((sailing) => sailing.itinerary_stops.length > 0)
+          ?.itinerary_stops ?? []
+
       const content: CruiseContent = {
         cruise: cruiseSummaryFrom(cruise),
         ship: ship ? cruiseShipFrom(ship) : null,
         sailings: sailingsWithItinerary,
         cabin_categories: ship?.categories?.map(cruiseCabinCategoryFrom) ?? [],
-        itinerary_stops: [],
+        itinerary_stops: representativeItinerary,
         policies: cruisePoliciesFrom(cruise),
       }
 

--- a/packages/cruises/tests/unit/source-adapter-shim.test.ts
+++ b/packages/cruises/tests/unit/source-adapter-shim.test.ts
@@ -361,11 +361,69 @@ describe("cruiseAdapterToSourceAdapter.getContent", () => {
     expect(content.cabin_categories[0].square_feet).toBe("170")
     expect(content.cabin_categories[0].grade_codes).toEqual(["IN1", "IN2"])
     expect(content.cabin_categories[0].wheelchair_accessible).toBe(true)
-    expect(content.itinerary_stops).toEqual([])
+    // Cruise-level stops mirror the first sailing that has an itinerary.
+    expect(content.itinerary_stops).toMatchObject([
+      { day_number: 1, port_name: "Athens", departure_time: "17:00" },
+      { day_number: 2, port_name: "Mykonos", arrival_time: "08:00", departure_time: "18:00" },
+    ])
     // Inclusions / exclusions HTML lands in supplier_notes.
     expect(
       content.policies.filter((p: { kind: string }) => p.kind === "supplier_notes"),
     ).toHaveLength(2)
+  })
+
+  it("takes the cruise-level itinerary from the first sailing that has stops", async () => {
+    const sailingRefs = ["sailing-empty", "sailing-1"] as const
+    const adapter = makeStubAdapter({
+      async listSailingsForCruise() {
+        return sailingRefs.map((externalId, i) => ({
+          sourceRef: { externalId, connectionId: "conn-x" },
+          cruiseRef: { externalId: "cruise-1", connectionId: "conn-x" },
+          shipRef: { externalId: "ship-1", connectionId: "conn-x" },
+          departureDate: `2026-0${6 + i}-01`,
+          returnDate: `2026-0${6 + i}-08`,
+          salesStatus: "open" as const,
+        }))
+      },
+    })
+    const shim = cruiseAdapterToSourceAdapter(adapter)
+    const result = await shim.getContent!(
+      { connection_id: "conn-x" },
+      {
+        entity_module: "cruises",
+        entity_id: `crus_${encodeSourceRef({ externalId: "cruise-1", connectionId: "conn-x" })}`,
+        locale: "en-GB",
+      },
+    )
+
+    // biome-ignore lint/suspicious/noExplicitAny: result.content is unknown -- owner: cruises; existing suppression is intentional pending typed cleanup.
+    const content = result.content as any
+    expect(content.sailings[0].itinerary_stops).toEqual([])
+    expect(content.itinerary_stops).toMatchObject([
+      { day_number: 1, port_name: "Athens" },
+      { day_number: 2, port_name: "Mykonos" },
+    ])
+  })
+
+  it("leaves the cruise-level itinerary empty when no sailing has stops", async () => {
+    const adapter = makeStubAdapter({
+      async fetchSailingItinerary() {
+        return []
+      },
+    })
+    const shim = cruiseAdapterToSourceAdapter(adapter)
+    const result = await shim.getContent!(
+      { connection_id: "conn-x" },
+      {
+        entity_module: "cruises",
+        entity_id: `crus_${encodeSourceRef({ externalId: "cruise-1", connectionId: "conn-x" })}`,
+        locale: "en-GB",
+      },
+    )
+
+    // biome-ignore lint/suspicious/noExplicitAny: result.content is unknown -- owner: cruises; existing suppression is intentional pending typed cleanup.
+    const content = result.content as any
+    expect(content.itinerary_stops).toEqual([])
   })
 
   it("throws when the cruise adapter returns null for the entity_id", async () => {


### PR DESCRIPTION
Closes #4782.

## What was wrong

`cruiseAdapterToSourceAdapter.getContent` fetched every sailing's itinerary and then hard-coded the cruise-level `itinerary_stops` to `[]`. `catalog-react` renders the Itinerary section behind that array, so a cruise served through the shim showed no itinerary at all — the stops were fetched, attached per sailing, and discarded one field up.

## The fix

- `packages/cruises` — the cruise-level array is now the first sailing that has stops, the same representative itinerary `@voyant-travel/connect-adapter` publishes. No merge: a cruise's route genuinely varies per sailing (reverse directions, seasonal variants), so picking one is honest where combining would not be.
- `packages/catalog-react` — the storefront `mapCruiseContent` falls back to the first sailing's stops when the cruise-level array is empty, which is what the operator-side enrichment mapper already did. Any adapter that leaves the field empty still renders the section.

Consumers that need the exact route for a chosen date already read the selected sailing's `itinerary_stops`; that path is unchanged. The issue's longer-term question — whether the top-level field should exist at all once the UI switches to the selected sailing — is left open deliberately, since dropping it is a contract change and every consumer reads it today.

## Verification

- `packages/cruises`: 289 passed / 7 skipped. Two new cases — the cruise-level array comes from the first sailing that *has* stops (the first sailing deliberately has none), and it stays empty when no sailing has any.
- `packages/catalog-react`: 19 files / 134 tests passed, including three new itinerary-mapping cases (cruise-level wins, sailing fallback, neither).
- Biome clean on all changed files.