### PR TITLE
Type the customer-portal request bodies by what a caller sends

### DIFF
--- a/.changeset/contracts-request-input-types.md
+++ b/.changeset/contracts-request-input-types.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/public-api-contracts": minor
+"@voyant-travel/public-api": patch
+---
+
+Derive the customer-portal request-body aliases from `z.input` rather than
+`z.infer`. `z.infer` is the schema's OUTPUT type, so a field carrying
+`.default()` read as required and a caller could not satisfy it — every consumer
+had to re-derive its request types by hand. `BootstrapCustomerPortalParsed` and
+`CreateCustomerPortalCompanionParsed` expose the post-parse shapes the server
+needs.

--- a/packages/public-api-contracts/src/profile.ts
+++ b/packages/public-api-contracts/src/profile.ts
@@ -324,25 +324,25 @@ export const importCustomerPortalBookingParticipantsResultSchema =
   importCustomerPortalBookingTravelersResultSchema
 
 export type CustomerPortalProfile = z.infer<typeof customerPortalProfileSchema>
-export type UpdateCustomerPortalProfileInput = z.infer<typeof updateCustomerPortalProfileSchema>
+export type UpdateCustomerPortalProfileInput = z.input<typeof updateCustomerPortalProfileSchema>
 export type CustomerPortalAddress = z.infer<typeof customerPortalAddressSchema>
 export type UpdateCustomerPortalAddressInput = z.input<typeof updateCustomerPortalAddressSchema>
 export type CustomerPortalProfileDocument = z.infer<typeof customerPortalProfileDocumentSchema>
-export type CreateCustomerPortalProfileDocumentInput = z.infer<
+export type CreateCustomerPortalProfileDocumentInput = z.input<
   typeof createCustomerPortalProfileDocumentSchema
 >
-export type UpdateCustomerPortalProfileDocumentInput = z.infer<
+export type UpdateCustomerPortalProfileDocumentInput = z.input<
   typeof updateCustomerPortalProfileDocumentSchema
 >
-export type BootstrapCustomerPortalInput = z.infer<typeof bootstrapCustomerPortalSchema>
+export type BootstrapCustomerPortalInput = z.input<typeof bootstrapCustomerPortalSchema>
 export type BootstrapCustomerPortalResult = z.infer<typeof bootstrapCustomerPortalResultSchema>
 export type CustomerPortalBootstrapCandidate = z.infer<
   typeof customerPortalBootstrapCandidateSchema
 >
 export type CustomerPortalCompanion = z.infer<typeof customerPortalCompanionSchema>
-export type CreateCustomerPortalCompanionInput = z.infer<typeof createCustomerPortalCompanionSchema>
-export type UpdateCustomerPortalCompanionInput = z.infer<typeof updateCustomerPortalCompanionSchema>
-export type ImportCustomerPortalBookingTravelersInput = z.infer<
+export type CreateCustomerPortalCompanionInput = z.input<typeof createCustomerPortalCompanionSchema>
+export type UpdateCustomerPortalCompanionInput = z.input<typeof updateCustomerPortalCompanionSchema>
+export type ImportCustomerPortalBookingTravelersInput = z.input<
   typeof importCustomerPortalBookingTravelersSchema
 >
 export type ImportCustomerPortalBookingTravelersResult = z.infer<
@@ -351,3 +351,16 @@ export type ImportCustomerPortalBookingTravelersResult = z.infer<
 export type ImportCustomerPortalBookingParticipantsInput = ImportCustomerPortalBookingTravelersInput
 export type ImportCustomerPortalBookingParticipantsResult =
   ImportCustomerPortalBookingTravelersResult
+
+/**
+ * The post-parse shapes for the two request bodies that carry `.default()`.
+ *
+ * `XInput` is what a caller sends; zod fills the defaults, so a server reading
+ * `input.role` needs the OUTPUT type instead. Exporting only the `z.infer`
+ * flavour made every consumer re-derive its request types by hand, which is the
+ * defect this pair fixes (voyant#4627 follow-up).
+ */
+export type BootstrapCustomerPortalParsed = z.output<typeof bootstrapCustomerPortalSchema>
+export type CreateCustomerPortalCompanionParsed = z.output<
+  typeof createCustomerPortalCompanionSchema
+>

--- a/packages/public-api-contracts/src/request-contracts.test.ts
+++ b/packages/public-api-contracts/src/request-contracts.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  type BootstrapCustomerPortalInput,
+  type BootstrapCustomerPortalParsed,
+  type CreateCustomerPortalCompanionInput,
+  type CreateCustomerPortalCompanionParsed,
+  createCustomerPortalCompanionSchema,
+} from "./index.js"
+
+/**
+ * A request-body alias must describe what a CALLER sends. `role` and
+ * `isPrimary` carry `.default()`, so they are optional on the way in and
+ * present on the way out.
+ *
+ * These are compile-time assertions on purpose: exporting the aliases off
+ * `z.infer` (the OUTPUT type) made defaulted fields read as required, and every
+ * consumer re-derived its request types with `z.input` by hand. If the aliases
+ * regress, `pnpm --filter @voyant-travel/public-api-contracts typecheck` fails
+ * on these lines rather than in somebody else's repository.
+ */
+
+// Fails to compile if the alias is z.infer: "missing role, isPrimary".
+const callerSendsMinimalCompanion: CreateCustomerPortalCompanionInput = { name: "Ana Popescu" }
+
+// Fails to compile if the alias is z.infer: createCustomerIfMissing becomes required.
+const callerSendsEmptyBootstrap: BootstrapCustomerPortalInput = {}
+
+// The post-parse shapes must still guarantee the defaulted fields.
+const parsedCompanionHasDefaults: Pick<CreateCustomerPortalCompanionParsed, "role" | "isPrimary"> =
+  { role: "other", isPrimary: false }
+const parsedBootstrapHasDefaults: Pick<BootstrapCustomerPortalParsed, "createCustomerIfMissing"> = {
+  createCustomerIfMissing: true,
+}
+
+describe("request-body contracts", () => {
+  it("accepts a caller payload that omits every defaulted field", () => {
+    const parsed = createCustomerPortalCompanionSchema.parse(callerSendsMinimalCompanion)
+    expect(parsed.role).toBe("other")
+    expect(parsed.isPrimary).toBe(false)
+  })
+
+  it("keeps the compile-time shapes referenced so tsc checks them", () => {
+    expect(callerSendsEmptyBootstrap).toEqual({})
+    expect(parsedCompanionHasDefaults.role).toBe("other")
+    expect(parsedBootstrapHasDefaults.createCustomerIfMissing).toBe(true)
+  })
+})

