### PR TITLE
Let a hosted chat client finish the MCP connector handshake

### DIFF
--- a/.changeset/mcp-oauth-hosted-client-interop.md
+++ b/.changeset/mcp-oauth-hosted-client-interop.md
@@ -1,0 +1,22 @@
+---
+"@voyant-travel/auth": patch
+"@voyant-travel/auth-react": patch
+"@voyant-travel/operator-settings-react": patch
+---
+
+Let ChatGPT Web and Claude Web actually complete the MCP connector handshake.
+
+Two contracts disagreed with themselves. Discovery advertised `mcp:read`,
+`mcp:write`, and `offline_access`, but a dynamic registration that omits `scope`
+— which is what a hosted client sends — was stored with `mcp:read` alone, so
+`authorize` answered the server's own advertised scopes with `invalid_scope`.
+The registration default now matches what discovery publishes; an explicit
+`scope` on the registration is still binding, and the operator consent screen
+plus the staff-derived permission filter remain the authorization boundaries.
+
+The consent screen and the MCP settings page then spelled the admin realm into
+URLs that the shell's realm-scoping fetcher scopes on their behalf, producing
+`/api/auth/admin/admin/oauth2/...` and a 404 on every consent decision, consent
+lookup, and connector listing. Those requests are written on the shared `/auth`
+prefix now, and a failed consent reports its status and the server's own error
+detail instead of one indistinguishable sentence.

--- a/packages/auth-react/package.json
+++ b/packages/auth-react/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-router": "^1.170.17",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@voyant-travel/admin": "workspace:^",
@@ -75,6 +76,7 @@
     "@voyant-travel/types": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
     "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "jsdom": "^29.1.1",
     "lucide-react": "^1.23.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/packages/auth-react/src/components/mcp-consent-page.test.tsx
+++ b/packages/auth-react/src/components/mcp-consent-page.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * The consent screen, rendered and clicked, with the admin shell's real
+ * realm-scoping fetcher underneath it.
+ *
+ * Everything about this failure lived in the seam between the component and the
+ * fetcher the shell injects, so a test that stubs the fetcher cannot see it:
+ * the component was internally consistent and produced a URL nothing serves.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { LocaleProvider } from "@voyant-travel/admin/providers/locale"
+import type { ReactNode } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { createAuthBasePathFetcher } from "../client.js"
+import type { McpConsentMessages } from "../i18n/mcp-consent.js"
+import { McpConsentPage } from "./mcp-consent-page.js"
+
+const BASE_URL = "/api"
+
+const messages: McpConsentMessages = {
+  title: "Connect {client}?",
+  subtitle: "{client} wants in.",
+  readTitle: "See your data",
+  readBody: "read body",
+  writeTitle: "Make changes",
+  writeBody: "write body",
+  boundaryTitle: "Bounded",
+  boundaryBody: "boundary body",
+  approve: "Connect",
+  deny: "Cancel",
+  approving: "Connecting…",
+  failed: "Could not complete the connection.",
+  failedDetail: "Technical detail: {detail}",
+  unknownClient: "This application",
+}
+
+/** A transport with the fetcher's own signature, so the recorded call is typed. */
+function stubTransport(respond: (url: string, init?: RequestInit) => Response) {
+  return vi.fn((url: string, init?: RequestInit) => Promise.resolve(respond(url, init)))
+}
+
+/** The composition `createStandardOperatorFrontend` builds for the admin shell. */
+function adminShellFetcher(transport: (url: string, init?: RequestInit) => Promise<Response>) {
+  return createAuthBasePathFetcher(transport, {
+    baseUrl: BASE_URL,
+    authBasePath: "/auth/admin",
+    sharedPaths: ["/me", "/status", "/shell-bootstrap"],
+  })
+}
+
+/** The consent route mounts inside the admin shell, which provides the locale. */
+function Shell({ children }: { children: ReactNode }) {
+  return <LocaleProvider localeStorageKey={null}>{children}</LocaleProvider>
+}
+
+function renderConsent(transport: (url: string, init?: RequestInit) => Promise<Response>) {
+  return render(
+    <Shell>
+      <McpConsentPage
+        clientName="ChatGPT"
+        scope="mcp:read mcp:write offline_access"
+        oauthQuery="client_id=abc&ba_param=client_id&ba_param=scope&sig=deadbeef"
+        baseUrl={BASE_URL}
+        fetcher={adminShellFetcher(transport)}
+        messages={messages}
+      />
+    </Shell>,
+  )
+}
+
+afterEach(cleanup)
+
+describe("McpConsentPage", () => {
+  it("sends approval to the admin OAuth endpoint with one realm segment", async () => {
+    const transport = stubTransport(() =>
+      Response.json({ redirectURI: "https://chatgpt.com/cb?code=1&state=xyz" }),
+    )
+    renderConsent(transport)
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }))
+
+    await waitFor(() => expect(transport).toHaveBeenCalled())
+    const [url, init] = transport.mock.calls[0] ?? ["", undefined]
+    expect(url).toBe("/api/auth/admin/oauth2/consent")
+    expect(url.split("/").filter((segment) => segment === "admin")).toHaveLength(1)
+    expect(JSON.parse(String(init?.body))).toEqual({
+      accept: true,
+      oauth_query: "client_id=abc&ba_param=client_id&ba_param=scope&sig=deadbeef",
+    })
+  })
+
+  it("shows the write row only when the request asks for it", () => {
+    const transport = stubTransport(() => Response.json({}))
+    const { unmount } = renderConsent(transport)
+    expect(screen.getByText("Make changes")).toBeDefined()
+    unmount()
+
+    render(
+      <Shell>
+        <McpConsentPage
+          clientName="ChatGPT"
+          scope="mcp:read"
+          oauthQuery="client_id=abc"
+          baseUrl={BASE_URL}
+          fetcher={adminShellFetcher(transport)}
+          messages={messages}
+        />
+      </Shell>,
+    )
+    expect(screen.queryByText("Make changes")).toBeNull()
+  })
+
+  it("names the failure instead of collapsing it into one sentence", async () => {
+    // A 404 here means the request never reached the authorization server. An
+    // operator who can only report "it didn't work" cannot tell anyone that.
+    const transport = stubTransport(() => new Response("Not Found", { status: 404 }))
+    renderConsent(transport)
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }))
+
+    const alert = await screen.findByRole("alert")
+    expect(alert.textContent).toContain("Could not complete the connection.")
+    expect(alert.textContent).toContain("404")
+  })
+
+  it("re-enables the buttons after a failure so the operator can retry", async () => {
+    const transport = stubTransport(() => Response.json({ error: "expired" }, { status: 400 }))
+    renderConsent(transport)
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }))
+    await screen.findByRole("alert")
+
+    const connect = screen.getByRole("button", { name: "Connect" }) as HTMLButtonElement
+    expect(connect.disabled).toBe(false)
+    expect(screen.getByRole("alert").textContent).toContain("expired")
+  })
+})