--- a/packages/public-api/src/customer-portal/index.ts
+++ b/packages/public-api/src/customer-portal/index.ts
@@ -20,8 +20,10 @@ export { createPublicCustomerPortalRoutes, publicCustomerPortalRoutes } from "./
 export { publicCustomerPortalService } from "./service-public.js"
 export type {
   BootstrapCustomerPortalInput,
+  BootstrapCustomerPortalParsed,
   BootstrapCustomerPortalResult,
   CreateCustomerPortalCompanionInput,
+  CreateCustomerPortalCompanionParsed,
   CreateCustomerPortalProfileDocumentInput,
   CustomerPortalAddress,
   CustomerPortalBookingBillingContact,

--- a/packages/public-api/src/customer-portal/service-public-impl.ts
+++ b/packages/public-api/src/customer-portal/service-public-impl.ts
@@ -33,9 +33,9 @@ import { and, asc, desc, eq, exists, inArray, isNull, or, sql } from "drizzle-or
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import type {
-  BootstrapCustomerPortalInput,
+  BootstrapCustomerPortalParsed,
   BootstrapCustomerPortalResult,
-  CreateCustomerPortalCompanionInput,
+  CreateCustomerPortalCompanionParsed,
   CustomerPortalAddress,
   CustomerPortalBookingBillingContact,
   CustomerPortalBookingDetail,
@@ -102,7 +102,7 @@ async function persistBootstrapMarketingConsent(
   db: PostgresJsDatabase,
   userId: string,
   authProfile: Awaited<ReturnType<typeof getAuthProfileRow>>,
-  input: BootstrapCustomerPortalInput,
+  input: BootstrapCustomerPortalParsed,
 ): Promise<void> {
   if (
     !authProfile ||
@@ -1875,7 +1875,7 @@ export const publicCustomerPortalService = {
   async bootstrap(
     db: PostgresJsDatabase,
     userId: string,
-    input: BootstrapCustomerPortalInput,
+    input: BootstrapCustomerPortalParsed,
   ): Promise<
     | BootstrapCustomerPortalResult
     | { error: "not_found" | "customer_record_not_found" | "customer_record_claimed" }
@@ -2226,7 +2226,7 @@ export const publicCustomerPortalService = {
   async createCompanion(
     db: PostgresJsDatabase,
     userId: string,
-    input: CreateCustomerPortalCompanionInput,
+    input: CreateCustomerPortalCompanionParsed,
   ): Promise<CustomerPortalCompanion | null> {
     const personId = await resolveLinkedCustomerRecordId(db, userId)
     if (!personId) {


### PR DESCRIPTION
Reported by platform while consuming `@voyant-travel/public-api-contracts@0.1.0`.

The request-body aliases were derived from **`z.infer`, which is the schema's
OUTPUT type**. A field carrying `.default()` is filled during parsing, so `role`
and `isPrimary` on a companion read as *required* — and a caller legitimately
omitting them could not satisfy the type. Platform re-derived all five request
bodies with `z.input` by hand, which defeats the purpose of a shared contract
package: every consumer pays the same tax.

## The fix

All seven `*Input` aliases now use `z.input`. Five of the seven schemas carry no
defaults, so those are unchanged in practice — making them consistent means a
`.default()` added later cannot silently break the alias again.

The server genuinely wants the output shape: `service-public-impl.ts` reads
`input.role` and `input.isPrimary` directly, relying on parsing having filled
them. So the two schemas that differ also export
`BootstrapCustomerPortalParsed` and `CreateCustomerPortalCompanionParsed`, and
the service signatures take those. Both flavours are re-exported from
`public-api`'s barrel.

## The test is compile-time on purpose

`src/request-contracts.test.ts` asserts with real declarations, not matchers:

```ts
const callerSendsMinimalCompanion: CreateCustomerPortalCompanionInput = { name: "Ana Popescu" }
const callerSendsEmptyBootstrap: BootstrapCustomerPortalInput = {}
```

Reverting an alias to `z.infer` fails
`pnpm --filter @voyant-travel/public-api-contracts typecheck` with precisely the
error platform saw — in this repository rather than theirs.

**I verified that by reverting it.** A first attempt using `expectTypeOf` passed
with the aliases reverted, so it proved nothing; the compile-time form is what
actually holds the line.

## Verification

- contracts: typecheck clean, 2 tests
- `public-api`: typecheck clean, 213 tests
- `public-api-react`: 33 tests
- `release:plan` clean, biome at main's baseline

Follow-up to #4788.