--- a/packages/auth-react/src/components/mcp-consent-page.tsx
+++ b/packages/auth-react/src/components/mcp-consent-page.tsx
@@ -25,6 +25,11 @@ import {
 import { Check, Eye, Pencil, ShieldCheck } from "lucide-react"
 import { type ReactNode, useState } from "react"
 import { type McpConsentMessages, useMcpConsentMessages } from "../i18n/mcp-consent.js"
+import {
+  McpConsentError,
+  type McpConsentFetcher,
+  submitMcpConsentDecision,
+} from "../mcp-consent-client.js"
 
 export interface McpConsentPageProps {
   /** Display name of the connecting client, from dynamic registration. */
@@ -40,7 +45,13 @@ export interface McpConsentPageProps {
   oauthQuery: string
   /** Absolute base URL of the API (e.g. `/api`). */
   baseUrl: string
-  fetcher?: (input: string, init?: RequestInit) => Promise<Response>
+  /**
+   * The shell's realm-scoping fetcher. Required rather than defaulted: this
+   * screen's URLs are written on the shared `/auth` prefix and only reach the
+   * admin realm because that fetcher maps them, so a plain `fetch` here would
+   * silently 404 (see `mcp-consent-client.ts`).
+   */
+  fetcher: McpConsentFetcher
   messages?: McpConsentMessages
 }
 
@@ -61,13 +72,13 @@ export function McpConsentPage({
   scope,
   oauthQuery,
   baseUrl,
-  fetcher = fetch,
+  fetcher,
   messages,
 }: McpConsentPageProps) {
   const fallback = useMcpConsentMessages()
   const t = messages ?? fallback
   const [pending, setPending] = useState<"accept" | "deny" | null>(null)
-  const [failed, setFailed] = useState(false)
+  const [failure, setFailure] = useState<string | null>(null)
 
   const name = clientName?.trim() || t.unknownClient
   const grantedScopes = new Set((scope ?? "").split(/\s+/).filter(Boolean))
@@ -75,24 +86,20 @@ export function McpConsentPage({
 
   const decide = async (accept: boolean) => {
     setPending(accept ? "accept" : "deny")
-    setFailed(false)
+    setFailure(null)
     try {
-      const response = await fetcher(`${baseUrl}/auth/admin/oauth2/consent`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ accept, oauth_query: oauthQuery }),
-      })
-      if (!response.ok) throw new Error("consent failed")
-      const result = (await response.json()) as { redirectURI?: string; url?: string }
-      // Accepting returns `redirectURI`; denying returns a `url` carrying the
-      // `access_denied` error back to the client. Both hand control back.
-      const redirectURI = result.redirectURI ?? result.url
-      if (!redirectURI) throw new Error("missing redirect")
       // Hand control back to the assistant with its authorization code.
-      window.location.href = redirectURI
-    } catch {
-      setFailed(true)
+      window.location.href = await submitMcpConsentDecision({
+        baseUrl,
+        fetcher,
+        accept,
+        oauthQuery,
+      })
+    } catch (error) {
+      // Keep what actually went wrong. "Try again" is useless advice for a
+      // deterministic failure, and an operator who reports the status line is
+      // reporting something a maintainer can act on.
+      setFailure(error instanceof McpConsentError ? error.diagnostic : String(error))
       setPending(null)
     }
   }
@@ -124,7 +131,16 @@ export function McpConsentPage({
           />
         </ul>
 
-        {failed ? <p className="text-sm text-destructive">{t.failed}</p> : null}
+        {failure === null ? null : (
+          <div role="alert" className="flex flex-col gap-1">
+            <p className="text-sm text-destructive">{t.failed}</p>
+            {failure ? (
+              <p className="font-mono text-xs text-muted-foreground">
+                {t.failedDetail.replace("{detail}", failure)}
+              </p>
+            ) : null}
+          </div>
+        )}
 
         <div className="flex flex-col gap-2">
           <Button onClick={() => void decide(true)} disabled={pending !== null}>

--- a/packages/auth-react/src/i18n/mcp-consent.ts
+++ b/packages/auth-react/src/i18n/mcp-consent.ts
@@ -13,6 +13,8 @@ export interface McpConsentMessages {
   deny: string
   approving: string
   failed: string
+  /** Technical detail line under the failure message; `{detail}` is verbatim. */
+  failedDetail: string
   unknownClient: string
 }
 
@@ -30,6 +32,7 @@ const en: McpConsentMessages = {
   deny: "Cancel",
   approving: "Connecting…",
   failed: "Could not complete the connection. Close this window and try again.",
+  failedDetail: "Technical detail: {detail}",
   unknownClient: "This application",
 }
 
@@ -48,6 +51,7 @@ const ro: McpConsentMessages = {
   deny: "Anuleaza",
   approving: "Se conecteaza…",
   failed: "Conectarea nu a putut fi finalizata. Inchide fereastra si incearca din nou.",
+  failedDetail: "Detaliu tehnic: {detail}",
   unknownClient: "Aceasta aplicatie",
 }
 

--- a/packages/auth-react/src/mcp-consent-client.test.ts
+++ b/packages/auth-react/src/mcp-consent-client.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest"
+import { createAuthBasePathFetcher } from "./client.js"
+import {
+  fetchMcpConsentClient,
+  McpConsentError,
+  submitMcpConsentDecision,
+} from "./mcp-consent-client.js"
+
+const BASE_URL = "/api"
+
+/**
+ * The genuine article from the admin shell, not a stand-in.
+ *
+ * A stub fetcher accepts whichever URL the caller happens to build, which is
+ * exactly how `/api/auth/admin/admin/oauth2/consent` shipped: the old tests
+ * asserted the string the component produced instead of the string the shell
+ * would actually request.
+ */
+function adminShellFetcher(transport: (url: string, init?: RequestInit) => Promise<Response>) {
+  return createAuthBasePathFetcher(transport, {
+    baseUrl: BASE_URL,
+    authBasePath: "/auth/admin",
+    sharedPaths: ["/me", "/status", "/shell-bootstrap"],
+  })
+}
+
+/** A transport with the fetcher's own signature, so the recorded call is typed. */
+function stubTransport(respond: (url: string, init?: RequestInit) => Response) {
+  return vi.fn((url: string, init?: RequestInit) => Promise.resolve(respond(url, init)))
+}
+
+function countRealmSegments(url: string): number {
+  return url.split("/").filter((segment) => segment === "admin").length
+}
+
+describe("MCP consent requests through the admin shell fetcher", () => {
+  it("reaches the admin OAuth consent endpoint with exactly one realm segment", async () => {
+    const transport = stubTransport(() =>
+      Response.json({ redirectURI: "https://claude.ai/cb?code=1" }),
+    )
+
+    const redirect = await submitMcpConsentDecision({
+      baseUrl: BASE_URL,
+      fetcher: adminShellFetcher(transport),
+      accept: true,
+      oauthQuery: "client_id=abc&sig=xyz",
+    })
+
+    const url = transport.mock.calls[0]?.[0] ?? ""
+    expect(url).toBe("/api/auth/admin/oauth2/consent")
+    expect(countRealmSegments(url)).toBe(1)
+    expect(redirect).toBe("https://claude.ai/cb?code=1")
+  })
+
+  it("reaches the public-client lookup with exactly one realm segment", async () => {
+    const transport = stubTransport(() => Response.json({ client_name: "ChatGPT" }))
+
+    const client = await fetchMcpConsentClient({
+      baseUrl: BASE_URL,
+      fetcher: adminShellFetcher(transport),
+      clientId: "client_abc",
+    })
+
+    const url = transport.mock.calls[0]?.[0] ?? ""
+    expect(url).toBe("/api/auth/admin/oauth2/public-client?client_id=client_abc")
+    expect(countRealmSegments(url)).toBe(1)
+    expect(client?.client_name).toBe("ChatGPT")
+  })
+
+  it("posts the signed query verbatim, repeated parameters and order intact", async () => {
+    // The authorization server signs one `ba_param` entry per signed parameter.
+    // Anything that parses this into an object drops all but the last, and the
+    // signature check then fails with `invalid_signature`.
+    const oauthQuery =
+      "response_type=code&client_id=abc&scope=mcp%3Aread+mcp%3Awrite+offline_access" +
+      "&ba_param=ba_iat&ba_param=client_id&ba_param=scope&ba_param=state&sig=deadbeef"
+    const transport = stubTransport(() => Response.json({ redirectURI: "https://claude.ai/cb" }))
+
+    await submitMcpConsentDecision({
+      baseUrl: BASE_URL,
+      fetcher: adminShellFetcher(transport),
+      accept: true,
+      oauthQuery,
+    })
+
+    const body = JSON.parse(String(transport.mock.calls[0]?.[1]?.body)) as { oauth_query: string }
+    expect(body.oauth_query).toBe(oauthQuery)
+    expect(new URLSearchParams(body.oauth_query).getAll("ba_param")).toEqual([
+      "ba_iat",
+      "client_id",
+      "scope",
+      "state",
+    ])
+  })
+
+  it("carries the status and server detail off a failed decision", async () => {
+    const transport = stubTransport(() =>
+      Response.json({ error: "invalid_signature" }, { status: 400 }),
+    )
+
+    const error = await submitMcpConsentDecision({
+      baseUrl: BASE_URL,
+      fetcher: adminShellFetcher(transport),
+      accept: true,
+      oauthQuery: "client_id=abc&sig=tampered",
+    }).catch((thrown: unknown) => thrown)
+
+    expect(error).toBeInstanceOf(McpConsentError)
+    expect((error as McpConsentError).status).toBe(400)
+    expect((error as McpConsentError).detail).toBe("invalid_signature")
+    expect((error as McpConsentError).diagnostic).toBe("400 invalid_signature")
+  })
+
+  it("distinguishes a routing 404 from a rejected decision", async () => {
+    // The failure this whole change exists to stop looked identical to every
+    // other failure. It must not any more.
+    const transport = stubTransport(() => new Response("Not Found", { status: 404 }))
+
+    const error = (await submitMcpConsentDecision({
+      baseUrl: BASE_URL,
+      fetcher: adminShellFetcher(transport),
+      accept: true,
+      oauthQuery: "client_id=abc",
+    }).catch((thrown: unknown) => thrown)) as McpConsentError
+
+    expect(error.status).toBe(404)
+    expect(error.diagnostic).toContain("404")
+  })
+
+  it("reports a 2xx response that carries no redirect instead of hanging", async () => {
+    const transport = stubTransport(() => Response.json({}))
+
+    const error = (await submitMcpConsentDecision({
+      baseUrl: BASE_URL,
+      fetcher: adminShellFetcher(transport),
+      accept: false,
+      oauthQuery: "client_id=abc",
+    }).catch((thrown: unknown) => thrown)) as McpConsentError
+
+    expect(error).toBeInstanceOf(McpConsentError)
+    expect(error.status).toBe(200)
+  })
+
+  it("falls back to no client name rather than blocking the grant", async () => {
+    const transport = stubTransport(() => new Response("", { status: 401 }))
+
+    await expect(
+      fetchMcpConsentClient({
+        baseUrl: BASE_URL,
+        fetcher: adminShellFetcher(transport),
+        clientId: "client_abc",
+      }),
+    ).resolves.toBeNull()
+  })
+})

--- a/packages/auth-react/src/mcp-consent-client.ts
+++ b/packages/auth-react/src/mcp-consent-client.ts
@@ -1,0 +1,138 @@
+/**
+ * The two OAuth calls the MCP consent screen makes.
+ *
+ * Both are written on the **shared** `/auth` prefix, not on `/auth/admin`. The
+ * admin shell injects a realm-scoping fetcher (`createAuthBasePathFetcher`)
+ * that maps `/auth/*` into the admin realm exactly once, the same way every
+ * other auth-react hook is routed. Spelling the realm out here as well produced
+ * `/api/auth/admin/admin/oauth2/consent`, a deterministic 404 that surfaced to
+ * the operator as "Could not complete the connection" and stopped both ChatGPT
+ * and Claude from ever completing a grant
+ * ([#4793](https://github.com/voyant-travel/voyant/issues/4793)).
+ *
+ * Keeping them here rather than inline in the component is what lets the URL
+ * contract be tested against the real fetcher instead of a stub that would
+ * happily accept either spelling.
+ */
+
+/** Looks up the display name of the client asking for consent. */
+export const MCP_CONSENT_PUBLIC_CLIENT_PATH = "/auth/oauth2/public-client"
+/** Records the operator's decision and returns the hand-back redirect. */
+export const MCP_CONSENT_DECISION_PATH = "/auth/oauth2/consent"
+
+export type McpConsentFetcher = (input: string, init?: RequestInit) => Promise<Response>
+
+/** What dynamic registration recorded about the connecting client. */
+export interface McpConsentClientDetails {
+  name?: string | null
+  client_name?: string | null
+}
+
+/**
+ * A consent request that did not succeed, with the response still attached.
+ *
+ * The consent screen used to catch every failure into one boolean, which turned
+ * a 404 on a malformed URL, an expired signature, and a lapsed session into the
+ * same sentence — leaving nothing for the operator to report or for diagnostics
+ * to key on. The status and server-supplied detail are carried so the failure
+ * can name itself.
+ */
+export class McpConsentError extends Error {
+  readonly status: number
+  readonly detail: string | undefined
+
+  constructor(message: string, status: number, detail?: string) {
+    super(message)
+    this.name = "McpConsentError"
+    this.status = status
+    this.detail = detail
+  }
+
+  /** One short line combining status and server detail, safe to show verbatim. */
+  get diagnostic(): string {
+    return this.detail ? `${this.status} ${this.detail}` : String(this.status)
+  }
+}
+
+/** Pull whatever the server said out of the body, without assuming a shape. */
+async function readErrorDetail(response: Response): Promise<string | undefined> {
+  let text: string
+  try {
+    text = await response.text()
+  } catch {
+    return undefined
+  }
+  if (!text) return undefined
+  try {
+    const body: unknown = JSON.parse(text)
+    if (typeof body === "object" && body !== null) {
+      const record = body as Record<string, unknown>
+      const candidate =
+        record.error_description ?? record.error ?? record.message ?? record.code ?? undefined
+      if (typeof candidate === "string" && candidate) return candidate
+    }
+  } catch {
+    // Not JSON — the raw body is the best detail available.
+  }
+  return text.slice(0, 200)
+}
+
+/**
+ * Resolve the connecting client's registered name.
+ *
+ * A failed lookup is not fatal: the screen falls back to "This application"
+ * rather than blocking a grant the operator asked for, so this answers `null`
+ * instead of throwing.
+ */
+export async function fetchMcpConsentClient(input: {
+  baseUrl: string
+  fetcher: McpConsentFetcher
+  clientId: string
+}): Promise<McpConsentClientDetails | null> {
+  const query = new URLSearchParams({ client_id: input.clientId })
+  const response = await input.fetcher(
+    `${input.baseUrl}${MCP_CONSENT_PUBLIC_CLIENT_PATH}?${query.toString()}`,
+    { credentials: "include" },
+  )
+  if (!response.ok) return null
+  return (await response.json()) as McpConsentClientDetails
+}
+
+/**
+ * Post the operator's decision and return the URI that hands control back.
+ *
+ * `oauthQuery` is the authorization server's own signed query and must be sent
+ * byte for byte — it carries a `ba_param` entry per signed parameter, so
+ * parsing it into an object and re-serializing collapses the repeats and
+ * invalidates the signature.
+ */
+export async function submitMcpConsentDecision(input: {
+  baseUrl: string
+  fetcher: McpConsentFetcher
+  accept: boolean
+  oauthQuery: string
+}): Promise<string> {
+  const response = await input.fetcher(`${input.baseUrl}${MCP_CONSENT_DECISION_PATH}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ accept: input.accept, oauth_query: input.oauthQuery }),
+  })
+
+  if (!response.ok) {
+    throw new McpConsentError(
+      "consent request failed",
+      response.status,
+      await readErrorDetail(response),
+    )
+  }
+
+  const result = (await response.json()) as { redirectURI?: string; url?: string }
+  // Accepting returns `redirectURI`; denying returns a `url` carrying the
+  // `access_denied` error back to the client. Both hand control back.
+  const redirectUri = result.redirectURI ?? result.url
+  if (!redirectUri) {
+    throw new McpConsentError("consent response carried no redirect", response.status)
+  }
+  return redirectUri
+}

--- a/packages/auth-react/src/mcp-consent-routes.tsx
+++ b/packages/auth-react/src/mcp-consent-routes.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react"
 import { z } from "zod"
 import { AuthLayout } from "./components/auth-layout.js"
 import { McpConsentPage } from "./components/mcp-consent-page.js"
+import { fetchMcpConsentClient } from "./mcp-consent-client.js"
 
 /**
  * The OAuth consent screen an MCP connector sends the operator to.
@@ -73,14 +74,7 @@ function McpConsentRoute() {
   const client = useQuery({
     queryKey: ["mcp-consent-client", client_id],
     enabled: Boolean(client_id),
-    queryFn: async () => {
-      const response = await fetcher(
-        `${baseUrl}/auth/admin/oauth2/public-client?client_id=${encodeURIComponent(client_id ?? "")}`,
-        { credentials: "include" },
-      )
-      if (!response.ok) return null
-      return (await response.json()) as { name?: string | null; client_name?: string | null }
-    },
+    queryFn: () => fetchMcpConsentClient({ baseUrl, fetcher, clientId: client_id ?? "" }),
   })
 
   return (

--- a/packages/auth-react/vitest.config.ts
+++ b/packages/auth-react/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+  },
+})

--- a/packages/auth/src/mcp-oauth.ts
+++ b/packages/auth/src/mcp-oauth.ts
@@ -194,9 +194,16 @@ export function mcpOAuthProviderConfig(options: McpOAuthPluginOptions) {
     // of the flow. The consent screen, not registration, is the trust boundary.
     allowDynamicClientRegistration: true,
     allowUnauthenticatedClientRegistration: true,
-    // A newly registered connector starts read-only; asking for write forces it
-    // through consent for the wider grant.
-    clientRegistrationDefaultScopes: [MCP_OAUTH_SCOPE_READ],
+    // A client that registers without a `scope` field — which is what ChatGPT
+    // does — gets this as its permanent registered scope set, and `authorize`
+    // rejects anything outside it with `invalid_scope`. So it has to match what
+    // discovery advertises: a server that publishes three scopes and then
+    // registers clients for one has told the client to ask for something it
+    // will refuse. Narrowing here is not a security control either, because it
+    // happens before any human is involved; the trust boundary is the operator
+    // on the consent screen, and after that `resolveMcpGrantScopes` clamps the
+    // grant to the approver's own permissions on every single request.
+    clientRegistrationDefaultScopes: [...MCP_OAUTH_SCOPES],
     clientRegistrationAllowedScopes: [...MCP_OAUTH_SCOPES],
     // Tokens are bearer credentials for the whole operator workspace: never
     // readable from a database dump.

--- a/packages/auth/tests/integration/mcp-oauth-hosted-client.test.ts
+++ b/packages/auth/tests/integration/mcp-oauth-hosted-client.test.ts
@@ -1,0 +1,293 @@
+/**
+ * The handshake a hosted chat client actually performs, driven end to end.
+ *
+ * ChatGPT Web and Claude Web are given nothing but the MCP URL. Everything they
+ * do afterwards is derived from documents this server publishes, which makes the
+ * published metadata a contract rather than documentation: whatever
+ * `scopes_supported` says, the client will ask for, and whatever dynamic
+ * registration defaults to is what `authorize` will hold it to. Those two were
+ * allowed to disagree — discovery advertised three scopes, registration stored
+ * one — and every hosted client bounced off `invalid_scope` before a human ever
+ * saw the consent screen ([#4793](https://github.com/voyant-travel/voyant/issues/4793)).
+ *
+ * Unlike `mcp-oauth-flow.test.ts`, this suite needs no database: it runs the
+ * real Better Auth handler over the in-memory adapter, so the discovery →
+ * registration → authorize → consent → token chain is exercised on every CI run
+ * rather than only where Postgres happens to be reachable.
+ */
+
+import { createHash } from "node:crypto"
+import { oauthProvider } from "@better-auth/oauth-provider"
+import { betterAuth } from "better-auth"
+import { memoryAdapter } from "better-auth/adapters/memory"
+import { jwt } from "better-auth/plugins"
+import { decodeJwt } from "jose"
+import { beforeAll, describe, expect, it } from "vitest"
+import {
+  MCP_OAUTH_SCOPES,
+  mcpOAuthProviderConfig,
+  parseOAuthScopeClaim,
+} from "../../src/mcp-oauth.js"
+
+const BASE_URL = "http://localhost:3300"
+const RESOURCE = `${BASE_URL}/api/v1/admin/mcp`
+/** Throwaway credential for the fixture operator; never leaves this suite. */
+const TEST_PASSWORD = "test-operator-password"
+
+/**
+ * The models the flow touches. The in-memory adapter clones this object per
+ * transaction, so every table has to exist up front — a lazily created one
+ * would not survive the clone.
+ */
+function emptyDatabase() {
+  return {
+    user: [],
+    session: [],
+    account: [],
+    verification: [],
+    jwks: [],
+    oauthClient: [],
+    oauthConsent: [],
+    oauthAccessToken: [],
+    rateLimit: [],
+  }
+}
+
+const auth = betterAuth({
+  appName: "Voyant",
+  baseURL: BASE_URL,
+  // The admin realm's mount point. The issuer, and therefore every signature the
+  // resource server verifies, is derived from it.
+  basePath: "/auth/admin",
+  secret: "x".repeat(32),
+  database: memoryAdapter(emptyDatabase()),
+  emailAndPassword: { enabled: true },
+  plugins: [jwt(), oauthProvider(mcpOAuthProviderConfig({ resource: RESOURCE }))],
+})
+
+function call(path: string, init?: RequestInit): Promise<Response> {
+  return auth.handler(new Request(`${BASE_URL}${path}`, init))
+}
+
+/**
+ * The two clients this has to work with, described the way they describe
+ * themselves: a public client, PKCE only, no credential to present at the token
+ * endpoint, and — the part that broke — no `scope` field during registration.
+ */
+const HOSTED_CLIENTS = [
+  { name: "ChatGPT", redirectUri: "https://chatgpt.com/connector_platform_oauth_redirect" },
+  { name: "Claude", redirectUri: "https://claude.ai/api/mcp/auth_callback" },
+] as const
+
+function registrationRequest(client: (typeof HOSTED_CLIENTS)[number], scope?: string) {
+  return {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      client_name: client.name,
+      redirect_uris: [client.redirectUri],
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      ...(scope ? { scope } : {}),
+    }),
+  } satisfies RequestInit
+}
+
+function pkce(verifier: string) {
+  return createHash("sha256").update(verifier).digest("base64url")
+}
+
+function authorizeUrl(input: {
+  clientId: string
+  redirectUri: string
+  scope: string
+  challenge: string
+  state: string
+}): string {
+  const query = new URLSearchParams({
+    response_type: "code",
+    client_id: input.clientId,
+    redirect_uri: input.redirectUri,
+    scope: input.scope,
+    code_challenge: input.challenge,
+    code_challenge_method: "S256",
+    resource: RESOURCE,
+    state: input.state,
+  })
+  return `/auth/admin/oauth2/authorize?${query.toString()}`
+}
+
+/** The signed query the authorization server hands the consent page. */
+function oauthQueryFrom(location: string): string {
+  return location.slice(location.indexOf("?") + 1)
+}
+
+let operatorCookie = ""
+
+beforeAll(async () => {
+  const signUp = await call("/auth/admin/sign-up/email", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      email: "operator@example.com",
+      password: TEST_PASSWORD,
+      name: "Operator",
+    }),
+  })
+  expect(signUp.status).toBeLessThan(300)
+  operatorCookie = (signUp.headers.getSetCookie?.() ?? [])
+    .map((value) => value.split(";")[0])
+    .join("; ")
+  expect(operatorCookie).not.toBe("")
+})
+
+describe("hosted MCP client handshake", () => {
+  it("advertises the same scopes registration will accept", async () => {
+    const response = await call("/auth/admin/.well-known/oauth-authorization-server")
+    expect(response.status).toBe(200)
+    const metadata = (await response.json()) as { scopes_supported?: string[] }
+
+    expect(metadata.scopes_supported).toEqual([...MCP_OAUTH_SCOPES])
+  })
+
+  for (const client of HOSTED_CLIENTS) {
+    it(`lets ${client.name} register without a scope and still ask for the advertised ones`, async () => {
+      // 1. Discovery. Everything below is derived from this document alone.
+      const discovery = await call("/auth/admin/.well-known/oauth-authorization-server")
+      const { scopes_supported } = (await discovery.json()) as { scopes_supported: string[] }
+
+      // 2. Dynamic registration, with no `scope` field — the hosted-client shape.
+      const registration = await call("/auth/admin/oauth2/register", registrationRequest(client))
+      expect(registration.status).toBeLessThan(300)
+      const registered = (await registration.json()) as { client_id: string; scope: string }
+      expect(registered.scope.split(" ")).toEqual(scopes_supported)
+
+      // 3. Authorize, asking for exactly what discovery advertised. This is the
+      //    step that used to redirect back with `invalid_scope`.
+      const verifier = "a".repeat(64)
+      const authorize = await call(
+        authorizeUrl({
+          clientId: registered.client_id,
+          redirectUri: client.redirectUri,
+          scope: scopes_supported.join(" "),
+          challenge: pkce(verifier),
+          state: "hosted-state",
+        }),
+        { headers: { cookie: operatorCookie }, redirect: "manual" },
+      )
+      const location = authorize.headers.get("location") ?? ""
+      expect(location).not.toContain("error=")
+      expect(location).toContain("/mcp-consent")
+
+      // 4. The operator approves. This is the request the consent page posts.
+      const oauthQuery = oauthQueryFrom(location)
+      const consent = await call("/auth/admin/oauth2/consent", {
+        method: "POST",
+        headers: { "content-type": "application/json", cookie: operatorCookie },
+        body: JSON.stringify({ accept: true, oauth_query: oauthQuery }),
+      })
+      expect(consent.status).toBeLessThan(300)
+      const decision = (await consent.json()) as { redirectURI?: string; url?: string }
+      const redirectURI = decision.redirectURI ?? decision.url ?? ""
+      const handback = new URL(redirectURI)
+      expect(handback.origin + handback.pathname).toBe(client.redirectUri)
+      expect(handback.searchParams.get("state")).toBe("hosted-state")
+      const code = handback.searchParams.get("code")
+      expect(code).toBeTruthy()
+
+      // 5. Code exchange. A public client presents only its PKCE verifier.
+      const token = await call("/auth/admin/oauth2/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code: code ?? "",
+          redirect_uri: client.redirectUri,
+          client_id: registered.client_id,
+          code_verifier: verifier,
+          resource: RESOURCE,
+        }).toString(),
+      })
+      expect(token.status).toBeLessThan(300)
+      const grant = (await token.json()) as {
+        access_token: string
+        refresh_token?: string
+        scope?: string
+      }
+
+      // `offline_access` was granted, so the connector must come away with a
+      // refresh token — without one it dies at the first token expiry and the
+      // operator has to reconnect it by hand.
+      expect(grant.refresh_token).toEqual(expect.any(String))
+
+      const claims = decodeJwt(grant.access_token)
+      expect(claims.iss).toBe(`${BASE_URL}/auth/admin`)
+      expect([claims.aud].flat()).toContain(RESOURCE)
+      expect(parseOAuthScopeClaim(claims.scope)).toEqual(scopes_supported)
+    })
+  }
+
+  it("still holds a client to a scope set it asked to be restricted to", async () => {
+    // Registering *with* a scope is an explicit narrowing, and it stays binding
+    // — the coherence fix above must not turn every client into a full one.
+    const registration = await call(
+      "/auth/admin/oauth2/register",
+      registrationRequest(HOSTED_CLIENTS[0], "mcp:read"),
+    )
+    const registered = (await registration.json()) as { client_id: string; scope: string }
+    expect(registered.scope).toBe("mcp:read")
+
+    const authorize = await call(
+      authorizeUrl({
+        clientId: registered.client_id,
+        redirectUri: HOSTED_CLIENTS[0].redirectUri,
+        scope: "mcp:read mcp:write",
+        challenge: pkce("b".repeat(64)),
+        state: "restricted-state",
+      }),
+      { headers: { cookie: operatorCookie }, redirect: "manual" },
+    )
+
+    const location = authorize.headers.get("location") ?? ""
+    expect(location).toContain("error=invalid_scope")
+    expect(location).toContain("mcp%3Awrite")
+  })
+
+  it("hands the consent page a signed query carrying repeated parameters", async () => {
+    // The signature covers a `ba_param` entry per signed parameter, so the query
+    // cannot survive being parsed into an object and re-serialized. The consent
+    // page posts the raw string for exactly this reason.
+    const registration = await call(
+      "/auth/admin/oauth2/register",
+      registrationRequest(HOSTED_CLIENTS[1]),
+    )
+    const registered = (await registration.json()) as { client_id: string }
+
+    const authorize = await call(
+      authorizeUrl({
+        clientId: registered.client_id,
+        redirectUri: HOSTED_CLIENTS[1].redirectUri,
+        scope: MCP_OAUTH_SCOPES.join(" "),
+        challenge: pkce("c".repeat(64)),
+        state: "repeated-state",
+      }),
+      { headers: { cookie: operatorCookie }, redirect: "manual" },
+    )
+
+    const oauthQuery = oauthQueryFrom(authorize.headers.get("location") ?? "")
+    const params = new URLSearchParams(oauthQuery)
+    expect(params.get("sig")).toBeTruthy()
+    expect(params.getAll("ba_param").length).toBeGreaterThan(1)
+
+    // Round-tripping through an object collapses the repeats and invalidates
+    // the signature — proving the verbatim requirement rather than asserting it.
+    const collapsed = new URLSearchParams(Object.fromEntries(params)).toString()
+    const rejected = await call("/auth/admin/oauth2/consent", {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie: operatorCookie },
+      body: JSON.stringify({ accept: true, oauth_query: collapsed }),
+    })
+    expect(rejected.status).toBeGreaterThanOrEqual(400)
+  })
+})

--- a/packages/auth/tests/unit/mcp-oauth.test.ts
+++ b/packages/auth/tests/unit/mcp-oauth.test.ts
@@ -216,8 +216,12 @@ describe("mcpOAuthProviderConfig", () => {
     expect(config.allowUnauthenticatedClientRegistration).toBe(true)
   })
 
-  it("registers new connectors read-only until consent widens them", () => {
-    expect(config.clientRegistrationDefaultScopes).toEqual([MCP_OAUTH_SCOPE_READ])
+  it("defaults a scope-omitting registration to exactly what discovery advertises", () => {
+    // A hosted client reads `scopes_supported` and asks for all of it. If the
+    // registration default were narrower, `authorize` would answer its own
+    // advertised scopes with `invalid_scope`.
+    expect(config.clientRegistrationDefaultScopes).toEqual(config.scopes)
+    expect(config.clientRegistrationDefaultScopes).toContain(MCP_OAUTH_SCOPE_READ)
   })
 
   it("hashes tokens and client secrets at rest", () => {

--- a/packages/operator-settings-react/package.json
+++ b/packages/operator-settings-react/package.json
@@ -46,6 +46,7 @@
     "@types/react-dom": "^19.2.3",
     "@voyant-travel/admin": "workspace:^",
     "@voyant-travel/admin-app": "workspace:^",
+    "@voyant-travel/auth-react": "workspace:^",
     "@voyant-travel/finance": "workspace:^",
     "@voyant-travel/finance-react": "workspace:^",
     "@voyant-travel/operator-settings": "workspace:^",

--- a/packages/operator-settings-react/src/mcp-connectors.test.ts
+++ b/packages/operator-settings-react/src/mcp-connectors.test.ts
@@ -1,3 +1,4 @@
+import { createAuthBasePathFetcher } from "@voyant-travel/auth-react/client"
 import { describe, expect, it, vi } from "vitest"
 import { listMcpConnectors, revokeMcpConnector, toMcpConnector } from "./mcp-connectors.js"
 
@@ -6,6 +7,22 @@ const consent = {
   clientId: "client_abc",
   scopes: ["mcp:read"],
   createdAt: "2026-07-29T10:00:00.000Z",
+}
+
+/**
+ * The admin shell's real realm-scoping fetcher, not a stub.
+ *
+ * These calls run inside the shell, whose fetcher maps `/auth/*` into the admin
+ * realm. Asserting the URL the caller builds — rather than the one the shell
+ * ends up requesting — is what let `/api/auth/admin/admin/oauth2/...` pass a
+ * green suite (#4793).
+ */
+function adminShellFetcher(transport: (url: string, init?: RequestInit) => Promise<Response>) {
+  return createAuthBasePathFetcher(transport, {
+    baseUrl: "/api",
+    authBasePath: "/auth/admin",
+    sharedPaths: ["/me", "/status", "/shell-bootstrap"],
+  })
 }
 
 describe("toMcpConnector", () => {
@@ -29,6 +46,23 @@ describe("toMcpConnector", () => {
 })
 
 describe("listMcpConnectors", () => {
+  it("reads both endpoints through the shell with exactly one realm segment", async () => {
+    const transport = vi.fn(async (url: string) =>
+      url.includes("get-consents") ? Response.json([consent]) : Response.json({ name: "Claude" }),
+    )
+
+    await listMcpConnectors("/api", adminShellFetcher(transport))
+
+    const requested = transport.mock.calls.map(([url]) => url)
+    expect(requested).toEqual([
+      "/api/auth/admin/oauth2/get-consents",
+      "/api/auth/admin/oauth2/get-client?client_id=client_abc",
+    ])
+    for (const url of requested) {
+      expect(url.split("/").filter((segment) => segment === "admin")).toHaveLength(1)
+    }
+  })
+
   it("resolves each consent to its registered client name", async () => {
     const fetcher = vi.fn(async (url: string) =>
       url.includes("get-consents")
@@ -36,7 +70,7 @@ describe("listMcpConnectors", () => {
         : Response.json({ name: "Claude Desktop" }),
     )
 
-    await expect(listMcpConnectors("/api", fetcher)).resolves.toEqual([
+    await expect(listMcpConnectors("/api", adminShellFetcher(fetcher))).resolves.toEqual([
       expect.objectContaining({ id: "consent_1", name: "Claude Desktop", canWrite: false }),
     ])
   })
@@ -46,7 +80,7 @@ describe("listMcpConnectors", () => {
       url.includes("get-consents") ? Response.json([consent]) : new Response("", { status: 500 }),
     )
 
-    const connectors = await listMcpConnectors("/api", fetcher)
+    const connectors = await listMcpConnectors("/api", adminShellFetcher(fetcher))
 
     // Hiding a live grant because a name lookup failed would keep the operator
     // from revoking something that still has access.
@@ -58,17 +92,17 @@ describe("listMcpConnectors", () => {
   it("throws when the consent list itself cannot be read", async () => {
     const fetcher = vi.fn(async () => new Response("", { status: 401 }))
 
-    await expect(listMcpConnectors("/api", fetcher)).rejects.toThrow()
+    await expect(listMcpConnectors("/api", adminShellFetcher(fetcher))).rejects.toThrow()
   })
 })
 
 describe("revokeMcpConnector", () => {
-  it("posts the consent id to the delete endpoint", async () => {
-    const fetcher = vi.fn(async () => Response.json({}))
+  it("posts the consent id to the admin realm's delete endpoint", async () => {
+    const transport = vi.fn(async () => Response.json({}))
 
-    await revokeMcpConnector("/api", fetcher, "consent_1")
+    await revokeMcpConnector("/api", adminShellFetcher(transport), "consent_1")
 
-    expect(fetcher).toHaveBeenCalledWith(
+    expect(transport).toHaveBeenCalledWith(
       "/api/auth/admin/oauth2/delete-consent",
       expect.objectContaining({ method: "POST", body: JSON.stringify({ id: "consent_1" }) }),
     )
@@ -77,6 +111,8 @@ describe("revokeMcpConnector", () => {
   it("surfaces a failed revoke instead of reporting success", async () => {
     const fetcher = vi.fn(async () => new Response("", { status: 404 }))
 
-    await expect(revokeMcpConnector("/api", fetcher, "consent_1")).rejects.toThrow()
+    await expect(
+      revokeMcpConnector("/api", adminShellFetcher(fetcher), "consent_1"),
+    ).rejects.toThrow()
   })
 })

--- a/packages/operator-settings-react/src/mcp-connectors.ts
+++ b/packages/operator-settings-react/src/mcp-connectors.ts
@@ -5,6 +5,12 @@
  * assistant they approved. Revoking deletes that row, and the MCP surface
  * re-checks it on every request, so disconnecting takes effect on the
  * assistant's next call.
+ *
+ * Every URL below is written on the **shared** `/auth` prefix. The admin shell
+ * injects a realm-scoping fetcher that maps `/auth/*` into the admin realm
+ * exactly once; naming the realm here as well produced
+ * `/api/auth/admin/admin/oauth2/...` and a 404 on each of these calls
+ * ([#4793](https://github.com/voyant-travel/voyant/issues/4793)).
  */
 
 export interface McpConsentRecord {
@@ -57,7 +63,7 @@ export async function listMcpConnectors(
   baseUrl: string,
   fetcher: McpFetcher,
 ): Promise<McpConnector[]> {
-  const response = await fetcher(`${baseUrl}/auth/admin/oauth2/get-consents`, {
+  const response = await fetcher(`${baseUrl}/auth/oauth2/get-consents`, {
     credentials: "include",
   })
   if (!response.ok) throw new Error("consents")
@@ -67,7 +73,7 @@ export async function listMcpConnectors(
     consents.map(async (consent) => {
       try {
         const clientResponse = await fetcher(
-          `${baseUrl}/auth/admin/oauth2/get-client?client_id=${encodeURIComponent(consent.clientId)}`,
+          `${baseUrl}/auth/oauth2/get-client?client_id=${encodeURIComponent(consent.clientId)}`,
           { credentials: "include" },
         )
         return toMcpConnector(consent, clientResponse.ok ? await clientResponse.json() : null)
@@ -84,7 +90,7 @@ export async function revokeMcpConnector(
   fetcher: McpFetcher,
   consentId: string,
 ): Promise<void> {
-  const response = await fetcher(`${baseUrl}/auth/admin/oauth2/delete-consent`, {
+  const response = await fetcher(`${baseUrl}/auth/oauth2/delete-consent`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     credentials: "include",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1459,6 +1459,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.170.17
         version: 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -1480,6 +1483,9 @@ importers:
       '@voyant-travel/voyant-typescript-config':
         specifier: workspace:^
         version: link:../typescript-config
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       lucide-react:
         specifier: ^1.23.0
         version: 1.23.0(react@19.2.7)
@@ -4520,6 +4526,9 @@ importers:
       '@voyant-travel/admin-app':
         specifier: workspace:^
         version: link:../admin-app
+      '@voyant-travel/auth-react':
+        specifier: workspace:^
+        version: link:../auth-react
       '@voyant-travel/finance':
         specifier: workspace:^
         version: link:../finance


### PR DESCRIPTION
Closes #4793.

A hosted assistant is handed nothing but the MCP URL, so every step after that is derived from documents this server publishes. Two of those documents disagreed with the code behind them.

## Registration defaulted narrower than discovery advertised

`.well-known/oauth-authorization-server` publishes `mcp:read`, `mcp:write`, and `offline_access`. A dynamic registration that omits `scope` — which is what the hosted clients send — was stored with `mcp:read` alone, and `authorize` then answered the server's own advertised scopes with:

```
?error=invalid_scope&error_description=The+following+scopes+are+invalid%3A+mcp%3Awrite%2C+offline_access
```

`clientRegistrationDefaultScopes` now matches `scopes`. Narrowing there was never a security control: it happens before any human is involved. An explicit `scope` on the registration is still binding, and the boundaries doing the real work are untouched — the operator on the consent screen, and `resolveMcpGrantScopes` clamping every request to the approver's own permissions.

## The consent screen scoped the admin realm twice

The admin shell injects `createAuthBasePathFetcher`, which maps `/auth/*` into the admin realm. The consent screen and the MCP settings page also spelled `/auth/admin` into their URLs, so the shell scoped them a second time and every request landed on `/api/auth/admin/admin/oauth2/...` and 404'd — the consent decision, the client-name lookup, and the whole connector list on Settings → MCP.

Those calls now use the shared `/auth` prefix, the same contract every other auth-react call already follows, and they live in `mcp-consent-client.ts` so the URL contract can be tested against the real fetcher. `fetcher` became a required prop on `McpConsentPage`: a plain `fetch` cannot satisfy this contract, and defaulting to one hid that.

## Failure diagnostics

A non-2xx consent collapsed into one boolean, so a deterministic 404, an expired signature, and a lapsed session all read as "Could not complete the connection." `McpConsentError` carries the status and the server's own error detail, and the screen shows it under the friendly sentence.

## Tests

The old tests could not see any of this: they asserted the URL the component built rather than the one the shell would request, and the end-to-end flow test needs a Postgres that is wired up nowhere, so it skips in CI.

- `packages/auth/tests/integration/mcp-oauth-hosted-client.test.ts` — discovery → scope-omitting DCR → authorize → consent → token, over the real Better Auth handler with the in-memory adapter, parameterized over both hosted clients' redirect/PKCE metadata. No database, so it runs on every CI run. Asserts the refresh token for `offline_access`, the issuer/audience/scope claims, that an explicitly restricted client still gets `invalid_scope`, and that collapsing the repeated `ba_param` entries invalidates the signed query.
- `packages/auth-react/src/mcp-consent-client.test.ts` and `src/components/mcp-consent-page.test.tsx` — both compose the genuine `createAuthBasePathFetcher`; the component one renders the screen and clicks Connect. Each asserts exactly one `admin` segment in the URL that reaches the transport.
- `packages/operator-settings-react/src/mcp-connectors.test.ts` — same treatment for the connector list and revoke.

All four consent/registration tests were confirmed red against the pre-fix code.

## Verification

- `pnpm verify:architecture` — pass
- `pnpm i18n:check` — pass (en + ro parity for the new `failedDetail` key)
- `biome check .` — 0 errors
- typecheck + build + full suites for `auth`, `auth-react`, `operator-settings-react` — pass

`auth-react` gained `jsdom` + `@testing-library/react` (dev only) and a `vitest.config.ts`, matching the other `*-react` packages; `operator-settings-react` gained `auth-react` as a devDependency so its test can use the real fetcher.