### PR TITLE
Repair the public shopping OpenAPI generator and regenerate its document

### DIFF
--- a/.changeset/public-shopping-spec-regenerated.md
+++ b/.changeset/public-shopping-spec-regenerated.md
@@ -1,0 +1,25 @@
+---
+"@voyant-travel/public-api": patch
+---
+
+Repair the public shopping OpenAPI generator and regenerate the document it had
+stopped producing.
+
+`generate:shopping-openapi` writes the document and then formats it with biome, so
+that a semantic change is not buried under thousands of formatting-only lines. The
+document passed biome's default 1 MiB ceiling as the public surface grew, and biome
+refuses an oversized file rather than skipping it — so the format step began exiting
+non-zero, the generator became unrunnable, and it left an unformatted document behind
+when it failed. The ceiling is now raised for this one invocation rather than in
+`biome.json`, so repo-wide runs keep skipping the 1.8 MiB migration snapshots.
+
+While it was broken the document drifted from the routes. `POST
+/v1/public/shopping/trip-selections/book` was missing from it entirely — a public
+endpoint absent from the published contract and from the in-app API reference, which
+renders these documents — and `/v1/public/shopping/search` and
+`/v1/public/shopping/trip-selections` had both moved on. Nothing else changed: the
+other twelve paths and every top-level field are byte-identical.
+
+The generator is now registered in `generated-specs.json`, so `verify:openapi-drift`
+regenerates and diffs it. It was the only generator in the repository whose output was
+unregistered, which is why the drift was invisible for as long as it was.

--- a/packages/public-api/openapi/public-api/public-api.json
+++ b/packages/public-api/openapi/public-api/public-api.json
@@ -3322,6 +3322,7 @@
                                     "excursions",
                                     "experiences",
                                     "activities",
+                                    "attractions",
                                     "stays",
                                     "cruises",
                                     "charters"
@@ -3391,7 +3392,7 @@
                               "additionalProperties": false
                             },
                             "minItems": 1,
-                            "maxItems": 7
+                            "maxItems": 8
                           }
                         },
                         "required": ["kind", "groups"],
@@ -3713,6 +3714,74 @@
                           "travelers"
                         ],
                         "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["cruise"]
+                          },
+                          "query": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 300
+                          },
+                          "departureDateFrom": {
+                            "type": "string",
+                            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                          },
+                          "departureDateTo": {
+                            "type": "string",
+                            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                          },
+                          "travelers": {
+                            "type": "object",
+                            "properties": {
+                              "adults": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 20
+                              },
+                              "childrenAges": {
+                                "type": "array",
+                                "items": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 17
+                                },
+                                "maxItems": 20
+                              },
+                              "infants": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 10
+                              },
+                              "seniors": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 20
+                              }
+                            },
+                            "required": ["adults"],
+                            "additionalProperties": false
+                          },
+                          "cruiseTypes": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": ["ocean", "river", "expedition", "coastal"]
+                            },
+                            "maxItems": 4
+                          },
+                          "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50
+                          }
+                        },
+                        "required": ["kind", "travelers"],
+                        "additionalProperties": false
                       }
                     ]
                   }
@@ -3804,6 +3873,7 @@
                                       "excursions",
                                       "experiences",
                                       "activities",
+                                      "attractions",
                                       "stays",
                                       "cruises",
                                       "charters"
@@ -3853,7 +3923,7 @@
                                               "properties": {
                                                 "amount": {
                                                   "type": "string",
-                                                  "minLength": 1
+                                                  "pattern": "^\\d+(?:\\.\\d+)?$"
                                                 },
                                                 "currency": {
                                                   "type": "string",
@@ -3868,7 +3938,7 @@
                                               "properties": {
                                                 "amount": {
                                                   "type": "string",
-                                                  "minLength": 1
+                                                  "pattern": "^\\d+(?:\\.\\d+)?$"
                                                 },
                                                 "currency": {
                                                   "type": "string",
@@ -3881,25 +3951,25 @@
                                             "fx": {
                                               "type": "object",
                                               "properties": {
-                                                "authority": {
+                                                "rate": {
+                                                  "type": "string",
+                                                  "pattern": "^(?:0*\\.[0-9]*[1-9][0-9]*|0*[1-9][0-9]*(?:\\.[0-9]+)?)$"
+                                                },
+                                                "provider": {
                                                   "type": "string",
                                                   "minLength": 1,
                                                   "maxLength": 128
-                                                },
-                                                "rate": {
-                                                  "type": "string",
-                                                  "minLength": 1
                                                 },
                                                 "quotedAt": {
                                                   "type": "string",
                                                   "format": "date-time"
                                                 },
                                                 "validUntil": {
-                                                  "type": "string",
+                                                  "type": ["string", "null"],
                                                   "format": "date-time"
                                                 }
                                               },
-                                              "required": ["authority", "rate", "quotedAt"],
+                                              "required": ["rate", "provider", "quotedAt"],
                                               "additionalProperties": false
                                             }
                                           },
@@ -4078,7 +4148,7 @@
                                         "properties": {
                                           "amount": {
                                             "type": "string",
-                                            "minLength": 1
+                                            "pattern": "^\\d+(?:\\.\\d+)?$"
                                           },
                                           "currency": {
                                             "type": "string",
@@ -4093,7 +4163,7 @@
                                         "properties": {
                                           "amount": {
                                             "type": "string",
-                                            "minLength": 1
+                                            "pattern": "^\\d+(?:\\.\\d+)?$"
                                           },
                                           "currency": {
                                             "type": "string",
@@ -4106,25 +4176,25 @@
                                       "fx": {
                                         "type": "object",
                                         "properties": {
-                                          "authority": {
+                                          "rate": {
+                                            "type": "string",
+                                            "pattern": "^(?:0*\\.[0-9]*[1-9][0-9]*|0*[1-9][0-9]*(?:\\.[0-9]+)?)$"
+                                          },
+                                          "provider": {
                                             "type": "string",
                                             "minLength": 1,
                                             "maxLength": 128
-                                          },
-                                          "rate": {
-                                            "type": "string",
-                                            "minLength": 1
                                           },
                                           "quotedAt": {
                                             "type": "string",
                                             "format": "date-time"
                                           },
                                           "validUntil": {
-                                            "type": "string",
+                                            "type": ["string", "null"],
                                             "format": "date-time"
                                           }
                                         },
-                                        "required": ["authority", "rate", "quotedAt"],
+                                        "required": ["rate", "provider", "quotedAt"],
                                         "additionalProperties": false
                                       }
                                     },
@@ -4287,7 +4357,7 @@
                                         "properties": {
                                           "amount": {
                                             "type": "string",
-                                            "minLength": 1
+                                            "pattern": "^\\d+(?:\\.\\d+)?$"
                                           },
                                           "currency": {
                                             "type": "string",
@@ -4302,7 +4372,7 @@
                                         "properties": {
                                           "amount": {
                                             "type": "string",
-                                            "minLength": 1
+                                            "pattern": "^\\d+(?:\\.\\d+)?$"
                                           },
                                           "currency": {
                                             "type": "string",
@@ -4315,25 +4385,25 @@
                                       "fx": {
                                         "type": "object",
                                         "properties": {
-                                          "authority": {
+                                          "rate": {
+                                            "type": "string",
+                                            "pattern": "^(?:0*\\.[0-9]*[1-9][0-9]*|0*[1-9][0-9]*(?:\\.[0-9]+)?)$"
+                                          },
+                                          "provider": {
                                             "type": "string",
                                             "minLength": 1,
                                             "maxLength": 128
-                                          },
-                                          "rate": {
-                                            "type": "string",
-                                            "minLength": 1
                                           },
                                           "quotedAt": {
                                             "type": "string",
                                             "format": "date-time"
                                           },
                                           "validUntil": {
-                                            "type": "string",
+                                            "type": ["string", "null"],
                                             "format": "date-time"
                                           }
                                         },
-                                        "required": ["authority", "rate", "quotedAt"],
+                                        "required": ["rate", "provider", "quotedAt"],
                                         "additionalProperties": false
                                       }
                                     },
@@ -4508,7 +4578,7 @@
                                         "properties": {
                                           "amount": {
                                             "type": "string",
-                                            "minLength": 1
+                                            "pattern": "^\\d+(?:\\.\\d+)?$"
                                           },
                                           "currency": {
                                             "type": "string",
@@ -4523,7 +4593,7 @@
                                         "properties": {
                                           "amount": {
                                             "type": "string",
-                                            "minLength": 1
+                                            "pattern": "^\\d+(?:\\.\\d+)?$"
                                           },
                                           "currency": {
                                             "type": "string",
@@ -4536,25 +4606,25 @@
                                       "fx": {
                                         "type": "object",
                                         "properties": {
-                                          "authority": {
+                                          "rate": {
+                                            "type": "string",
+                                            "pattern": "^(?:0*\\.[0-9]*[1-9][0-9]*|0*[1-9][0-9]*(?:\\.[0-9]+)?)$"
+                                          },
+                                          "provider": {
                                             "type": "string",
                                             "minLength": 1,
                                             "maxLength": 128
-                                          },
-                                          "rate": {
-                                            "type": "string",
-                                            "minLength": 1
                                           },
                                           "quotedAt": {
                                             "type": "string",
                                             "format": "date-time"
                                           },
                                           "validUntil": {
-                                            "type": "string",
+                                            "type": ["string", "null"],
                                             "format": "date-time"
                                           }
                                         },
-                                        "required": ["authority", "rate", "quotedAt"],
+                                        "required": ["rate", "provider", "quotedAt"],
                                         "additionalProperties": false
                                       }
                                     },
@@ -4606,6 +4676,242 @@
                               "type": "string",
                               "minLength": 16,
                               "maxLength": 512
+                            }
+                          },
+                          "required": ["kind", "scope", "offers", "coverage"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "enum": ["cruise"]
+                            },
+                            "scope": {
+                              "type": "object",
+                              "properties": {
+                                "marketId": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 128
+                                },
+                                "locale": {
+                                  "type": "string",
+                                  "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                                },
+                                "currency": {
+                                  "type": "string",
+                                  "pattern": "^[A-Z]{3}$"
+                                },
+                                "available": {
+                                  "type": "object",
+                                  "properties": {
+                                    "marketIds": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "maxLength": 128
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "locales": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "currencies": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Z]{3}$"
+                                      },
+                                      "minItems": 1
+                                    }
+                                  },
+                                  "required": ["marketIds", "locales", "currencies"],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": ["marketId", "locale", "currency", "available"],
+                              "additionalProperties": false
+                            },
+                            "offers": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "offerRef": {
+                                    "type": "string",
+                                    "minLength": 16,
+                                    "maxLength": 512
+                                  },
+                                  "title": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "cruiseType": {
+                                    "type": "string",
+                                    "enum": ["ocean", "river", "expedition", "coastal"]
+                                  },
+                                  "lineName": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "shipName": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "departureDate": {
+                                    "type": "string",
+                                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                                  },
+                                  "returnDate": {
+                                    "type": "string",
+                                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                                  },
+                                  "nights": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                  },
+                                  "embarkPortName": {
+                                    "type": "string"
+                                  },
+                                  "disembarkPortName": {
+                                    "type": "string"
+                                  },
+                                  "cabinName": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "availability": {
+                                    "type": "string",
+                                    "enum": ["available", "limited"]
+                                  },
+                                  "image": {
+                                    "type": "object",
+                                    "properties": {
+                                      "url": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      },
+                                      "alt": {
+                                        "type": "string",
+                                        "maxLength": 300
+                                      }
+                                    },
+                                    "required": ["url"],
+                                    "additionalProperties": false
+                                  },
+                                  "price": {
+                                    "type": "object",
+                                    "properties": {
+                                      "native": {
+                                        "type": "object",
+                                        "properties": {
+                                          "amount": {
+                                            "type": "string",
+                                            "pattern": "^\\d+(?:\\.\\d+)?$"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "pattern": "^[A-Z]{3}$"
+                                          }
+                                        },
+                                        "required": ["amount", "currency"],
+                                        "additionalProperties": false
+                                      },
+                                      "presentation": {
+                                        "type": "object",
+                                        "properties": {
+                                          "amount": {
+                                            "type": "string",
+                                            "pattern": "^\\d+(?:\\.\\d+)?$"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "pattern": "^[A-Z]{3}$"
+                                          }
+                                        },
+                                        "required": ["amount", "currency"],
+                                        "additionalProperties": false
+                                      },
+                                      "fx": {
+                                        "type": "object",
+                                        "properties": {
+                                          "rate": {
+                                            "type": "string",
+                                            "pattern": "^(?:0*\\.[0-9]*[1-9][0-9]*|0*[1-9][0-9]*(?:\\.[0-9]+)?)$"
+                                          },
+                                          "provider": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128
+                                          },
+                                          "quotedAt": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          },
+                                          "validUntil": {
+                                            "type": ["string", "null"],
+                                            "format": "date-time"
+                                          }
+                                        },
+                                        "required": ["rate", "provider", "quotedAt"],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": ["native", "presentation"],
+                                    "additionalProperties": false
+                                  },
+                                  "expiresAt": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  }
+                                },
+                                "required": [
+                                  "offerRef",
+                                  "title",
+                                  "cruiseType",
+                                  "lineName",
+                                  "shipName",
+                                  "departureDate",
+                                  "returnDate",
+                                  "nights",
+                                  "cabinName",
+                                  "availability",
+                                  "price",
+                                  "expiresAt"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "coverage": {
+                              "type": "object",
+                              "properties": {
+                                "status": {
+                                  "type": "string",
+                                  "enum": ["complete", "partial", "unavailable"]
+                                },
+                                "succeeded": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "failed": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "timedOut": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["status", "succeeded", "failed", "timedOut"],
+                              "additionalProperties": false
                             }
                           },
                           "required": ["kind", "scope", "offers", "coverage"],
@@ -4752,7 +5058,7 @@
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["product", "flight", "stay", "package"]
+                          "enum": ["product", "flight", "stay", "package", "cruise"]
                         },
                         "offerRef": {
                           "type": "string",
@@ -4862,7 +5168,7 @@
                               },
                               "kind": {
                                 "type": "string",
-                                "enum": ["product", "flight", "stay", "package"]
+                                "enum": ["product", "flight", "stay", "package", "cruise"]
                               },
                               "quantity": {
                                 "type": "integer",
@@ -5012,7 +5318,7 @@
                             "properties": {
                               "kind": {
                                 "type": "string",
-                                "enum": ["product", "flight", "stay", "package"]
+                                "enum": ["product", "flight", "stay", "package", "cruise"]
                               },
                               "offerRef": {
                                 "type": "string",
@@ -5162,7 +5468,7 @@
                               },
                               "kind": {
                                 "type": "string",
-                                "enum": ["product", "flight", "stay", "package"]
+                                "enum": ["product", "flight", "stay", "package", "cruise"]
                               },
                               "quantity": {
                                 "type": "integer",
@@ -5295,6 +5601,14982 @@
         },
         "operationId": "patchPublicShoppingTripSelections",
         "summary": "PATCH /v1/public/shopping/trip-selections",
+        "tags": ["shopping"],
+        "x-voyant-module": "shopping",
+        "x-voyant-surface": "public-api",
+        "x-voyant-package-name": "@voyant-travel/public-api"
+      }
+    },
+    "/v1/public/shopping/trip-selections/book": {
+      "post": {
+        "x-voyant-api-id": "@voyant-travel/public-api#api.public",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "selectionRef": {
+                    "type": "string",
+                    "minLength": 16,
+                    "maxLength": 512
+                  },
+                  "expectedRevision": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "idempotencyKey": {
+                    "type": "string",
+                    "minLength": 8,
+                    "maxLength": 128
+                  }
+                },
+                "required": ["selectionRef", "expectedRevision", "idempotencyKey"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "A managed composite Booking Session for the exact Trip revision",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "bookingSessionCapability": {
+                          "type": "string",
+                          "pattern": "^bcap_[A-Za-z0-9_-]{43,}$"
+                        },
+                        "outcome": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["session_created"]
+                                },
+                                "session": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "target": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["product"]
+                                            },
+                                            "productId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "productId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["catalog_item"]
+                                            },
+                                            "catalogItemId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "catalogItemId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["owned_entity"]
+                                            },
+                                            "entityModule": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "entityId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "entityModule", "entityId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["trip_snapshot"]
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripEnvelopeId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["managed_itinerary"]
+                                            }
+                                          },
+                                          "required": ["kind"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "origin": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["accepted_proposal_version"]
+                                            },
+                                            "proposalId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "proposalVersionId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": [
+                                            "kind",
+                                            "proposalId",
+                                            "proposalVersionId",
+                                            "tripSnapshotId"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "actorKind": {
+                                      "type": "string",
+                                      "enum": ["anonymous", "customer", "staff", "partner"]
+                                    },
+                                    "state": {
+                                      "type": "string",
+                                      "enum": [
+                                        "active",
+                                        "supplier_pending",
+                                        "component_pending",
+                                        "consumed",
+                                        "expired",
+                                        "abandoned"
+                                      ]
+                                    },
+                                    "revision": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "scope": {
+                                      "type": "object",
+                                      "properties": {
+                                        "locale": {
+                                          "type": "string",
+                                          "minLength": 2
+                                        },
+                                        "market": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "currency": {
+                                          "type": "string",
+                                          "minLength": 3,
+                                          "maxLength": 3
+                                        }
+                                      },
+                                      "required": ["locale", "market"]
+                                    },
+                                    "requirements": {
+                                      "type": "object",
+                                      "properties": {
+                                        "showsConfigure": {
+                                          "type": "boolean"
+                                        },
+                                        "showsBilling": {
+                                          "type": "boolean"
+                                        },
+                                        "showsTravelers": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAccommodation": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAddons": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAncillaries": {
+                                          "type": "boolean",
+                                          "default": false
+                                        },
+                                        "showsPayment": {
+                                          "type": "boolean"
+                                        },
+                                        "showsReview": {
+                                          "type": "boolean",
+                                          "enum": [true]
+                                        },
+                                        "configureSubSteps": {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["departure"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean",
+                                                    "enum": [true]
+                                                  }
+                                                },
+                                                "required": ["kind", "required"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["product-option"]
+                                                  },
+                                                  "options": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "isDefault": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "units": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "id": {
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "unitType": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "minQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              },
+                                                              "maxQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              }
+                                                            },
+                                                            "required": ["id", "name"]
+                                                          }
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "options"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["option-units"]
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-category"]
+                                                  },
+                                                  "categories": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": {
+                                                          "type": "string"
+                                                        },
+                                                        "capacityMin": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "capacityMax": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "description": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "categories"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-number"]
+                                                  },
+                                                  "perCategory": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "id": {
+                                                            "type": "string"
+                                                          },
+                                                          "code": {
+                                                            "type": "string"
+                                                          },
+                                                          "label": {
+                                                            "type": "string"
+                                                          },
+                                                          "capacity": {
+                                                            "type": "integer",
+                                                            "minimum": 0
+                                                          },
+                                                          "hasAccessibilityFeatures": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": ["id", "label"]
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "perCategory"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["date-range"]
+                                                  },
+                                                  "minNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  },
+                                                  "maxNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  }
+                                                },
+                                                "required": ["kind", "minNights", "maxNights"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["occupancy"]
+                                                  },
+                                                  "bands": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "label": {
+                                                          "type": "string"
+                                                        },
+                                                        "minAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "minCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "code",
+                                                        "label",
+                                                        "minCount",
+                                                        "maxCount"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "bands"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["air-arrangement"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "paxBands": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "minAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "minCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["code", "label", "minCount", "maxCount"]
+                                          }
+                                        },
+                                        "paxBandsAllowedTotal": {
+                                          "type": "object",
+                                          "properties": {
+                                            "min": {
+                                              "type": "integer"
+                                            },
+                                            "max": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": ["min", "max"]
+                                        },
+                                        "paxBandDependencies": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "dependentCode": {
+                                                "type": "string"
+                                              },
+                                              "masterCode": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "requires",
+                                                  "limits_per_master",
+                                                  "limits_sum",
+                                                  "excludes"
+                                                ]
+                                              },
+                                              "maxPerMaster": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxDependentSum": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["dependentCode", "masterCode", "type"]
+                                          }
+                                        },
+                                        "travelerFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "options": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["value", "label"]
+                                                }
+                                              },
+                                              "appliesToBands": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": ["key", "label", "type", "required"]
+                                          }
+                                        },
+                                        "bookingFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "group": {
+                                                "type": "string",
+                                                "enum": ["billing", "company", "preferences"]
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "label",
+                                              "type",
+                                              "required",
+                                              "group"
+                                            ]
+                                          }
+                                        },
+                                        "accommodation": {
+                                          "type": "object",
+                                          "properties": {
+                                            "roomOptions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "capacity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "baseRateHint": {
+                                                    "type": ["number", "null"]
+                                                  },
+                                                  "ratePlans": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "chargeFrequency": {
+                                                          "type": "string",
+                                                          "enum": ["per_night", "per_stay"]
+                                                        },
+                                                        "cancellationPolicy": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "inclusions": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "currency": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["id", "name"]
+                                              }
+                                            },
+                                            "sharedRoomAllowed": {
+                                              "type": "boolean"
+                                            },
+                                            "subSteps": {
+                                              "type": "array",
+                                              "items": {
+                                                "oneOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["rooms"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "description": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "capacity": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "baseRateHint": {
+                                                              "type": ["number", "null"]
+                                                            },
+                                                            "ratePlans": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "id": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "name": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "chargeFrequency": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "per_night",
+                                                                      "per_stay"
+                                                                    ]
+                                                                  },
+                                                                  "cancellationPolicy": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "inclusions": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "currency": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["id", "name"]
+                                                              }
+                                                            }
+                                                          },
+                                                          "required": ["id", "name"]
+                                                        }
+                                                      },
+                                                      "sharedRoomAllowed": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "sharedRoomAllowed"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["extensions"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "city": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "side": {
+                                                              "type": "string",
+                                                              "enum": ["pre", "post"]
+                                                            },
+                                                            "nights": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "pricePerPersonHint": {
+                                                              "type": ["number", "null"]
+                                                            }
+                                                          },
+                                                          "required": ["id", "name", "side"]
+                                                        }
+                                                      },
+                                                      "allowsPre": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "allowsPost": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "allowsPre",
+                                                      "allowsPost"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": ["sharedRoomAllowed"]
+                                        },
+                                        "addons": {
+                                          "type": "object",
+                                          "properties": {
+                                            "catalog": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "groupKey": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricingMode": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "unitAmountCents": {
+                                                    "type": ["integer", "null"]
+                                                  },
+                                                  "currency": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricedPerPerson": {
+                                                    "type": ["boolean", "null"]
+                                                  },
+                                                  "selectionType": {
+                                                    "type": ["string", "null"],
+                                                    "enum": [
+                                                      "optional",
+                                                      "required",
+                                                      "default_selected",
+                                                      "unavailable",
+                                                      null
+                                                    ]
+                                                  },
+                                                  "minQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "maxQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "defaultQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  }
+                                                },
+                                                "required": ["id", "name", "kind"]
+                                              }
+                                            },
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "groupBy": {
+                                                    "type": "string",
+                                                    "enum": ["port", "day"]
+                                                  },
+                                                  "perGuestSelection": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "kind": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "extras",
+                                                            "excursions",
+                                                            "insurance"
+                                                          ]
+                                                        },
+                                                        "groupKey": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricingMode": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "unitAmountCents": {
+                                                          "type": ["integer", "null"]
+                                                        },
+                                                        "currency": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": ["boolean", "null"]
+                                                        },
+                                                        "selectionType": {
+                                                          "type": ["string", "null"],
+                                                          "enum": [
+                                                            "optional",
+                                                            "required",
+                                                            "default_selected",
+                                                            "unavailable",
+                                                            null
+                                                          ]
+                                                        },
+                                                        "minQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "maxQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "defaultQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["id", "name", "kind"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": [
+                                                  "kind",
+                                                  "label",
+                                                  "perGuestSelection",
+                                                  "items"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "ancillaries": {
+                                          "type": "object",
+                                          "properties": {
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "offers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "offerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerLabel": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "title": {
+                                                          "type": "string"
+                                                        },
+                                                        "summary": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "planLabel": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "price": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "amountMinor": {
+                                                              "type": "integer"
+                                                            },
+                                                            "currency": {
+                                                              "type": "string",
+                                                              "pattern": "^[A-Z]{3}$"
+                                                            }
+                                                          },
+                                                          "required": ["amountMinor", "currency"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": "boolean",
+                                                          "default": false
+                                                        },
+                                                        "highlights": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": ["label"],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "eligibility": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "status": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "eligible",
+                                                                "ineligible",
+                                                                "referral"
+                                                              ]
+                                                            },
+                                                            "reasons": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "code": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "message": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["code", "message"],
+                                                                "additionalProperties": false
+                                                              },
+                                                              "default": []
+                                                            }
+                                                          },
+                                                          "required": ["status"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "disclosures": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "kind": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "versionId": {
+                                                                "type": "string"
+                                                              },
+                                                              "url": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "kind",
+                                                              "label",
+                                                              "versionId",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "requiredTravelerFields": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "key": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              },
+                                                              "sensitive": {
+                                                                "type": "boolean",
+                                                                "default": false
+                                                              },
+                                                              "options": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "value": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "label": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "required": ["value", "label"],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "helpText": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key",
+                                                              "label",
+                                                              "type",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "validUntil": {
+                                                          "type": "string"
+                                                        },
+                                                        "quoteRef": {
+                                                          "type": "string"
+                                                        },
+                                                        "metadata": {
+                                                          "type": "object",
+                                                          "additionalProperties": {}
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "offerId",
+                                                        "sourceId",
+                                                        "providerId",
+                                                        "providerLabel",
+                                                        "kind",
+                                                        "title",
+                                                        "price",
+                                                        "eligibility",
+                                                        "validUntil",
+                                                        "quoteRef"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  },
+                                                  "diagnostics": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "status": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "ok",
+                                                            "timeout",
+                                                            "error",
+                                                            "unavailable"
+                                                          ]
+                                                        },
+                                                        "message": {
+                                                          "type": "string"
+                                                        },
+                                                        "latencyMs": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["sourceId", "status"],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  }
+                                                },
+                                                "required": ["kind", "label"],
+                                                "additionalProperties": false
+                                              },
+                                              "default": []
+                                            }
+                                          }
+                                        },
+                                        "paymentIntents": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string",
+                                            "enum": [
+                                              "hold",
+                                              "card",
+                                              "bank_transfer",
+                                              "ticket_on_credit",
+                                              "inquiry"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "showsConfigure",
+                                        "showsBilling",
+                                        "showsTravelers",
+                                        "showsAccommodation",
+                                        "showsAddons",
+                                        "showsPayment",
+                                        "showsReview",
+                                        "paxBands",
+                                        "paxBandsAllowedTotal",
+                                        "travelerFields",
+                                        "bookingFields",
+                                        "paymentIntents"
+                                      ]
+                                    },
+                                    "requirementsFingerprint": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "expiresAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "target",
+                                    "actorKind",
+                                    "state",
+                                    "revision",
+                                    "scope",
+                                    "expiresAt",
+                                    "createdAt",
+                                    "updatedAt"
+                                  ]
+                                }
+                              },
+                              "required": ["kind", "session"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["session_updated"]
+                                },
+                                "session": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "target": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["product"]
+                                            },
+                                            "productId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "productId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["catalog_item"]
+                                            },
+                                            "catalogItemId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "catalogItemId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["owned_entity"]
+                                            },
+                                            "entityModule": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "entityId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "entityModule", "entityId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["trip_snapshot"]
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripEnvelopeId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["managed_itinerary"]
+                                            }
+                                          },
+                                          "required": ["kind"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "origin": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["accepted_proposal_version"]
+                                            },
+                                            "proposalId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "proposalVersionId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": [
+                                            "kind",
+                                            "proposalId",
+                                            "proposalVersionId",
+                                            "tripSnapshotId"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "actorKind": {
+                                      "type": "string",
+                                      "enum": ["anonymous", "customer", "staff", "partner"]
+                                    },
+                                    "state": {
+                                      "type": "string",
+                                      "enum": [
+                                        "active",
+                                        "supplier_pending",
+                                        "component_pending",
+                                        "consumed",
+                                        "expired",
+                                        "abandoned"
+                                      ]
+                                    },
+                                    "revision": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "scope": {
+                                      "type": "object",
+                                      "properties": {
+                                        "locale": {
+                                          "type": "string",
+                                          "minLength": 2
+                                        },
+                                        "market": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "currency": {
+                                          "type": "string",
+                                          "minLength": 3,
+                                          "maxLength": 3
+                                        }
+                                      },
+                                      "required": ["locale", "market"]
+                                    },
+                                    "requirements": {
+                                      "type": "object",
+                                      "properties": {
+                                        "showsConfigure": {
+                                          "type": "boolean"
+                                        },
+                                        "showsBilling": {
+                                          "type": "boolean"
+                                        },
+                                        "showsTravelers": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAccommodation": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAddons": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAncillaries": {
+                                          "type": "boolean",
+                                          "default": false
+                                        },
+                                        "showsPayment": {
+                                          "type": "boolean"
+                                        },
+                                        "showsReview": {
+                                          "type": "boolean",
+                                          "enum": [true]
+                                        },
+                                        "configureSubSteps": {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["departure"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean",
+                                                    "enum": [true]
+                                                  }
+                                                },
+                                                "required": ["kind", "required"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["product-option"]
+                                                  },
+                                                  "options": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "isDefault": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "units": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "id": {
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "unitType": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "minQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              },
+                                                              "maxQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              }
+                                                            },
+                                                            "required": ["id", "name"]
+                                                          }
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "options"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["option-units"]
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-category"]
+                                                  },
+                                                  "categories": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": {
+                                                          "type": "string"
+                                                        },
+                                                        "capacityMin": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "capacityMax": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "description": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "categories"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-number"]
+                                                  },
+                                                  "perCategory": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "id": {
+                                                            "type": "string"
+                                                          },
+                                                          "code": {
+                                                            "type": "string"
+                                                          },
+                                                          "label": {
+                                                            "type": "string"
+                                                          },
+                                                          "capacity": {
+                                                            "type": "integer",
+                                                            "minimum": 0
+                                                          },
+                                                          "hasAccessibilityFeatures": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": ["id", "label"]
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "perCategory"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["date-range"]
+                                                  },
+                                                  "minNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  },
+                                                  "maxNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  }
+                                                },
+                                                "required": ["kind", "minNights", "maxNights"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["occupancy"]
+                                                  },
+                                                  "bands": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "label": {
+                                                          "type": "string"
+                                                        },
+                                                        "minAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "minCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "code",
+                                                        "label",
+                                                        "minCount",
+                                                        "maxCount"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "bands"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["air-arrangement"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "paxBands": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "minAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "minCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["code", "label", "minCount", "maxCount"]
+                                          }
+                                        },
+                                        "paxBandsAllowedTotal": {
+                                          "type": "object",
+                                          "properties": {
+                                            "min": {
+                                              "type": "integer"
+                                            },
+                                            "max": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": ["min", "max"]
+                                        },
+                                        "paxBandDependencies": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "dependentCode": {
+                                                "type": "string"
+                                              },
+                                              "masterCode": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "requires",
+                                                  "limits_per_master",
+                                                  "limits_sum",
+                                                  "excludes"
+                                                ]
+                                              },
+                                              "maxPerMaster": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxDependentSum": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["dependentCode", "masterCode", "type"]
+                                          }
+                                        },
+                                        "travelerFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "options": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["value", "label"]
+                                                }
+                                              },
+                                              "appliesToBands": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": ["key", "label", "type", "required"]
+                                          }
+                                        },
+                                        "bookingFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "group": {
+                                                "type": "string",
+                                                "enum": ["billing", "company", "preferences"]
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "label",
+                                              "type",
+                                              "required",
+                                              "group"
+                                            ]
+                                          }
+                                        },
+                                        "accommodation": {
+                                          "type": "object",
+                                          "properties": {
+                                            "roomOptions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "capacity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "baseRateHint": {
+                                                    "type": ["number", "null"]
+                                                  },
+                                                  "ratePlans": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "chargeFrequency": {
+                                                          "type": "string",
+                                                          "enum": ["per_night", "per_stay"]
+                                                        },
+                                                        "cancellationPolicy": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "inclusions": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "currency": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["id", "name"]
+                                              }
+                                            },
+                                            "sharedRoomAllowed": {
+                                              "type": "boolean"
+                                            },
+                                            "subSteps": {
+                                              "type": "array",
+                                              "items": {
+                                                "oneOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["rooms"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "description": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "capacity": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "baseRateHint": {
+                                                              "type": ["number", "null"]
+                                                            },
+                                                            "ratePlans": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "id": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "name": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "chargeFrequency": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "per_night",
+                                                                      "per_stay"
+                                                                    ]
+                                                                  },
+                                                                  "cancellationPolicy": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "inclusions": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "currency": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["id", "name"]
+                                                              }
+                                                            }
+                                                          },
+                                                          "required": ["id", "name"]
+                                                        }
+                                                      },
+                                                      "sharedRoomAllowed": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "sharedRoomAllowed"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["extensions"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "city": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "side": {
+                                                              "type": "string",
+                                                              "enum": ["pre", "post"]
+                                                            },
+                                                            "nights": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "pricePerPersonHint": {
+                                                              "type": ["number", "null"]
+                                                            }
+                                                          },
+                                                          "required": ["id", "name", "side"]
+                                                        }
+                                                      },
+                                                      "allowsPre": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "allowsPost": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "allowsPre",
+                                                      "allowsPost"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": ["sharedRoomAllowed"]
+                                        },
+                                        "addons": {
+                                          "type": "object",
+                                          "properties": {
+                                            "catalog": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "groupKey": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricingMode": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "unitAmountCents": {
+                                                    "type": ["integer", "null"]
+                                                  },
+                                                  "currency": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricedPerPerson": {
+                                                    "type": ["boolean", "null"]
+                                                  },
+                                                  "selectionType": {
+                                                    "type": ["string", "null"],
+                                                    "enum": [
+                                                      "optional",
+                                                      "required",
+                                                      "default_selected",
+                                                      "unavailable",
+                                                      null
+                                                    ]
+                                                  },
+                                                  "minQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "maxQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "defaultQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  }
+                                                },
+                                                "required": ["id", "name", "kind"]
+                                              }
+                                            },
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "groupBy": {
+                                                    "type": "string",
+                                                    "enum": ["port", "day"]
+                                                  },
+                                                  "perGuestSelection": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "kind": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "extras",
+                                                            "excursions",
+                                                            "insurance"
+                                                          ]
+                                                        },
+                                                        "groupKey": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricingMode": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "unitAmountCents": {
+                                                          "type": ["integer", "null"]
+                                                        },
+                                                        "currency": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": ["boolean", "null"]
+                                                        },
+                                                        "selectionType": {
+                                                          "type": ["string", "null"],
+                                                          "enum": [
+                                                            "optional",
+                                                            "required",
+                                                            "default_selected",
+                                                            "unavailable",
+                                                            null
+                                                          ]
+                                                        },
+                                                        "minQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "maxQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "defaultQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["id", "name", "kind"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": [
+                                                  "kind",
+                                                  "label",
+                                                  "perGuestSelection",
+                                                  "items"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "ancillaries": {
+                                          "type": "object",
+                                          "properties": {
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "offers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "offerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerLabel": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "title": {
+                                                          "type": "string"
+                                                        },
+                                                        "summary": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "planLabel": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "price": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "amountMinor": {
+                                                              "type": "integer"
+                                                            },
+                                                            "currency": {
+                                                              "type": "string",
+                                                              "pattern": "^[A-Z]{3}$"
+                                                            }
+                                                          },
+                                                          "required": ["amountMinor", "currency"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": "boolean",
+                                                          "default": false
+                                                        },
+                                                        "highlights": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": ["label"],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "eligibility": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "status": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "eligible",
+                                                                "ineligible",
+                                                                "referral"
+                                                              ]
+                                                            },
+                                                            "reasons": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "code": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "message": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["code", "message"],
+                                                                "additionalProperties": false
+                                                              },
+                                                              "default": []
+                                                            }
+                                                          },
+                                                          "required": ["status"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "disclosures": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "kind": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "versionId": {
+                                                                "type": "string"
+                                                              },
+                                                              "url": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "kind",
+                                                              "label",
+                                                              "versionId",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "requiredTravelerFields": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "key": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              },
+                                                              "sensitive": {
+                                                                "type": "boolean",
+                                                                "default": false
+                                                              },
+                                                              "options": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "value": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "label": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "required": ["value", "label"],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "helpText": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key",
+                                                              "label",
+                                                              "type",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "validUntil": {
+                                                          "type": "string"
+                                                        },
+                                                        "quoteRef": {
+                                                          "type": "string"
+                                                        },
+                                                        "metadata": {
+                                                          "type": "object",
+                                                          "additionalProperties": {}
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "offerId",
+                                                        "sourceId",
+                                                        "providerId",
+                                                        "providerLabel",
+                                                        "kind",
+                                                        "title",
+                                                        "price",
+                                                        "eligibility",
+                                                        "validUntil",
+                                                        "quoteRef"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  },
+                                                  "diagnostics": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "status": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "ok",
+                                                            "timeout",
+                                                            "error",
+                                                            "unavailable"
+                                                          ]
+                                                        },
+                                                        "message": {
+                                                          "type": "string"
+                                                        },
+                                                        "latencyMs": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["sourceId", "status"],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  }
+                                                },
+                                                "required": ["kind", "label"],
+                                                "additionalProperties": false
+                                              },
+                                              "default": []
+                                            }
+                                          }
+                                        },
+                                        "paymentIntents": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string",
+                                            "enum": [
+                                              "hold",
+                                              "card",
+                                              "bank_transfer",
+                                              "ticket_on_credit",
+                                              "inquiry"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "showsConfigure",
+                                        "showsBilling",
+                                        "showsTravelers",
+                                        "showsAccommodation",
+                                        "showsAddons",
+                                        "showsPayment",
+                                        "showsReview",
+                                        "paxBands",
+                                        "paxBandsAllowedTotal",
+                                        "travelerFields",
+                                        "bookingFields",
+                                        "paymentIntents"
+                                      ]
+                                    },
+                                    "requirementsFingerprint": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "expiresAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "target",
+                                    "actorKind",
+                                    "state",
+                                    "revision",
+                                    "scope",
+                                    "expiresAt",
+                                    "createdAt",
+                                    "updatedAt"
+                                  ]
+                                }
+                              },
+                              "required": ["kind", "session"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["session_resumed"]
+                                },
+                                "session": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "target": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["product"]
+                                            },
+                                            "productId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "productId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["catalog_item"]
+                                            },
+                                            "catalogItemId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "catalogItemId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["owned_entity"]
+                                            },
+                                            "entityModule": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "entityId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "entityModule", "entityId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["trip_snapshot"]
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripEnvelopeId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["managed_itinerary"]
+                                            }
+                                          },
+                                          "required": ["kind"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "origin": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["accepted_proposal_version"]
+                                            },
+                                            "proposalId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "proposalVersionId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": [
+                                            "kind",
+                                            "proposalId",
+                                            "proposalVersionId",
+                                            "tripSnapshotId"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "actorKind": {
+                                      "type": "string",
+                                      "enum": ["anonymous", "customer", "staff", "partner"]
+                                    },
+                                    "state": {
+                                      "type": "string",
+                                      "enum": [
+                                        "active",
+                                        "supplier_pending",
+                                        "component_pending",
+                                        "consumed",
+                                        "expired",
+                                        "abandoned"
+                                      ]
+                                    },
+                                    "revision": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "scope": {
+                                      "type": "object",
+                                      "properties": {
+                                        "locale": {
+                                          "type": "string",
+                                          "minLength": 2
+                                        },
+                                        "market": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "currency": {
+                                          "type": "string",
+                                          "minLength": 3,
+                                          "maxLength": 3
+                                        }
+                                      },
+                                      "required": ["locale", "market"]
+                                    },
+                                    "requirements": {
+                                      "type": "object",
+                                      "properties": {
+                                        "showsConfigure": {
+                                          "type": "boolean"
+                                        },
+                                        "showsBilling": {
+                                          "type": "boolean"
+                                        },
+                                        "showsTravelers": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAccommodation": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAddons": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAncillaries": {
+                                          "type": "boolean",
+                                          "default": false
+                                        },
+                                        "showsPayment": {
+                                          "type": "boolean"
+                                        },
+                                        "showsReview": {
+                                          "type": "boolean",
+                                          "enum": [true]
+                                        },
+                                        "configureSubSteps": {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["departure"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean",
+                                                    "enum": [true]
+                                                  }
+                                                },
+                                                "required": ["kind", "required"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["product-option"]
+                                                  },
+                                                  "options": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "isDefault": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "units": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "id": {
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "unitType": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "minQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              },
+                                                              "maxQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              }
+                                                            },
+                                                            "required": ["id", "name"]
+                                                          }
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "options"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["option-units"]
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-category"]
+                                                  },
+                                                  "categories": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": {
+                                                          "type": "string"
+                                                        },
+                                                        "capacityMin": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "capacityMax": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "description": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "categories"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-number"]
+                                                  },
+                                                  "perCategory": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "id": {
+                                                            "type": "string"
+                                                          },
+                                                          "code": {
+                                                            "type": "string"
+                                                          },
+                                                          "label": {
+                                                            "type": "string"
+                                                          },
+                                                          "capacity": {
+                                                            "type": "integer",
+                                                            "minimum": 0
+                                                          },
+                                                          "hasAccessibilityFeatures": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": ["id", "label"]
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "perCategory"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["date-range"]
+                                                  },
+                                                  "minNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  },
+                                                  "maxNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  }
+                                                },
+                                                "required": ["kind", "minNights", "maxNights"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["occupancy"]
+                                                  },
+                                                  "bands": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "label": {
+                                                          "type": "string"
+                                                        },
+                                                        "minAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "minCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "code",
+                                                        "label",
+                                                        "minCount",
+                                                        "maxCount"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "bands"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["air-arrangement"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "paxBands": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "minAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "minCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["code", "label", "minCount", "maxCount"]
+                                          }
+                                        },
+                                        "paxBandsAllowedTotal": {
+                                          "type": "object",
+                                          "properties": {
+                                            "min": {
+                                              "type": "integer"
+                                            },
+                                            "max": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": ["min", "max"]
+                                        },
+                                        "paxBandDependencies": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "dependentCode": {
+                                                "type": "string"
+                                              },
+                                              "masterCode": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "requires",
+                                                  "limits_per_master",
+                                                  "limits_sum",
+                                                  "excludes"
+                                                ]
+                                              },
+                                              "maxPerMaster": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxDependentSum": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["dependentCode", "masterCode", "type"]
+                                          }
+                                        },
+                                        "travelerFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "options": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["value", "label"]
+                                                }
+                                              },
+                                              "appliesToBands": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": ["key", "label", "type", "required"]
+                                          }
+                                        },
+                                        "bookingFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "group": {
+                                                "type": "string",
+                                                "enum": ["billing", "company", "preferences"]
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "label",
+                                              "type",
+                                              "required",
+                                              "group"
+                                            ]
+                                          }
+                                        },
+                                        "accommodation": {
+                                          "type": "object",
+                                          "properties": {
+                                            "roomOptions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "capacity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "baseRateHint": {
+                                                    "type": ["number", "null"]
+                                                  },
+                                                  "ratePlans": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "chargeFrequency": {
+                                                          "type": "string",
+                                                          "enum": ["per_night", "per_stay"]
+                                                        },
+                                                        "cancellationPolicy": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "inclusions": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "currency": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["id", "name"]
+                                              }
+                                            },
+                                            "sharedRoomAllowed": {
+                                              "type": "boolean"
+                                            },
+                                            "subSteps": {
+                                              "type": "array",
+                                              "items": {
+                                                "oneOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["rooms"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "description": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "capacity": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "baseRateHint": {
+                                                              "type": ["number", "null"]
+                                                            },
+                                                            "ratePlans": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "id": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "name": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "chargeFrequency": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "per_night",
+                                                                      "per_stay"
+                                                                    ]
+                                                                  },
+                                                                  "cancellationPolicy": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "inclusions": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "currency": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["id", "name"]
+                                                              }
+                                                            }
+                                                          },
+                                                          "required": ["id", "name"]
+                                                        }
+                                                      },
+                                                      "sharedRoomAllowed": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "sharedRoomAllowed"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["extensions"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "city": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "side": {
+                                                              "type": "string",
+                                                              "enum": ["pre", "post"]
+                                                            },
+                                                            "nights": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "pricePerPersonHint": {
+                                                              "type": ["number", "null"]
+                                                            }
+                                                          },
+                                                          "required": ["id", "name", "side"]
+                                                        }
+                                                      },
+                                                      "allowsPre": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "allowsPost": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "allowsPre",
+                                                      "allowsPost"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": ["sharedRoomAllowed"]
+                                        },
+                                        "addons": {
+                                          "type": "object",
+                                          "properties": {
+                                            "catalog": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "groupKey": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricingMode": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "unitAmountCents": {
+                                                    "type": ["integer", "null"]
+                                                  },
+                                                  "currency": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricedPerPerson": {
+                                                    "type": ["boolean", "null"]
+                                                  },
+                                                  "selectionType": {
+                                                    "type": ["string", "null"],
+                                                    "enum": [
+                                                      "optional",
+                                                      "required",
+                                                      "default_selected",
+                                                      "unavailable",
+                                                      null
+                                                    ]
+                                                  },
+                                                  "minQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "maxQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "defaultQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  }
+                                                },
+                                                "required": ["id", "name", "kind"]
+                                              }
+                                            },
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "groupBy": {
+                                                    "type": "string",
+                                                    "enum": ["port", "day"]
+                                                  },
+                                                  "perGuestSelection": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "kind": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "extras",
+                                                            "excursions",
+                                                            "insurance"
+                                                          ]
+                                                        },
+                                                        "groupKey": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricingMode": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "unitAmountCents": {
+                                                          "type": ["integer", "null"]
+                                                        },
+                                                        "currency": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": ["boolean", "null"]
+                                                        },
+                                                        "selectionType": {
+                                                          "type": ["string", "null"],
+                                                          "enum": [
+                                                            "optional",
+                                                            "required",
+                                                            "default_selected",
+                                                            "unavailable",
+                                                            null
+                                                          ]
+                                                        },
+                                                        "minQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "maxQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "defaultQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["id", "name", "kind"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": [
+                                                  "kind",
+                                                  "label",
+                                                  "perGuestSelection",
+                                                  "items"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "ancillaries": {
+                                          "type": "object",
+                                          "properties": {
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "offers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "offerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerLabel": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "title": {
+                                                          "type": "string"
+                                                        },
+                                                        "summary": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "planLabel": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "price": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "amountMinor": {
+                                                              "type": "integer"
+                                                            },
+                                                            "currency": {
+                                                              "type": "string",
+                                                              "pattern": "^[A-Z]{3}$"
+                                                            }
+                                                          },
+                                                          "required": ["amountMinor", "currency"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": "boolean",
+                                                          "default": false
+                                                        },
+                                                        "highlights": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": ["label"],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "eligibility": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "status": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "eligible",
+                                                                "ineligible",
+                                                                "referral"
+                                                              ]
+                                                            },
+                                                            "reasons": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "code": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "message": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["code", "message"],
+                                                                "additionalProperties": false
+                                                              },
+                                                              "default": []
+                                                            }
+                                                          },
+                                                          "required": ["status"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "disclosures": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "kind": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "versionId": {
+                                                                "type": "string"
+                                                              },
+                                                              "url": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "kind",
+                                                              "label",
+                                                              "versionId",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "requiredTravelerFields": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "key": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              },
+                                                              "sensitive": {
+                                                                "type": "boolean",
+                                                                "default": false
+                                                              },
+                                                              "options": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "value": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "label": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "required": ["value", "label"],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "helpText": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key",
+                                                              "label",
+                                                              "type",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "validUntil": {
+                                                          "type": "string"
+                                                        },
+                                                        "quoteRef": {
+                                                          "type": "string"
+                                                        },
+                                                        "metadata": {
+                                                          "type": "object",
+                                                          "additionalProperties": {}
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "offerId",
+                                                        "sourceId",
+                                                        "providerId",
+                                                        "providerLabel",
+                                                        "kind",
+                                                        "title",
+                                                        "price",
+                                                        "eligibility",
+                                                        "validUntil",
+                                                        "quoteRef"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  },
+                                                  "diagnostics": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "status": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "ok",
+                                                            "timeout",
+                                                            "error",
+                                                            "unavailable"
+                                                          ]
+                                                        },
+                                                        "message": {
+                                                          "type": "string"
+                                                        },
+                                                        "latencyMs": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["sourceId", "status"],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  }
+                                                },
+                                                "required": ["kind", "label"],
+                                                "additionalProperties": false
+                                              },
+                                              "default": []
+                                            }
+                                          }
+                                        },
+                                        "paymentIntents": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string",
+                                            "enum": [
+                                              "hold",
+                                              "card",
+                                              "bank_transfer",
+                                              "ticket_on_credit",
+                                              "inquiry"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "showsConfigure",
+                                        "showsBilling",
+                                        "showsTravelers",
+                                        "showsAccommodation",
+                                        "showsAddons",
+                                        "showsPayment",
+                                        "showsReview",
+                                        "paxBands",
+                                        "paxBandsAllowedTotal",
+                                        "travelerFields",
+                                        "bookingFields",
+                                        "paymentIntents"
+                                      ]
+                                    },
+                                    "requirementsFingerprint": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "expiresAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "selection": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    },
+                                    "redaction": {
+                                      "type": "string",
+                                      "enum": ["none", "selection_omitted"]
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "target",
+                                    "actorKind",
+                                    "state",
+                                    "revision",
+                                    "scope",
+                                    "expiresAt",
+                                    "createdAt",
+                                    "updatedAt",
+                                    "redaction"
+                                  ]
+                                }
+                              },
+                              "required": ["kind", "session"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["session_adopted"]
+                                },
+                                "session": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "target": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["product"]
+                                            },
+                                            "productId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "productId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["catalog_item"]
+                                            },
+                                            "catalogItemId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "catalogItemId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["owned_entity"]
+                                            },
+                                            "entityModule": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "entityId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "entityModule", "entityId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["trip_snapshot"]
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripEnvelopeId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["managed_itinerary"]
+                                            }
+                                          },
+                                          "required": ["kind"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "origin": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["accepted_proposal_version"]
+                                            },
+                                            "proposalId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "proposalVersionId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": [
+                                            "kind",
+                                            "proposalId",
+                                            "proposalVersionId",
+                                            "tripSnapshotId"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "actorKind": {
+                                      "type": "string",
+                                      "enum": ["anonymous", "customer", "staff", "partner"]
+                                    },
+                                    "state": {
+                                      "type": "string",
+                                      "enum": [
+                                        "active",
+                                        "supplier_pending",
+                                        "component_pending",
+                                        "consumed",
+                                        "expired",
+                                        "abandoned"
+                                      ]
+                                    },
+                                    "revision": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "scope": {
+                                      "type": "object",
+                                      "properties": {
+                                        "locale": {
+                                          "type": "string",
+                                          "minLength": 2
+                                        },
+                                        "market": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "currency": {
+                                          "type": "string",
+                                          "minLength": 3,
+                                          "maxLength": 3
+                                        }
+                                      },
+                                      "required": ["locale", "market"]
+                                    },
+                                    "requirements": {
+                                      "type": "object",
+                                      "properties": {
+                                        "showsConfigure": {
+                                          "type": "boolean"
+                                        },
+                                        "showsBilling": {
+                                          "type": "boolean"
+                                        },
+                                        "showsTravelers": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAccommodation": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAddons": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAncillaries": {
+                                          "type": "boolean",
+                                          "default": false
+                                        },
+                                        "showsPayment": {
+                                          "type": "boolean"
+                                        },
+                                        "showsReview": {
+                                          "type": "boolean",
+                                          "enum": [true]
+                                        },
+                                        "configureSubSteps": {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["departure"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean",
+                                                    "enum": [true]
+                                                  }
+                                                },
+                                                "required": ["kind", "required"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["product-option"]
+                                                  },
+                                                  "options": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "isDefault": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "units": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "id": {
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "unitType": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "minQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              },
+                                                              "maxQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              }
+                                                            },
+                                                            "required": ["id", "name"]
+                                                          }
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "options"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["option-units"]
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-category"]
+                                                  },
+                                                  "categories": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": {
+                                                          "type": "string"
+                                                        },
+                                                        "capacityMin": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "capacityMax": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "description": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "categories"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-number"]
+                                                  },
+                                                  "perCategory": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "id": {
+                                                            "type": "string"
+                                                          },
+                                                          "code": {
+                                                            "type": "string"
+                                                          },
+                                                          "label": {
+                                                            "type": "string"
+                                                          },
+                                                          "capacity": {
+                                                            "type": "integer",
+                                                            "minimum": 0
+                                                          },
+                                                          "hasAccessibilityFeatures": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": ["id", "label"]
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "perCategory"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["date-range"]
+                                                  },
+                                                  "minNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  },
+                                                  "maxNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  }
+                                                },
+                                                "required": ["kind", "minNights", "maxNights"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["occupancy"]
+                                                  },
+                                                  "bands": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "label": {
+                                                          "type": "string"
+                                                        },
+                                                        "minAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "minCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "code",
+                                                        "label",
+                                                        "minCount",
+                                                        "maxCount"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "bands"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["air-arrangement"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "paxBands": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "minAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "minCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["code", "label", "minCount", "maxCount"]
+                                          }
+                                        },
+                                        "paxBandsAllowedTotal": {
+                                          "type": "object",
+                                          "properties": {
+                                            "min": {
+                                              "type": "integer"
+                                            },
+                                            "max": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": ["min", "max"]
+                                        },
+                                        "paxBandDependencies": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "dependentCode": {
+                                                "type": "string"
+                                              },
+                                              "masterCode": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "requires",
+                                                  "limits_per_master",
+                                                  "limits_sum",
+                                                  "excludes"
+                                                ]
+                                              },
+                                              "maxPerMaster": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxDependentSum": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["dependentCode", "masterCode", "type"]
+                                          }
+                                        },
+                                        "travelerFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "options": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["value", "label"]
+                                                }
+                                              },
+                                              "appliesToBands": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": ["key", "label", "type", "required"]
+                                          }
+                                        },
+                                        "bookingFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "group": {
+                                                "type": "string",
+                                                "enum": ["billing", "company", "preferences"]
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "label",
+                                              "type",
+                                              "required",
+                                              "group"
+                                            ]
+                                          }
+                                        },
+                                        "accommodation": {
+                                          "type": "object",
+                                          "properties": {
+                                            "roomOptions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "capacity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "baseRateHint": {
+                                                    "type": ["number", "null"]
+                                                  },
+                                                  "ratePlans": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "chargeFrequency": {
+                                                          "type": "string",
+                                                          "enum": ["per_night", "per_stay"]
+                                                        },
+                                                        "cancellationPolicy": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "inclusions": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "currency": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["id", "name"]
+                                              }
+                                            },
+                                            "sharedRoomAllowed": {
+                                              "type": "boolean"
+                                            },
+                                            "subSteps": {
+                                              "type": "array",
+                                              "items": {
+                                                "oneOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["rooms"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "description": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "capacity": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "baseRateHint": {
+                                                              "type": ["number", "null"]
+                                                            },
+                                                            "ratePlans": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "id": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "name": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "chargeFrequency": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "per_night",
+                                                                      "per_stay"
+                                                                    ]
+                                                                  },
+                                                                  "cancellationPolicy": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "inclusions": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "currency": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["id", "name"]
+                                                              }
+                                                            }
+                                                          },
+                                                          "required": ["id", "name"]
+                                                        }
+                                                      },
+                                                      "sharedRoomAllowed": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "sharedRoomAllowed"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["extensions"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "city": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "side": {
+                                                              "type": "string",
+                                                              "enum": ["pre", "post"]
+                                                            },
+                                                            "nights": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "pricePerPersonHint": {
+                                                              "type": ["number", "null"]
+                                                            }
+                                                          },
+                                                          "required": ["id", "name", "side"]
+                                                        }
+                                                      },
+                                                      "allowsPre": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "allowsPost": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "allowsPre",
+                                                      "allowsPost"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": ["sharedRoomAllowed"]
+                                        },
+                                        "addons": {
+                                          "type": "object",
+                                          "properties": {
+                                            "catalog": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "groupKey": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricingMode": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "unitAmountCents": {
+                                                    "type": ["integer", "null"]
+                                                  },
+                                                  "currency": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricedPerPerson": {
+                                                    "type": ["boolean", "null"]
+                                                  },
+                                                  "selectionType": {
+                                                    "type": ["string", "null"],
+                                                    "enum": [
+                                                      "optional",
+                                                      "required",
+                                                      "default_selected",
+                                                      "unavailable",
+                                                      null
+                                                    ]
+                                                  },
+                                                  "minQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "maxQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "defaultQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  }
+                                                },
+                                                "required": ["id", "name", "kind"]
+                                              }
+                                            },
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "groupBy": {
+                                                    "type": "string",
+                                                    "enum": ["port", "day"]
+                                                  },
+                                                  "perGuestSelection": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "kind": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "extras",
+                                                            "excursions",
+                                                            "insurance"
+                                                          ]
+                                                        },
+                                                        "groupKey": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricingMode": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "unitAmountCents": {
+                                                          "type": ["integer", "null"]
+                                                        },
+                                                        "currency": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": ["boolean", "null"]
+                                                        },
+                                                        "selectionType": {
+                                                          "type": ["string", "null"],
+                                                          "enum": [
+                                                            "optional",
+                                                            "required",
+                                                            "default_selected",
+                                                            "unavailable",
+                                                            null
+                                                          ]
+                                                        },
+                                                        "minQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "maxQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "defaultQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["id", "name", "kind"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": [
+                                                  "kind",
+                                                  "label",
+                                                  "perGuestSelection",
+                                                  "items"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "ancillaries": {
+                                          "type": "object",
+                                          "properties": {
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "offers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "offerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerLabel": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "title": {
+                                                          "type": "string"
+                                                        },
+                                                        "summary": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "planLabel": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "price": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "amountMinor": {
+                                                              "type": "integer"
+                                                            },
+                                                            "currency": {
+                                                              "type": "string",
+                                                              "pattern": "^[A-Z]{3}$"
+                                                            }
+                                                          },
+                                                          "required": ["amountMinor", "currency"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": "boolean",
+                                                          "default": false
+                                                        },
+                                                        "highlights": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": ["label"],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "eligibility": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "status": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "eligible",
+                                                                "ineligible",
+                                                                "referral"
+                                                              ]
+                                                            },
+                                                            "reasons": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "code": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "message": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["code", "message"],
+                                                                "additionalProperties": false
+                                                              },
+                                                              "default": []
+                                                            }
+                                                          },
+                                                          "required": ["status"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "disclosures": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "kind": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "versionId": {
+                                                                "type": "string"
+                                                              },
+                                                              "url": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "kind",
+                                                              "label",
+                                                              "versionId",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "requiredTravelerFields": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "key": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              },
+                                                              "sensitive": {
+                                                                "type": "boolean",
+                                                                "default": false
+                                                              },
+                                                              "options": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "value": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "label": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "required": ["value", "label"],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "helpText": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key",
+                                                              "label",
+                                                              "type",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "validUntil": {
+                                                          "type": "string"
+                                                        },
+                                                        "quoteRef": {
+                                                          "type": "string"
+                                                        },
+                                                        "metadata": {
+                                                          "type": "object",
+                                                          "additionalProperties": {}
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "offerId",
+                                                        "sourceId",
+                                                        "providerId",
+                                                        "providerLabel",
+                                                        "kind",
+                                                        "title",
+                                                        "price",
+                                                        "eligibility",
+                                                        "validUntil",
+                                                        "quoteRef"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  },
+                                                  "diagnostics": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "status": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "ok",
+                                                            "timeout",
+                                                            "error",
+                                                            "unavailable"
+                                                          ]
+                                                        },
+                                                        "message": {
+                                                          "type": "string"
+                                                        },
+                                                        "latencyMs": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["sourceId", "status"],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  }
+                                                },
+                                                "required": ["kind", "label"],
+                                                "additionalProperties": false
+                                              },
+                                              "default": []
+                                            }
+                                          }
+                                        },
+                                        "paymentIntents": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string",
+                                            "enum": [
+                                              "hold",
+                                              "card",
+                                              "bank_transfer",
+                                              "ticket_on_credit",
+                                              "inquiry"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "showsConfigure",
+                                        "showsBilling",
+                                        "showsTravelers",
+                                        "showsAccommodation",
+                                        "showsAddons",
+                                        "showsPayment",
+                                        "showsReview",
+                                        "paxBands",
+                                        "paxBandsAllowedTotal",
+                                        "travelerFields",
+                                        "bookingFields",
+                                        "paymentIntents"
+                                      ]
+                                    },
+                                    "requirementsFingerprint": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "expiresAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "selection": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    },
+                                    "redaction": {
+                                      "type": "string",
+                                      "enum": ["none", "selection_omitted"]
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "target",
+                                    "actorKind",
+                                    "state",
+                                    "revision",
+                                    "scope",
+                                    "expiresAt",
+                                    "createdAt",
+                                    "updatedAt",
+                                    "redaction"
+                                  ]
+                                }
+                              },
+                              "required": ["kind", "session"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["session_renewed"]
+                                },
+                                "session": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "target": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["product"]
+                                            },
+                                            "productId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "productId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["catalog_item"]
+                                            },
+                                            "catalogItemId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "catalogItemId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["owned_entity"]
+                                            },
+                                            "entityModule": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "entityId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "entityModule", "entityId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["trip_snapshot"]
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripEnvelopeId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["managed_itinerary"]
+                                            }
+                                          },
+                                          "required": ["kind"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "origin": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["accepted_proposal_version"]
+                                            },
+                                            "proposalId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "proposalVersionId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": [
+                                            "kind",
+                                            "proposalId",
+                                            "proposalVersionId",
+                                            "tripSnapshotId"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "actorKind": {
+                                      "type": "string",
+                                      "enum": ["anonymous", "customer", "staff", "partner"]
+                                    },
+                                    "state": {
+                                      "type": "string",
+                                      "enum": [
+                                        "active",
+                                        "supplier_pending",
+                                        "component_pending",
+                                        "consumed",
+                                        "expired",
+                                        "abandoned"
+                                      ]
+                                    },
+                                    "revision": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "scope": {
+                                      "type": "object",
+                                      "properties": {
+                                        "locale": {
+                                          "type": "string",
+                                          "minLength": 2
+                                        },
+                                        "market": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "currency": {
+                                          "type": "string",
+                                          "minLength": 3,
+                                          "maxLength": 3
+                                        }
+                                      },
+                                      "required": ["locale", "market"]
+                                    },
+                                    "requirements": {
+                                      "type": "object",
+                                      "properties": {
+                                        "showsConfigure": {
+                                          "type": "boolean"
+                                        },
+                                        "showsBilling": {
+                                          "type": "boolean"
+                                        },
+                                        "showsTravelers": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAccommodation": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAddons": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAncillaries": {
+                                          "type": "boolean",
+                                          "default": false
+                                        },
+                                        "showsPayment": {
+                                          "type": "boolean"
+                                        },
+                                        "showsReview": {
+                                          "type": "boolean",
+                                          "enum": [true]
+                                        },
+                                        "configureSubSteps": {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["departure"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean",
+                                                    "enum": [true]
+                                                  }
+                                                },
+                                                "required": ["kind", "required"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["product-option"]
+                                                  },
+                                                  "options": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "isDefault": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "units": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "id": {
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "unitType": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "minQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              },
+                                                              "maxQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              }
+                                                            },
+                                                            "required": ["id", "name"]
+                                                          }
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "options"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["option-units"]
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-category"]
+                                                  },
+                                                  "categories": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": {
+                                                          "type": "string"
+                                                        },
+                                                        "capacityMin": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "capacityMax": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "description": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "categories"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-number"]
+                                                  },
+                                                  "perCategory": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "id": {
+                                                            "type": "string"
+                                                          },
+                                                          "code": {
+                                                            "type": "string"
+                                                          },
+                                                          "label": {
+                                                            "type": "string"
+                                                          },
+                                                          "capacity": {
+                                                            "type": "integer",
+                                                            "minimum": 0
+                                                          },
+                                                          "hasAccessibilityFeatures": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": ["id", "label"]
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "perCategory"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["date-range"]
+                                                  },
+                                                  "minNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  },
+                                                  "maxNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  }
+                                                },
+                                                "required": ["kind", "minNights", "maxNights"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["occupancy"]
+                                                  },
+                                                  "bands": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "label": {
+                                                          "type": "string"
+                                                        },
+                                                        "minAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "minCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "code",
+                                                        "label",
+                                                        "minCount",
+                                                        "maxCount"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "bands"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["air-arrangement"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "paxBands": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "minAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "minCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["code", "label", "minCount", "maxCount"]
+                                          }
+                                        },
+                                        "paxBandsAllowedTotal": {
+                                          "type": "object",
+                                          "properties": {
+                                            "min": {
+                                              "type": "integer"
+                                            },
+                                            "max": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": ["min", "max"]
+                                        },
+                                        "paxBandDependencies": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "dependentCode": {
+                                                "type": "string"
+                                              },
+                                              "masterCode": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "requires",
+                                                  "limits_per_master",
+                                                  "limits_sum",
+                                                  "excludes"
+                                                ]
+                                              },
+                                              "maxPerMaster": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxDependentSum": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["dependentCode", "masterCode", "type"]
+                                          }
+                                        },
+                                        "travelerFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "options": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["value", "label"]
+                                                }
+                                              },
+                                              "appliesToBands": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": ["key", "label", "type", "required"]
+                                          }
+                                        },
+                                        "bookingFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "group": {
+                                                "type": "string",
+                                                "enum": ["billing", "company", "preferences"]
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "label",
+                                              "type",
+                                              "required",
+                                              "group"
+                                            ]
+                                          }
+                                        },
+                                        "accommodation": {
+                                          "type": "object",
+                                          "properties": {
+                                            "roomOptions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "capacity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "baseRateHint": {
+                                                    "type": ["number", "null"]
+                                                  },
+                                                  "ratePlans": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "chargeFrequency": {
+                                                          "type": "string",
+                                                          "enum": ["per_night", "per_stay"]
+                                                        },
+                                                        "cancellationPolicy": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "inclusions": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "currency": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["id", "name"]
+                                              }
+                                            },
+                                            "sharedRoomAllowed": {
+                                              "type": "boolean"
+                                            },
+                                            "subSteps": {
+                                              "type": "array",
+                                              "items": {
+                                                "oneOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["rooms"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "description": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "capacity": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "baseRateHint": {
+                                                              "type": ["number", "null"]
+                                                            },
+                                                            "ratePlans": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "id": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "name": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "chargeFrequency": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "per_night",
+                                                                      "per_stay"
+                                                                    ]
+                                                                  },
+                                                                  "cancellationPolicy": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "inclusions": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "currency": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["id", "name"]
+                                                              }
+                                                            }
+                                                          },
+                                                          "required": ["id", "name"]
+                                                        }
+                                                      },
+                                                      "sharedRoomAllowed": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "sharedRoomAllowed"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["extensions"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "city": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "side": {
+                                                              "type": "string",
+                                                              "enum": ["pre", "post"]
+                                                            },
+                                                            "nights": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "pricePerPersonHint": {
+                                                              "type": ["number", "null"]
+                                                            }
+                                                          },
+                                                          "required": ["id", "name", "side"]
+                                                        }
+                                                      },
+                                                      "allowsPre": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "allowsPost": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "allowsPre",
+                                                      "allowsPost"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": ["sharedRoomAllowed"]
+                                        },
+                                        "addons": {
+                                          "type": "object",
+                                          "properties": {
+                                            "catalog": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "groupKey": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricingMode": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "unitAmountCents": {
+                                                    "type": ["integer", "null"]
+                                                  },
+                                                  "currency": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricedPerPerson": {
+                                                    "type": ["boolean", "null"]
+                                                  },
+                                                  "selectionType": {
+                                                    "type": ["string", "null"],
+                                                    "enum": [
+                                                      "optional",
+                                                      "required",
+                                                      "default_selected",
+                                                      "unavailable",
+                                                      null
+                                                    ]
+                                                  },
+                                                  "minQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "maxQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "defaultQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  }
+                                                },
+                                                "required": ["id", "name", "kind"]
+                                              }
+                                            },
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "groupBy": {
+                                                    "type": "string",
+                                                    "enum": ["port", "day"]
+                                                  },
+                                                  "perGuestSelection": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "kind": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "extras",
+                                                            "excursions",
+                                                            "insurance"
+                                                          ]
+                                                        },
+                                                        "groupKey": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricingMode": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "unitAmountCents": {
+                                                          "type": ["integer", "null"]
+                                                        },
+                                                        "currency": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": ["boolean", "null"]
+                                                        },
+                                                        "selectionType": {
+                                                          "type": ["string", "null"],
+                                                          "enum": [
+                                                            "optional",
+                                                            "required",
+                                                            "default_selected",
+                                                            "unavailable",
+                                                            null
+                                                          ]
+                                                        },
+                                                        "minQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "maxQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "defaultQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["id", "name", "kind"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": [
+                                                  "kind",
+                                                  "label",
+                                                  "perGuestSelection",
+                                                  "items"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "ancillaries": {
+                                          "type": "object",
+                                          "properties": {
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "offers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "offerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerLabel": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "title": {
+                                                          "type": "string"
+                                                        },
+                                                        "summary": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "planLabel": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "price": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "amountMinor": {
+                                                              "type": "integer"
+                                                            },
+                                                            "currency": {
+                                                              "type": "string",
+                                                              "pattern": "^[A-Z]{3}$"
+                                                            }
+                                                          },
+                                                          "required": ["amountMinor", "currency"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": "boolean",
+                                                          "default": false
+                                                        },
+                                                        "highlights": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": ["label"],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "eligibility": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "status": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "eligible",
+                                                                "ineligible",
+                                                                "referral"
+                                                              ]
+                                                            },
+                                                            "reasons": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "code": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "message": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["code", "message"],
+                                                                "additionalProperties": false
+                                                              },
+                                                              "default": []
+                                                            }
+                                                          },
+                                                          "required": ["status"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "disclosures": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "kind": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "versionId": {
+                                                                "type": "string"
+                                                              },
+                                                              "url": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "kind",
+                                                              "label",
+                                                              "versionId",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "requiredTravelerFields": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "key": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              },
+                                                              "sensitive": {
+                                                                "type": "boolean",
+                                                                "default": false
+                                                              },
+                                                              "options": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "value": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "label": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "required": ["value", "label"],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "helpText": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key",
+                                                              "label",
+                                                              "type",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "validUntil": {
+                                                          "type": "string"
+                                                        },
+                                                        "quoteRef": {
+                                                          "type": "string"
+                                                        },
+                                                        "metadata": {
+                                                          "type": "object",
+                                                          "additionalProperties": {}
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "offerId",
+                                                        "sourceId",
+                                                        "providerId",
+                                                        "providerLabel",
+                                                        "kind",
+                                                        "title",
+                                                        "price",
+                                                        "eligibility",
+                                                        "validUntil",
+                                                        "quoteRef"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  },
+                                                  "diagnostics": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "status": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "ok",
+                                                            "timeout",
+                                                            "error",
+                                                            "unavailable"
+                                                          ]
+                                                        },
+                                                        "message": {
+                                                          "type": "string"
+                                                        },
+                                                        "latencyMs": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["sourceId", "status"],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  }
+                                                },
+                                                "required": ["kind", "label"],
+                                                "additionalProperties": false
+                                              },
+                                              "default": []
+                                            }
+                                          }
+                                        },
+                                        "paymentIntents": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string",
+                                            "enum": [
+                                              "hold",
+                                              "card",
+                                              "bank_transfer",
+                                              "ticket_on_credit",
+                                              "inquiry"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "showsConfigure",
+                                        "showsBilling",
+                                        "showsTravelers",
+                                        "showsAccommodation",
+                                        "showsAddons",
+                                        "showsPayment",
+                                        "showsReview",
+                                        "paxBands",
+                                        "paxBandsAllowedTotal",
+                                        "travelerFields",
+                                        "bookingFields",
+                                        "paymentIntents"
+                                      ]
+                                    },
+                                    "requirementsFingerprint": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "expiresAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "target",
+                                    "actorKind",
+                                    "state",
+                                    "revision",
+                                    "scope",
+                                    "expiresAt",
+                                    "createdAt",
+                                    "updatedAt"
+                                  ]
+                                }
+                              },
+                              "required": ["kind", "session"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["session_abandoned"]
+                                },
+                                "session": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "target": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["product"]
+                                            },
+                                            "productId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "productId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["catalog_item"]
+                                            },
+                                            "catalogItemId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "catalogItemId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["owned_entity"]
+                                            },
+                                            "entityModule": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "entityId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "entityModule", "entityId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["trip_snapshot"]
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripEnvelopeId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["managed_itinerary"]
+                                            }
+                                          },
+                                          "required": ["kind"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "origin": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["accepted_proposal_version"]
+                                            },
+                                            "proposalId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "proposalVersionId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": [
+                                            "kind",
+                                            "proposalId",
+                                            "proposalVersionId",
+                                            "tripSnapshotId"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "actorKind": {
+                                      "type": "string",
+                                      "enum": ["anonymous", "customer", "staff", "partner"]
+                                    },
+                                    "state": {
+                                      "type": "string",
+                                      "enum": [
+                                        "active",
+                                        "supplier_pending",
+                                        "component_pending",
+                                        "consumed",
+                                        "expired",
+                                        "abandoned"
+                                      ]
+                                    },
+                                    "revision": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "scope": {
+                                      "type": "object",
+                                      "properties": {
+                                        "locale": {
+                                          "type": "string",
+                                          "minLength": 2
+                                        },
+                                        "market": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "currency": {
+                                          "type": "string",
+                                          "minLength": 3,
+                                          "maxLength": 3
+                                        }
+                                      },
+                                      "required": ["locale", "market"]
+                                    },
+                                    "requirements": {
+                                      "type": "object",
+                                      "properties": {
+                                        "showsConfigure": {
+                                          "type": "boolean"
+                                        },
+                                        "showsBilling": {
+                                          "type": "boolean"
+                                        },
+                                        "showsTravelers": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAccommodation": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAddons": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAncillaries": {
+                                          "type": "boolean",
+                                          "default": false
+                                        },
+                                        "showsPayment": {
+                                          "type": "boolean"
+                                        },
+                                        "showsReview": {
+                                          "type": "boolean",
+                                          "enum": [true]
+                                        },
+                                        "configureSubSteps": {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["departure"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean",
+                                                    "enum": [true]
+                                                  }
+                                                },
+                                                "required": ["kind", "required"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["product-option"]
+                                                  },
+                                                  "options": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "isDefault": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "units": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "id": {
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "unitType": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "minQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              },
+                                                              "maxQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              }
+                                                            },
+                                                            "required": ["id", "name"]
+                                                          }
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "options"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["option-units"]
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-category"]
+                                                  },
+                                                  "categories": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": {
+                                                          "type": "string"
+                                                        },
+                                                        "capacityMin": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "capacityMax": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "description": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "categories"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-number"]
+                                                  },
+                                                  "perCategory": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "id": {
+                                                            "type": "string"
+                                                          },
+                                                          "code": {
+                                                            "type": "string"
+                                                          },
+                                                          "label": {
+                                                            "type": "string"
+                                                          },
+                                                          "capacity": {
+                                                            "type": "integer",
+                                                            "minimum": 0
+                                                          },
+                                                          "hasAccessibilityFeatures": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": ["id", "label"]
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "perCategory"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["date-range"]
+                                                  },
+                                                  "minNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  },
+                                                  "maxNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  }
+                                                },
+                                                "required": ["kind", "minNights", "maxNights"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["occupancy"]
+                                                  },
+                                                  "bands": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "label": {
+                                                          "type": "string"
+                                                        },
+                                                        "minAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "minCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "code",
+                                                        "label",
+                                                        "minCount",
+                                                        "maxCount"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "bands"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["air-arrangement"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "paxBands": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "minAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "minCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["code", "label", "minCount", "maxCount"]
+                                          }
+                                        },
+                                        "paxBandsAllowedTotal": {
+                                          "type": "object",
+                                          "properties": {
+                                            "min": {
+                                              "type": "integer"
+                                            },
+                                            "max": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": ["min", "max"]
+                                        },
+                                        "paxBandDependencies": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "dependentCode": {
+                                                "type": "string"
+                                              },
+                                              "masterCode": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "requires",
+                                                  "limits_per_master",
+                                                  "limits_sum",
+                                                  "excludes"
+                                                ]
+                                              },
+                                              "maxPerMaster": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxDependentSum": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["dependentCode", "masterCode", "type"]
+                                          }
+                                        },
+                                        "travelerFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "options": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["value", "label"]
+                                                }
+                                              },
+                                              "appliesToBands": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": ["key", "label", "type", "required"]
+                                          }
+                                        },
+                                        "bookingFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "group": {
+                                                "type": "string",
+                                                "enum": ["billing", "company", "preferences"]
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "label",
+                                              "type",
+                                              "required",
+                                              "group"
+                                            ]
+                                          }
+                                        },
+                                        "accommodation": {
+                                          "type": "object",
+                                          "properties": {
+                                            "roomOptions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "capacity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "baseRateHint": {
+                                                    "type": ["number", "null"]
+                                                  },
+                                                  "ratePlans": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "chargeFrequency": {
+                                                          "type": "string",
+                                                          "enum": ["per_night", "per_stay"]
+                                                        },
+                                                        "cancellationPolicy": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "inclusions": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "currency": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["id", "name"]
+                                              }
+                                            },
+                                            "sharedRoomAllowed": {
+                                              "type": "boolean"
+                                            },
+                                            "subSteps": {
+                                              "type": "array",
+                                              "items": {
+                                                "oneOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["rooms"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "description": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "capacity": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "baseRateHint": {
+                                                              "type": ["number", "null"]
+                                                            },
+                                                            "ratePlans": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "id": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "name": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "chargeFrequency": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "per_night",
+                                                                      "per_stay"
+                                                                    ]
+                                                                  },
+                                                                  "cancellationPolicy": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "inclusions": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "currency": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["id", "name"]
+                                                              }
+                                                            }
+                                                          },
+                                                          "required": ["id", "name"]
+                                                        }
+                                                      },
+                                                      "sharedRoomAllowed": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "sharedRoomAllowed"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["extensions"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "city": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "side": {
+                                                              "type": "string",
+                                                              "enum": ["pre", "post"]
+                                                            },
+                                                            "nights": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "pricePerPersonHint": {
+                                                              "type": ["number", "null"]
+                                                            }
+                                                          },
+                                                          "required": ["id", "name", "side"]
+                                                        }
+                                                      },
+                                                      "allowsPre": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "allowsPost": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "allowsPre",
+                                                      "allowsPost"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": ["sharedRoomAllowed"]
+                                        },
+                                        "addons": {
+                                          "type": "object",
+                                          "properties": {
+                                            "catalog": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "groupKey": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricingMode": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "unitAmountCents": {
+                                                    "type": ["integer", "null"]
+                                                  },
+                                                  "currency": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricedPerPerson": {
+                                                    "type": ["boolean", "null"]
+                                                  },
+                                                  "selectionType": {
+                                                    "type": ["string", "null"],
+                                                    "enum": [
+                                                      "optional",
+                                                      "required",
+                                                      "default_selected",
+                                                      "unavailable",
+                                                      null
+                                                    ]
+                                                  },
+                                                  "minQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "maxQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "defaultQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  }
+                                                },
+                                                "required": ["id", "name", "kind"]
+                                              }
+                                            },
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "groupBy": {
+                                                    "type": "string",
+                                                    "enum": ["port", "day"]
+                                                  },
+                                                  "perGuestSelection": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "kind": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "extras",
+                                                            "excursions",
+                                                            "insurance"
+                                                          ]
+                                                        },
+                                                        "groupKey": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricingMode": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "unitAmountCents": {
+                                                          "type": ["integer", "null"]
+                                                        },
+                                                        "currency": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": ["boolean", "null"]
+                                                        },
+                                                        "selectionType": {
+                                                          "type": ["string", "null"],
+                                                          "enum": [
+                                                            "optional",
+                                                            "required",
+                                                            "default_selected",
+                                                            "unavailable",
+                                                            null
+                                                          ]
+                                                        },
+                                                        "minQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "maxQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "defaultQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["id", "name", "kind"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": [
+                                                  "kind",
+                                                  "label",
+                                                  "perGuestSelection",
+                                                  "items"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "ancillaries": {
+                                          "type": "object",
+                                          "properties": {
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "offers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "offerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerLabel": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "title": {
+                                                          "type": "string"
+                                                        },
+                                                        "summary": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "planLabel": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "price": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "amountMinor": {
+                                                              "type": "integer"
+                                                            },
+                                                            "currency": {
+                                                              "type": "string",
+                                                              "pattern": "^[A-Z]{3}$"
+                                                            }
+                                                          },
+                                                          "required": ["amountMinor", "currency"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": "boolean",
+                                                          "default": false
+                                                        },
+                                                        "highlights": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": ["label"],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "eligibility": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "status": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "eligible",
+                                                                "ineligible",
+                                                                "referral"
+                                                              ]
+                                                            },
+                                                            "reasons": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "code": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "message": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["code", "message"],
+                                                                "additionalProperties": false
+                                                              },
+                                                              "default": []
+                                                            }
+                                                          },
+                                                          "required": ["status"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "disclosures": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "kind": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "versionId": {
+                                                                "type": "string"
+                                                              },
+                                                              "url": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "kind",
+                                                              "label",
+                                                              "versionId",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "requiredTravelerFields": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "key": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              },
+                                                              "sensitive": {
+                                                                "type": "boolean",
+                                                                "default": false
+                                                              },
+                                                              "options": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "value": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "label": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "required": ["value", "label"],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "helpText": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key",
+                                                              "label",
+                                                              "type",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "validUntil": {
+                                                          "type": "string"
+                                                        },
+                                                        "quoteRef": {
+                                                          "type": "string"
+                                                        },
+                                                        "metadata": {
+                                                          "type": "object",
+                                                          "additionalProperties": {}
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "offerId",
+                                                        "sourceId",
+                                                        "providerId",
+                                                        "providerLabel",
+                                                        "kind",
+                                                        "title",
+                                                        "price",
+                                                        "eligibility",
+                                                        "validUntil",
+                                                        "quoteRef"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  },
+                                                  "diagnostics": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "status": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "ok",
+                                                            "timeout",
+                                                            "error",
+                                                            "unavailable"
+                                                          ]
+                                                        },
+                                                        "message": {
+                                                          "type": "string"
+                                                        },
+                                                        "latencyMs": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["sourceId", "status"],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  }
+                                                },
+                                                "required": ["kind", "label"],
+                                                "additionalProperties": false
+                                              },
+                                              "default": []
+                                            }
+                                          }
+                                        },
+                                        "paymentIntents": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string",
+                                            "enum": [
+                                              "hold",
+                                              "card",
+                                              "bank_transfer",
+                                              "ticket_on_credit",
+                                              "inquiry"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "showsConfigure",
+                                        "showsBilling",
+                                        "showsTravelers",
+                                        "showsAccommodation",
+                                        "showsAddons",
+                                        "showsPayment",
+                                        "showsReview",
+                                        "paxBands",
+                                        "paxBandsAllowedTotal",
+                                        "travelerFields",
+                                        "bookingFields",
+                                        "paymentIntents"
+                                      ]
+                                    },
+                                    "requirementsFingerprint": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "expiresAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "target",
+                                    "actorKind",
+                                    "state",
+                                    "revision",
+                                    "scope",
+                                    "expiresAt",
+                                    "createdAt",
+                                    "updatedAt"
+                                  ]
+                                }
+                              },
+                              "required": ["kind", "session"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["quote_created"]
+                                },
+                                "session": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "target": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["product"]
+                                            },
+                                            "productId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "productId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["catalog_item"]
+                                            },
+                                            "catalogItemId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "catalogItemId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["owned_entity"]
+                                            },
+                                            "entityModule": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "entityId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "entityModule", "entityId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["trip_snapshot"]
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripEnvelopeId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["managed_itinerary"]
+                                            }
+                                          },
+                                          "required": ["kind"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "origin": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["accepted_proposal_version"]
+                                            },
+                                            "proposalId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "proposalVersionId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": [
+                                            "kind",
+                                            "proposalId",
+                                            "proposalVersionId",
+                                            "tripSnapshotId"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "actorKind": {
+                                      "type": "string",
+                                      "enum": ["anonymous", "customer", "staff", "partner"]
+                                    },
+                                    "state": {
+                                      "type": "string",
+                                      "enum": [
+                                        "active",
+                                        "supplier_pending",
+                                        "component_pending",
+                                        "consumed",
+                                        "expired",
+                                        "abandoned"
+                                      ]
+                                    },
+                                    "revision": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "scope": {
+                                      "type": "object",
+                                      "properties": {
+                                        "locale": {
+                                          "type": "string",
+                                          "minLength": 2
+                                        },
+                                        "market": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "currency": {
+                                          "type": "string",
+                                          "minLength": 3,
+                                          "maxLength": 3
+                                        }
+                                      },
+                                      "required": ["locale", "market"]
+                                    },
+                                    "requirements": {
+                                      "type": "object",
+                                      "properties": {
+                                        "showsConfigure": {
+                                          "type": "boolean"
+                                        },
+                                        "showsBilling": {
+                                          "type": "boolean"
+                                        },
+                                        "showsTravelers": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAccommodation": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAddons": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAncillaries": {
+                                          "type": "boolean",
+                                          "default": false
+                                        },
+                                        "showsPayment": {
+                                          "type": "boolean"
+                                        },
+                                        "showsReview": {
+                                          "type": "boolean",
+                                          "enum": [true]
+                                        },
+                                        "configureSubSteps": {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["departure"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean",
+                                                    "enum": [true]
+                                                  }
+                                                },
+                                                "required": ["kind", "required"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["product-option"]
+                                                  },
+                                                  "options": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "isDefault": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "units": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "id": {
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "unitType": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "minQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              },
+                                                              "maxQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              }
+                                                            },
+                                                            "required": ["id", "name"]
+                                                          }
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "options"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["option-units"]
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-category"]
+                                                  },
+                                                  "categories": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": {
+                                                          "type": "string"
+                                                        },
+                                                        "capacityMin": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "capacityMax": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "description": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "categories"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-number"]
+                                                  },
+                                                  "perCategory": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "id": {
+                                                            "type": "string"
+                                                          },
+                                                          "code": {
+                                                            "type": "string"
+                                                          },
+                                                          "label": {
+                                                            "type": "string"
+                                                          },
+                                                          "capacity": {
+                                                            "type": "integer",
+                                                            "minimum": 0
+                                                          },
+                                                          "hasAccessibilityFeatures": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": ["id", "label"]
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "perCategory"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["date-range"]
+                                                  },
+                                                  "minNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  },
+                                                  "maxNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  }
+                                                },
+                                                "required": ["kind", "minNights", "maxNights"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["occupancy"]
+                                                  },
+                                                  "bands": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "label": {
+                                                          "type": "string"
+                                                        },
+                                                        "minAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "minCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "code",
+                                                        "label",
+                                                        "minCount",
+                                                        "maxCount"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "bands"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["air-arrangement"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "paxBands": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "minAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "minCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["code", "label", "minCount", "maxCount"]
+                                          }
+                                        },
+                                        "paxBandsAllowedTotal": {
+                                          "type": "object",
+                                          "properties": {
+                                            "min": {
+                                              "type": "integer"
+                                            },
+                                            "max": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": ["min", "max"]
+                                        },
+                                        "paxBandDependencies": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "dependentCode": {
+                                                "type": "string"
+                                              },
+                                              "masterCode": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "requires",
+                                                  "limits_per_master",
+                                                  "limits_sum",
+                                                  "excludes"
+                                                ]
+                                              },
+                                              "maxPerMaster": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxDependentSum": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["dependentCode", "masterCode", "type"]
+                                          }
+                                        },
+                                        "travelerFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "options": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["value", "label"]
+                                                }
+                                              },
+                                              "appliesToBands": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": ["key", "label", "type", "required"]
+                                          }
+                                        },
+                                        "bookingFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "group": {
+                                                "type": "string",
+                                                "enum": ["billing", "company", "preferences"]
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "label",
+                                              "type",
+                                              "required",
+                                              "group"
+                                            ]
+                                          }
+                                        },
+                                        "accommodation": {
+                                          "type": "object",
+                                          "properties": {
+                                            "roomOptions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "capacity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "baseRateHint": {
+                                                    "type": ["number", "null"]
+                                                  },
+                                                  "ratePlans": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "chargeFrequency": {
+                                                          "type": "string",
+                                                          "enum": ["per_night", "per_stay"]
+                                                        },
+                                                        "cancellationPolicy": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "inclusions": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "currency": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["id", "name"]
+                                              }
+                                            },
+                                            "sharedRoomAllowed": {
+                                              "type": "boolean"
+                                            },
+                                            "subSteps": {
+                                              "type": "array",
+                                              "items": {
+                                                "oneOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["rooms"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "description": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "capacity": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "baseRateHint": {
+                                                              "type": ["number", "null"]
+                                                            },
+                                                            "ratePlans": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "id": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "name": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "chargeFrequency": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "per_night",
+                                                                      "per_stay"
+                                                                    ]
+                                                                  },
+                                                                  "cancellationPolicy": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "inclusions": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "currency": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["id", "name"]
+                                                              }
+                                                            }
+                                                          },
+                                                          "required": ["id", "name"]
+                                                        }
+                                                      },
+                                                      "sharedRoomAllowed": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "sharedRoomAllowed"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["extensions"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "city": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "side": {
+                                                              "type": "string",
+                                                              "enum": ["pre", "post"]
+                                                            },
+                                                            "nights": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "pricePerPersonHint": {
+                                                              "type": ["number", "null"]
+                                                            }
+                                                          },
+                                                          "required": ["id", "name", "side"]
+                                                        }
+                                                      },
+                                                      "allowsPre": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "allowsPost": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "allowsPre",
+                                                      "allowsPost"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": ["sharedRoomAllowed"]
+                                        },
+                                        "addons": {
+                                          "type": "object",
+                                          "properties": {
+                                            "catalog": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "groupKey": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricingMode": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "unitAmountCents": {
+                                                    "type": ["integer", "null"]
+                                                  },
+                                                  "currency": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricedPerPerson": {
+                                                    "type": ["boolean", "null"]
+                                                  },
+                                                  "selectionType": {
+                                                    "type": ["string", "null"],
+                                                    "enum": [
+                                                      "optional",
+                                                      "required",
+                                                      "default_selected",
+                                                      "unavailable",
+                                                      null
+                                                    ]
+                                                  },
+                                                  "minQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "maxQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "defaultQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  }
+                                                },
+                                                "required": ["id", "name", "kind"]
+                                              }
+                                            },
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "groupBy": {
+                                                    "type": "string",
+                                                    "enum": ["port", "day"]
+                                                  },
+                                                  "perGuestSelection": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "kind": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "extras",
+                                                            "excursions",
+                                                            "insurance"
+                                                          ]
+                                                        },
+                                                        "groupKey": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricingMode": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "unitAmountCents": {
+                                                          "type": ["integer", "null"]
+                                                        },
+                                                        "currency": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": ["boolean", "null"]
+                                                        },
+                                                        "selectionType": {
+                                                          "type": ["string", "null"],
+                                                          "enum": [
+                                                            "optional",
+                                                            "required",
+                                                            "default_selected",
+                                                            "unavailable",
+                                                            null
+                                                          ]
+                                                        },
+                                                        "minQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "maxQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "defaultQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["id", "name", "kind"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": [
+                                                  "kind",
+                                                  "label",
+                                                  "perGuestSelection",
+                                                  "items"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "ancillaries": {
+                                          "type": "object",
+                                          "properties": {
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "offers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "offerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerLabel": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "title": {
+                                                          "type": "string"
+                                                        },
+                                                        "summary": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "planLabel": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "price": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "amountMinor": {
+                                                              "type": "integer"
+                                                            },
+                                                            "currency": {
+                                                              "type": "string",
+                                                              "pattern": "^[A-Z]{3}$"
+                                                            }
+                                                          },
+                                                          "required": ["amountMinor", "currency"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": "boolean",
+                                                          "default": false
+                                                        },
+                                                        "highlights": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": ["label"],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "eligibility": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "status": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "eligible",
+                                                                "ineligible",
+                                                                "referral"
+                                                              ]
+                                                            },
+                                                            "reasons": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "code": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "message": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["code", "message"],
+                                                                "additionalProperties": false
+                                                              },
+                                                              "default": []
+                                                            }
+                                                          },
+                                                          "required": ["status"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "disclosures": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "kind": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "versionId": {
+                                                                "type": "string"
+                                                              },
+                                                              "url": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "kind",
+                                                              "label",
+                                                              "versionId",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "requiredTravelerFields": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "key": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              },
+                                                              "sensitive": {
+                                                                "type": "boolean",
+                                                                "default": false
+                                                              },
+                                                              "options": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "value": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "label": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "required": ["value", "label"],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "helpText": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key",
+                                                              "label",
+                                                              "type",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "validUntil": {
+                                                          "type": "string"
+                                                        },
+                                                        "quoteRef": {
+                                                          "type": "string"
+                                                        },
+                                                        "metadata": {
+                                                          "type": "object",
+                                                          "additionalProperties": {}
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "offerId",
+                                                        "sourceId",
+                                                        "providerId",
+                                                        "providerLabel",
+                                                        "kind",
+                                                        "title",
+                                                        "price",
+                                                        "eligibility",
+                                                        "validUntil",
+                                                        "quoteRef"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  },
+                                                  "diagnostics": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "status": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "ok",
+                                                            "timeout",
+                                                            "error",
+                                                            "unavailable"
+                                                          ]
+                                                        },
+                                                        "message": {
+                                                          "type": "string"
+                                                        },
+                                                        "latencyMs": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["sourceId", "status"],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  }
+                                                },
+                                                "required": ["kind", "label"],
+                                                "additionalProperties": false
+                                              },
+                                              "default": []
+                                            }
+                                          }
+                                        },
+                                        "paymentIntents": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string",
+                                            "enum": [
+                                              "hold",
+                                              "card",
+                                              "bank_transfer",
+                                              "ticket_on_credit",
+                                              "inquiry"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "showsConfigure",
+                                        "showsBilling",
+                                        "showsTravelers",
+                                        "showsAccommodation",
+                                        "showsAddons",
+                                        "showsPayment",
+                                        "showsReview",
+                                        "paxBands",
+                                        "paxBandsAllowedTotal",
+                                        "travelerFields",
+                                        "bookingFields",
+                                        "paymentIntents"
+                                      ]
+                                    },
+                                    "requirementsFingerprint": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "expiresAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "target",
+                                    "actorKind",
+                                    "state",
+                                    "revision",
+                                    "scope",
+                                    "expiresAt",
+                                    "createdAt",
+                                    "updatedAt"
+                                  ]
+                                },
+                                "quote": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "sessionId": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "sessionRevision": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "state": {
+                                      "type": "string",
+                                      "enum": ["active", "superseded", "consumed", "expired"]
+                                    },
+                                    "requirements": {
+                                      "type": "object",
+                                      "properties": {
+                                        "showsConfigure": {
+                                          "type": "boolean"
+                                        },
+                                        "showsBilling": {
+                                          "type": "boolean"
+                                        },
+                                        "showsTravelers": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAccommodation": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAddons": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAncillaries": {
+                                          "type": "boolean",
+                                          "default": false
+                                        },
+                                        "showsPayment": {
+                                          "type": "boolean"
+                                        },
+                                        "showsReview": {
+                                          "type": "boolean",
+                                          "enum": [true]
+                                        },
+                                        "configureSubSteps": {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["departure"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean",
+                                                    "enum": [true]
+                                                  }
+                                                },
+                                                "required": ["kind", "required"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["product-option"]
+                                                  },
+                                                  "options": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "isDefault": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "units": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "id": {
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "unitType": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "minQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              },
+                                                              "maxQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              }
+                                                            },
+                                                            "required": ["id", "name"]
+                                                          }
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "options"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["option-units"]
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-category"]
+                                                  },
+                                                  "categories": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": {
+                                                          "type": "string"
+                                                        },
+                                                        "capacityMin": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "capacityMax": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "description": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "categories"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-number"]
+                                                  },
+                                                  "perCategory": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "id": {
+                                                            "type": "string"
+                                                          },
+                                                          "code": {
+                                                            "type": "string"
+                                                          },
+                                                          "label": {
+                                                            "type": "string"
+                                                          },
+                                                          "capacity": {
+                                                            "type": "integer",
+                                                            "minimum": 0
+                                                          },
+                                                          "hasAccessibilityFeatures": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": ["id", "label"]
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "perCategory"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["date-range"]
+                                                  },
+                                                  "minNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  },
+                                                  "maxNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  }
+                                                },
+                                                "required": ["kind", "minNights", "maxNights"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["occupancy"]
+                                                  },
+                                                  "bands": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "label": {
+                                                          "type": "string"
+                                                        },
+                                                        "minAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "minCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "code",
+                                                        "label",
+                                                        "minCount",
+                                                        "maxCount"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "bands"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["air-arrangement"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "paxBands": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "minAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "minCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["code", "label", "minCount", "maxCount"]
+                                          }
+                                        },
+                                        "paxBandsAllowedTotal": {
+                                          "type": "object",
+                                          "properties": {
+                                            "min": {
+                                              "type": "integer"
+                                            },
+                                            "max": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": ["min", "max"]
+                                        },
+                                        "paxBandDependencies": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "dependentCode": {
+                                                "type": "string"
+                                              },
+                                              "masterCode": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "requires",
+                                                  "limits_per_master",
+                                                  "limits_sum",
+                                                  "excludes"
+                                                ]
+                                              },
+                                              "maxPerMaster": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxDependentSum": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["dependentCode", "masterCode", "type"]
+                                          }
+                                        },
+                                        "travelerFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "options": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["value", "label"]
+                                                }
+                                              },
+                                              "appliesToBands": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": ["key", "label", "type", "required"]
+                                          }
+                                        },
+                                        "bookingFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "group": {
+                                                "type": "string",
+                                                "enum": ["billing", "company", "preferences"]
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "label",
+                                              "type",
+                                              "required",
+                                              "group"
+                                            ]
+                                          }
+                                        },
+                                        "accommodation": {
+                                          "type": "object",
+                                          "properties": {
+                                            "roomOptions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "capacity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "baseRateHint": {
+                                                    "type": ["number", "null"]
+                                                  },
+                                                  "ratePlans": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "chargeFrequency": {
+                                                          "type": "string",
+                                                          "enum": ["per_night", "per_stay"]
+                                                        },
+                                                        "cancellationPolicy": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "inclusions": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "currency": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["id", "name"]
+                                              }
+                                            },
+                                            "sharedRoomAllowed": {
+                                              "type": "boolean"
+                                            },
+                                            "subSteps": {
+                                              "type": "array",
+                                              "items": {
+                                                "oneOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["rooms"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "description": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "capacity": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "baseRateHint": {
+                                                              "type": ["number", "null"]
+                                                            },
+                                                            "ratePlans": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "id": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "name": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "chargeFrequency": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "per_night",
+                                                                      "per_stay"
+                                                                    ]
+                                                                  },
+                                                                  "cancellationPolicy": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "inclusions": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "currency": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["id", "name"]
+                                                              }
+                                                            }
+                                                          },
+                                                          "required": ["id", "name"]
+                                                        }
+                                                      },
+                                                      "sharedRoomAllowed": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "sharedRoomAllowed"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["extensions"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "city": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "side": {
+                                                              "type": "string",
+                                                              "enum": ["pre", "post"]
+                                                            },
+                                                            "nights": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "pricePerPersonHint": {
+                                                              "type": ["number", "null"]
+                                                            }
+                                                          },
+                                                          "required": ["id", "name", "side"]
+                                                        }
+                                                      },
+                                                      "allowsPre": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "allowsPost": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "allowsPre",
+                                                      "allowsPost"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": ["sharedRoomAllowed"]
+                                        },
+                                        "addons": {
+                                          "type": "object",
+                                          "properties": {
+                                            "catalog": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "groupKey": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricingMode": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "unitAmountCents": {
+                                                    "type": ["integer", "null"]
+                                                  },
+                                                  "currency": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricedPerPerson": {
+                                                    "type": ["boolean", "null"]
+                                                  },
+                                                  "selectionType": {
+                                                    "type": ["string", "null"],
+                                                    "enum": [
+                                                      "optional",
+                                                      "required",
+                                                      "default_selected",
+                                                      "unavailable",
+                                                      null
+                                                    ]
+                                                  },
+                                                  "minQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "maxQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "defaultQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  }
+                                                },
+                                                "required": ["id", "name", "kind"]
+                                              }
+                                            },
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "groupBy": {
+                                                    "type": "string",
+                                                    "enum": ["port", "day"]
+                                                  },
+                                                  "perGuestSelection": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "kind": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "extras",
+                                                            "excursions",
+                                                            "insurance"
+                                                          ]
+                                                        },
+                                                        "groupKey": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricingMode": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "unitAmountCents": {
+                                                          "type": ["integer", "null"]
+                                                        },
+                                                        "currency": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": ["boolean", "null"]
+                                                        },
+                                                        "selectionType": {
+                                                          "type": ["string", "null"],
+                                                          "enum": [
+                                                            "optional",
+                                                            "required",
+                                                            "default_selected",
+                                                            "unavailable",
+                                                            null
+                                                          ]
+                                                        },
+                                                        "minQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "maxQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "defaultQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["id", "name", "kind"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": [
+                                                  "kind",
+                                                  "label",
+                                                  "perGuestSelection",
+                                                  "items"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "ancillaries": {
+                                          "type": "object",
+                                          "properties": {
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "offers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "offerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerLabel": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "title": {
+                                                          "type": "string"
+                                                        },
+                                                        "summary": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "planLabel": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "price": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "amountMinor": {
+                                                              "type": "integer"
+                                                            },
+                                                            "currency": {
+                                                              "type": "string",
+                                                              "pattern": "^[A-Z]{3}$"
+                                                            }
+                                                          },
+                                                          "required": ["amountMinor", "currency"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": "boolean",
+                                                          "default": false
+                                                        },
+                                                        "highlights": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": ["label"],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "eligibility": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "status": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "eligible",
+                                                                "ineligible",
+                                                                "referral"
+                                                              ]
+                                                            },
+                                                            "reasons": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "code": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "message": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["code", "message"],
+                                                                "additionalProperties": false
+                                                              },
+                                                              "default": []
+                                                            }
+                                                          },
+                                                          "required": ["status"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "disclosures": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "kind": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "versionId": {
+                                                                "type": "string"
+                                                              },
+                                                              "url": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "kind",
+                                                              "label",
+                                                              "versionId",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "requiredTravelerFields": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "key": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              },
+                                                              "sensitive": {
+                                                                "type": "boolean",
+                                                                "default": false
+                                                              },
+                                                              "options": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "value": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "label": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "required": ["value", "label"],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "helpText": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key",
+                                                              "label",
+                                                              "type",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "validUntil": {
+                                                          "type": "string"
+                                                        },
+                                                        "quoteRef": {
+                                                          "type": "string"
+                                                        },
+                                                        "metadata": {
+                                                          "type": "object",
+                                                          "additionalProperties": {}
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "offerId",
+                                                        "sourceId",
+                                                        "providerId",
+                                                        "providerLabel",
+                                                        "kind",
+                                                        "title",
+                                                        "price",
+                                                        "eligibility",
+                                                        "validUntil",
+                                                        "quoteRef"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  },
+                                                  "diagnostics": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "status": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "ok",
+                                                            "timeout",
+                                                            "error",
+                                                            "unavailable"
+                                                          ]
+                                                        },
+                                                        "message": {
+                                                          "type": "string"
+                                                        },
+                                                        "latencyMs": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["sourceId", "status"],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  }
+                                                },
+                                                "required": ["kind", "label"],
+                                                "additionalProperties": false
+                                              },
+                                              "default": []
+                                            }
+                                          }
+                                        },
+                                        "paymentIntents": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string",
+                                            "enum": [
+                                              "hold",
+                                              "card",
+                                              "bank_transfer",
+                                              "ticket_on_credit",
+                                              "inquiry"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "showsConfigure",
+                                        "showsBilling",
+                                        "showsTravelers",
+                                        "showsAccommodation",
+                                        "showsAddons",
+                                        "showsPayment",
+                                        "showsReview",
+                                        "paxBands",
+                                        "paxBandsAllowedTotal",
+                                        "travelerFields",
+                                        "bookingFields",
+                                        "paymentIntents"
+                                      ]
+                                    },
+                                    "requirementsFingerprint": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "pricing": {
+                                      "type": "object",
+                                      "properties": {
+                                        "currency": {
+                                          "type": "string",
+                                          "minLength": 3,
+                                          "maxLength": 3
+                                        },
+                                        "lines": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "kind": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "base",
+                                                  "addon",
+                                                  "accommodation",
+                                                  "supplement",
+                                                  "discount",
+                                                  "fee"
+                                                ]
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "quantity": {
+                                                "type": "number",
+                                                "minimum": 0
+                                              },
+                                              "unitAmount": {
+                                                "type": "integer"
+                                              },
+                                              "totalAmount": {
+                                                "type": "integer"
+                                              },
+                                              "taxIncluded": {
+                                                "type": "boolean"
+                                              },
+                                              "pricingBasis": {
+                                                "type": "string",
+                                                "enum": ["per_person", "per_unit", "per_booking"]
+                                              },
+                                              "componentId": {
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "authority": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "booking_quote",
+                                                  "accepted_proposal_manual"
+                                                ]
+                                              }
+                                            },
+                                            "required": [
+                                              "kind",
+                                              "label",
+                                              "unitAmount",
+                                              "totalAmount"
+                                            ]
+                                          }
+                                        },
+                                        "taxes": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "rate": {
+                                                "type": "number",
+                                                "minimum": 0
+                                              },
+                                              "amount": {
+                                                "type": "integer"
+                                              },
+                                              "base": {
+                                                "type": "integer"
+                                              },
+                                              "includedInPrice": {
+                                                "type": "boolean"
+                                              },
+                                              "scope": {
+                                                "type": "string",
+                                                "enum": ["included", "excluded", "withheld"]
+                                              },
+                                              "componentId": {
+                                                "type": "string",
+                                                "minLength": 1
+                                              }
+                                            },
+                                            "required": ["code", "label", "rate", "amount", "base"]
+                                          }
+                                        },
+                                        "subtotal": {
+                                          "type": "integer"
+                                        },
+                                        "taxTotal": {
+                                          "type": "integer"
+                                        },
+                                        "total": {
+                                          "type": "integer"
+                                        },
+                                        "appliedOffers": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "offerId": {
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "offerName": {
+                                                "type": "string"
+                                              },
+                                              "discountAppliedCents": {
+                                                "type": "integer"
+                                              },
+                                              "discountedPriceCents": {
+                                                "type": "integer"
+                                              },
+                                              "currency": {
+                                                "type": "string"
+                                              },
+                                              "discountKind": {
+                                                "type": "string",
+                                                "enum": ["percentage", "fixed_amount"]
+                                              },
+                                              "discountPercent": {
+                                                "type": ["number", "null"]
+                                              },
+                                              "discountAmountCents": {
+                                                "type": ["integer", "null"]
+                                              },
+                                              "appliedCode": {
+                                                "type": ["string", "null"]
+                                              },
+                                              "stackable": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "offerId",
+                                              "offerName",
+                                              "discountAppliedCents",
+                                              "discountedPriceCents",
+                                              "currency",
+                                              "discountKind",
+                                              "discountPercent",
+                                              "discountAmountCents",
+                                              "appliedCode",
+                                              "stackable"
+                                            ]
+                                          }
+                                        },
+                                        "promotionCodeStatus": {
+                                          "oneOf": [
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["code_valid"]
+                                                }
+                                              },
+                                              "required": ["kind"]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["code_not_found"]
+                                                }
+                                              },
+                                              "required": ["kind"]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["code_expired"]
+                                                }
+                                              },
+                                              "required": ["kind"]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["code_not_yet_valid"]
+                                                }
+                                              },
+                                              "required": ["kind"]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["code_not_applicable"]
+                                                },
+                                                "reason": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "scope",
+                                                    "min_pax",
+                                                    "eligibility",
+                                                    "currency"
+                                                  ]
+                                                }
+                                              },
+                                              "required": ["kind", "reason"]
+                                            }
+                                          ]
+                                        },
+                                        "policyEvidence": {
+                                          "type": "object",
+                                          "properties": {
+                                            "cancellation": {},
+                                            "bookingTerms": {}
+                                          }
+                                        },
+                                        "componentPolicies": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "cancellation": {},
+                                              "bookingTerms": {},
+                                              "componentId": {
+                                                "type": "string",
+                                                "minLength": 1
+                                              }
+                                            },
+                                            "required": ["componentId"]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "currency",
+                                        "lines",
+                                        "taxes",
+                                        "subtotal",
+                                        "taxTotal",
+                                        "total"
+                                      ]
+                                    },
+                                    "paymentPlan": {
+                                      "type": "object",
+                                      "properties": {
+                                        "policySource": {
+                                          "type": "string",
+                                          "enum": [
+                                            "booking",
+                                            "proposal",
+                                            "listing",
+                                            "category",
+                                            "supplier",
+                                            "operator_default"
+                                          ]
+                                        },
+                                        "currency": {
+                                          "type": "string",
+                                          "minLength": 3,
+                                          "maxLength": 3
+                                        },
+                                        "totalCents": {
+                                          "type": "integer",
+                                          "minimum": 0
+                                        },
+                                        "dueNowCents": {
+                                          "type": "integer",
+                                          "minimum": 0
+                                        },
+                                        "payInFullCents": {
+                                          "type": ["integer", "null"],
+                                          "minimum": 0
+                                        },
+                                        "entries": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "scheduleType": {
+                                                "type": "string",
+                                                "enum": ["deposit", "balance", "full"]
+                                              },
+                                              "amountCents": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "currency": {
+                                                "type": "string",
+                                                "minLength": 3,
+                                                "maxLength": 3
+                                              },
+                                              "dueDate": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "scheduleType",
+                                              "amountCents",
+                                              "currency",
+                                              "dueDate"
+                                            ]
+                                          },
+                                          "minItems": 1
+                                        }
+                                      },
+                                      "required": [
+                                        "policySource",
+                                        "currency",
+                                        "totalCents",
+                                        "dueNowCents",
+                                        "payInFullCents",
+                                        "entries"
+                                      ]
+                                    },
+                                    "quotedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "expiresAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "sessionId",
+                                    "sessionRevision",
+                                    "state",
+                                    "requirements",
+                                    "requirementsFingerprint",
+                                    "pricing",
+                                    "quotedAt",
+                                    "expiresAt"
+                                  ]
+                                }
+                              },
+                              "required": ["kind", "session", "quote"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["hold_created"]
+                                },
+                                "session": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "target": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["product"]
+                                            },
+                                            "productId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "productId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["catalog_item"]
+                                            },
+                                            "catalogItemId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "catalogItemId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["owned_entity"]
+                                            },
+                                            "entityModule": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "entityId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "entityModule", "entityId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["trip_snapshot"]
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripEnvelopeId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["managed_itinerary"]
+                                            }
+                                          },
+                                          "required": ["kind"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "origin": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["accepted_proposal_version"]
+                                            },
+                                            "proposalId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "proposalVersionId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": [
+                                            "kind",
+                                            "proposalId",
+                                            "proposalVersionId",
+                                            "tripSnapshotId"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "actorKind": {
+                                      "type": "string",
+                                      "enum": ["anonymous", "customer", "staff", "partner"]
+                                    },
+                                    "state": {
+                                      "type": "string",
+                                      "enum": [
+                                        "active",
+                                        "supplier_pending",
+                                        "component_pending",
+                                        "consumed",
+                                        "expired",
+                                        "abandoned"
+                                      ]
+                                    },
+                                    "revision": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "scope": {
+                                      "type": "object",
+                                      "properties": {
+                                        "locale": {
+                                          "type": "string",
+                                          "minLength": 2
+                                        },
+                                        "market": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "currency": {
+                                          "type": "string",
+                                          "minLength": 3,
+                                          "maxLength": 3
+                                        }
+                                      },
+                                      "required": ["locale", "market"]
+                                    },
+                                    "requirements": {
+                                      "type": "object",
+                                      "properties": {
+                                        "showsConfigure": {
+                                          "type": "boolean"
+                                        },
+                                        "showsBilling": {
+                                          "type": "boolean"
+                                        },
+                                        "showsTravelers": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAccommodation": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAddons": {
+                                          "type": "boolean"
+                                        },
+                                        "showsAncillaries": {
+                                          "type": "boolean",
+                                          "default": false
+                                        },
+                                        "showsPayment": {
+                                          "type": "boolean"
+                                        },
+                                        "showsReview": {
+                                          "type": "boolean",
+                                          "enum": [true]
+                                        },
+                                        "configureSubSteps": {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["departure"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean",
+                                                    "enum": [true]
+                                                  }
+                                                },
+                                                "required": ["kind", "required"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["product-option"]
+                                                  },
+                                                  "options": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "isDefault": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "units": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "id": {
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "type": "string"
+                                                              },
+                                                              "description": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "unitType": {
+                                                                "type": ["string", "null"]
+                                                              },
+                                                              "minQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              },
+                                                              "maxQuantity": {
+                                                                "type": ["integer", "null"],
+                                                                "minimum": 0
+                                                              }
+                                                            },
+                                                            "required": ["id", "name"]
+                                                          }
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "options"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["option-units"]
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-category"]
+                                                  },
+                                                  "categories": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": {
+                                                          "type": "string"
+                                                        },
+                                                        "capacityMin": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "capacityMax": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "description": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "categories"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["cabin-number"]
+                                                  },
+                                                  "perCategory": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "id": {
+                                                            "type": "string"
+                                                          },
+                                                          "code": {
+                                                            "type": "string"
+                                                          },
+                                                          "label": {
+                                                            "type": "string"
+                                                          },
+                                                          "capacity": {
+                                                            "type": "integer",
+                                                            "minimum": 0
+                                                          },
+                                                          "hasAccessibilityFeatures": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": ["id", "label"]
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "perCategory"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["date-range"]
+                                                  },
+                                                  "minNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  },
+                                                  "maxNights": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  }
+                                                },
+                                                "required": ["kind", "minNights", "maxNights"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["occupancy"]
+                                                  },
+                                                  "bands": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "string"
+                                                        },
+                                                        "label": {
+                                                          "type": "string"
+                                                        },
+                                                        "minAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxAge": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "minCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        },
+                                                        "maxCount": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "code",
+                                                        "label",
+                                                        "minCount",
+                                                        "maxCount"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["kind", "bands"]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["air-arrangement"]
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": ["kind"]
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "paxBands": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "minAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "minCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["code", "label", "minCount", "maxCount"]
+                                          }
+                                        },
+                                        "paxBandsAllowedTotal": {
+                                          "type": "object",
+                                          "properties": {
+                                            "min": {
+                                              "type": "integer"
+                                            },
+                                            "max": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": ["min", "max"]
+                                        },
+                                        "paxBandDependencies": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "dependentCode": {
+                                                "type": "string"
+                                              },
+                                              "masterCode": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "requires",
+                                                  "limits_per_master",
+                                                  "limits_sum",
+                                                  "excludes"
+                                                ]
+                                              },
+                                              "maxPerMaster": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxDependentSum": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": ["dependentCode", "masterCode", "type"]
+                                          }
+                                        },
+                                        "travelerFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "options": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["value", "label"]
+                                                }
+                                              },
+                                              "appliesToBands": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": ["key", "label", "type", "required"]
+                                          }
+                                        },
+                                        "bookingFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "group": {
+                                                "type": "string",
+                                                "enum": ["billing", "company", "preferences"]
+                                              },
+                                              "maxLength": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "label",
+                                              "type",
+                                              "required",
+                                              "group"
+                                            ]
+                                          }
+                                        },
+                                        "accommodation": {
+                                          "type": "object",
+                                          "properties": {
+                                            "roomOptions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "capacity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "baseRateHint": {
+                                                    "type": ["number", "null"]
+                                                  },
+                                                  "ratePlans": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "chargeFrequency": {
+                                                          "type": "string",
+                                                          "enum": ["per_night", "per_stay"]
+                                                        },
+                                                        "cancellationPolicy": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "inclusions": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "currency": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["id", "name"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["id", "name"]
+                                              }
+                                            },
+                                            "sharedRoomAllowed": {
+                                              "type": "boolean"
+                                            },
+                                            "subSteps": {
+                                              "type": "array",
+                                              "items": {
+                                                "oneOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["rooms"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "description": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "capacity": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "baseRateHint": {
+                                                              "type": ["number", "null"]
+                                                            },
+                                                            "ratePlans": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "id": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "name": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "chargeFrequency": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "per_night",
+                                                                      "per_stay"
+                                                                    ]
+                                                                  },
+                                                                  "cancellationPolicy": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "inclusions": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "currency": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["id", "name"]
+                                                              }
+                                                            }
+                                                          },
+                                                          "required": ["id", "name"]
+                                                        }
+                                                      },
+                                                      "sharedRoomAllowed": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "sharedRoomAllowed"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["extensions"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "city": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "side": {
+                                                              "type": "string",
+                                                              "enum": ["pre", "post"]
+                                                            },
+                                                            "nights": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "pricePerPersonHint": {
+                                                              "type": ["number", "null"]
+                                                            }
+                                                          },
+                                                          "required": ["id", "name", "side"]
+                                                        }
+                                                      },
+                                                      "allowsPre": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "allowsPost": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "options",
+                                                      "allowsPre",
+                                                      "allowsPost"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": ["sharedRoomAllowed"]
+                                        },
+                                        "addons": {
+                                          "type": "object",
+                                          "properties": {
+                                            "catalog": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "groupKey": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricingMode": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "unitAmountCents": {
+                                                    "type": ["integer", "null"]
+                                                  },
+                                                  "currency": {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  "pricedPerPerson": {
+                                                    "type": ["boolean", "null"]
+                                                  },
+                                                  "selectionType": {
+                                                    "type": ["string", "null"],
+                                                    "enum": [
+                                                      "optional",
+                                                      "required",
+                                                      "default_selected",
+                                                      "unavailable",
+                                                      null
+                                                    ]
+                                                  },
+                                                  "minQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "maxQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  },
+                                                  "defaultQuantity": {
+                                                    "type": ["integer", "null"],
+                                                    "minimum": 0
+                                                  }
+                                                },
+                                                "required": ["id", "name", "kind"]
+                                              }
+                                            },
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                    "enum": ["extras", "excursions", "insurance"]
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "groupBy": {
+                                                    "type": "string",
+                                                    "enum": ["port", "day"]
+                                                  },
+                                                  "perGuestSelection": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "kind": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "extras",
+                                                            "excursions",
+                                                            "insurance"
+                                                          ]
+                                                        },
+                                                        "groupKey": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricingMode": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "unitAmountCents": {
+                                                          "type": ["integer", "null"]
+                                                        },
+                                                        "currency": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": ["boolean", "null"]
+                                                        },
+                                                        "selectionType": {
+                                                          "type": ["string", "null"],
+                                                          "enum": [
+                                                            "optional",
+                                                            "required",
+                                                            "default_selected",
+                                                            "unavailable",
+                                                            null
+                                                          ]
+                                                        },
+                                                        "minQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "maxQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        },
+                                                        "defaultQuantity": {
+                                                          "type": ["integer", "null"],
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["id", "name", "kind"]
+                                                    }
+                                                  }
+                                                },
+                                                "required": [
+                                                  "kind",
+                                                  "label",
+                                                  "perGuestSelection",
+                                                  "items"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "ancillaries": {
+                                          "type": "object",
+                                          "properties": {
+                                            "groups": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "offers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "offerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerLabel": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "title": {
+                                                          "type": "string"
+                                                        },
+                                                        "summary": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "planLabel": {
+                                                          "type": ["string", "null"]
+                                                        },
+                                                        "price": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "amountMinor": {
+                                                              "type": "integer"
+                                                            },
+                                                            "currency": {
+                                                              "type": "string",
+                                                              "pattern": "^[A-Z]{3}$"
+                                                            }
+                                                          },
+                                                          "required": ["amountMinor", "currency"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "pricedPerPerson": {
+                                                          "type": "boolean",
+                                                          "default": false
+                                                        },
+                                                        "highlights": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": ["label"],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "eligibility": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "status": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "eligible",
+                                                                "ineligible",
+                                                                "referral"
+                                                              ]
+                                                            },
+                                                            "reasons": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "code": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "message": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["code", "message"],
+                                                                "additionalProperties": false
+                                                              },
+                                                              "default": []
+                                                            }
+                                                          },
+                                                          "required": ["status"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "disclosures": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "kind": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "versionId": {
+                                                                "type": "string"
+                                                              },
+                                                              "url": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "kind",
+                                                              "label",
+                                                              "versionId",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "requiredTravelerFields": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "key": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": {
+                                                                "type": "string"
+                                                              },
+                                                              "required": {
+                                                                "type": "boolean"
+                                                              },
+                                                              "sensitive": {
+                                                                "type": "boolean",
+                                                                "default": false
+                                                              },
+                                                              "options": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "value": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "label": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "required": ["value", "label"],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "helpText": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key",
+                                                              "label",
+                                                              "type",
+                                                              "required"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          "default": []
+                                                        },
+                                                        "validUntil": {
+                                                          "type": "string"
+                                                        },
+                                                        "quoteRef": {
+                                                          "type": "string"
+                                                        },
+                                                        "metadata": {
+                                                          "type": "object",
+                                                          "additionalProperties": {}
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "offerId",
+                                                        "sourceId",
+                                                        "providerId",
+                                                        "providerLabel",
+                                                        "kind",
+                                                        "title",
+                                                        "price",
+                                                        "eligibility",
+                                                        "validUntil",
+                                                        "quoteRef"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  },
+                                                  "diagnostics": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "sourceId": {
+                                                          "type": "string"
+                                                        },
+                                                        "providerId": {
+                                                          "type": "string"
+                                                        },
+                                                        "status": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "ok",
+                                                            "timeout",
+                                                            "error",
+                                                            "unavailable"
+                                                          ]
+                                                        },
+                                                        "message": {
+                                                          "type": "string"
+                                                        },
+                                                        "latencyMs": {
+                                                          "type": "integer",
+                                                          "minimum": 0
+                                                        }
+                                                      },
+                                                      "required": ["sourceId", "status"],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "default": []
+                                                  }
+                                                },
+                                                "required": ["kind", "label"],
+                                                "additionalProperties": false
+                                              },
+                                              "default": []
+                                            }
+                                          }
+                                        },
+                                        "paymentIntents": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string",
+                                            "enum": [
+                                              "hold",
+                                              "card",
+                                              "bank_transfer",
+                                              "ticket_on_credit",
+                                              "inquiry"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "showsConfigure",
+                                        "showsBilling",
+                                        "showsTravelers",
+                                        "showsAccommodation",
+                                        "showsAddons",
+                                        "showsPayment",
+                                        "showsReview",
+                                        "paxBands",
+                                        "paxBandsAllowedTotal",
+                                        "travelerFields",
+                                        "bookingFields",
+                                        "paymentIntents"
+                                      ]
+                                    },
+                                    "requirementsFingerprint": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "expiresAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "target",
+                                    "actorKind",
+                                    "state",
+                                    "revision",
+                                    "scope",
+                                    "expiresAt",
+                                    "createdAt",
+                                    "updatedAt"
+                                  ]
+                                },
+                                "hold": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "sessionId": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "quoteId": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "target": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["product"]
+                                            },
+                                            "productId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "productId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["catalog_item"]
+                                            },
+                                            "catalogItemId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "catalogItemId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["owned_entity"]
+                                            },
+                                            "entityModule": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "entityId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "entityModule", "entityId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["trip_snapshot"]
+                                            },
+                                            "tripSnapshotId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "tripEnvelopeId": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": ["managed_itinerary"]
+                                            }
+                                          },
+                                          "required": ["kind"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "quantity": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "state": {
+                                      "type": "string",
+                                      "enum": ["active", "converted", "released", "expired"]
+                                    },
+                                    "expiresAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "sessionId",
+                                    "quoteId",
+                                    "target",
+                                    "quantity",
+                                    "state",
+                                    "expiresAt",
+                                    "createdAt"
+                                  ]
+                                }
+                              },
+                              "required": ["kind", "session", "hold"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["commit_result"]
+                                },
+                                "outcome": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["committed"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["none"]
+                                        },
+                                        "checkoutIntent": {
+                                          "type": "string",
+                                          "enum": [
+                                            "hold",
+                                            "card",
+                                            "bank_transfer",
+                                            "ticket_on_credit",
+                                            "inquiry"
+                                          ]
+                                        },
+                                        "bankTransfer": {
+                                          "type": "object",
+                                          "properties": {
+                                            "paymentSessionId": {
+                                              "type": ["string", "null"],
+                                              "minLength": 1
+                                            },
+                                            "document": {
+                                              "type": ["object", "null"],
+                                              "properties": {
+                                                "id": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "number": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": ["proforma", "invoice"]
+                                                }
+                                              },
+                                              "required": ["id", "number", "type"]
+                                            },
+                                            "instructions": {
+                                              "type": "object",
+                                              "properties": {
+                                                "beneficiary": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "iban": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "bankName": {
+                                                  "type": ["string", "null"],
+                                                  "minLength": 1
+                                                },
+                                                "reference": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "amountCents": {
+                                                  "type": "integer",
+                                                  "exclusiveMinimum": 0
+                                                },
+                                                "currency": {
+                                                  "type": "string",
+                                                  "minLength": 3,
+                                                  "maxLength": 3
+                                                },
+                                                "dueAt": {
+                                                  "type": "string",
+                                                  "format": "date-time"
+                                                }
+                                              },
+                                              "required": [
+                                                "beneficiary",
+                                                "iban",
+                                                "bankName",
+                                                "reference",
+                                                "amountCents",
+                                                "currency",
+                                                "dueAt"
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "paymentSessionId",
+                                            "document",
+                                            "instructions"
+                                          ]
+                                        },
+                                        "booking": {
+                                          "type": "object",
+                                          "properties": {
+                                            "id": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "status": {
+                                              "type": "string",
+                                              "enum": ["confirmed"]
+                                            }
+                                          },
+                                          "required": ["id", "status"]
+                                        },
+                                        "allocationIds": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          }
+                                        },
+                                        "consumedSessionId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "consumedQuoteId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "convertedHoldId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "supplierOperationId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "operatorBackedRiskAccepted": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "nextAction",
+                                        "booking",
+                                        "allocationIds",
+                                        "consumedSessionId",
+                                        "consumedQuoteId"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["component_bookings_committed"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["none"]
+                                        },
+                                        "checkoutIntent": {
+                                          "type": "string",
+                                          "enum": [
+                                            "hold",
+                                            "card",
+                                            "bank_transfer",
+                                            "ticket_on_credit",
+                                            "inquiry"
+                                          ]
+                                        },
+                                        "bankTransfer": {
+                                          "type": "object",
+                                          "properties": {
+                                            "paymentSessionId": {
+                                              "type": ["string", "null"],
+                                              "minLength": 1
+                                            },
+                                            "document": {
+                                              "type": ["object", "null"],
+                                              "properties": {
+                                                "id": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "number": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": ["proforma", "invoice"]
+                                                }
+                                              },
+                                              "required": ["id", "number", "type"]
+                                            },
+                                            "instructions": {
+                                              "type": "object",
+                                              "properties": {
+                                                "beneficiary": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "iban": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "bankName": {
+                                                  "type": ["string", "null"],
+                                                  "minLength": 1
+                                                },
+                                                "reference": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "amountCents": {
+                                                  "type": "integer",
+                                                  "exclusiveMinimum": 0
+                                                },
+                                                "currency": {
+                                                  "type": "string",
+                                                  "minLength": 3,
+                                                  "maxLength": 3
+                                                },
+                                                "dueAt": {
+                                                  "type": "string",
+                                                  "format": "date-time"
+                                                }
+                                              },
+                                              "required": [
+                                                "beneficiary",
+                                                "iban",
+                                                "bankName",
+                                                "reference",
+                                                "amountCents",
+                                                "currency",
+                                                "dueAt"
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "paymentSessionId",
+                                            "document",
+                                            "instructions"
+                                          ]
+                                        },
+                                        "bookings": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "componentId": {
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "bookingId": {
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "status": {
+                                                "type": "string",
+                                                "enum": ["confirmed"]
+                                              },
+                                              "allocationIds": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "supplierOperationId": {
+                                                "type": "string",
+                                                "minLength": 1
+                                              }
+                                            },
+                                            "required": [
+                                              "componentId",
+                                              "bookingId",
+                                              "status",
+                                              "allocationIds"
+                                            ]
+                                          },
+                                          "minItems": 1
+                                        },
+                                        "consumedSessionId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "consumedQuoteId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "convertedHoldId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "nextAction",
+                                        "bookings",
+                                        "consumedSessionId",
+                                        "consumedQuoteId"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["component_commit_pending"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["continue_component_commit"]
+                                        },
+                                        "components": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "componentId": {
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "state": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "booking_confirmed",
+                                                  "supplier_pending",
+                                                  "supplier_in_doubt",
+                                                  "manual_confirmation_required"
+                                                ]
+                                              },
+                                              "bookingId": {
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "supplierOperationId": {
+                                                "type": "string",
+                                                "minLength": 1
+                                              }
+                                            },
+                                            "required": ["componentId", "state"]
+                                          }
+                                        }
+                                      },
+                                      "required": ["kind", "nextAction", "components"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["payment_required"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["establish_payment_guarantee"]
+                                        },
+                                        "checkoutIntent": {
+                                          "type": "string",
+                                          "enum": [
+                                            "hold",
+                                            "card",
+                                            "bank_transfer",
+                                            "ticket_on_credit",
+                                            "inquiry"
+                                          ]
+                                        },
+                                        "paymentTarget": {
+                                          "type": "string",
+                                          "enum": ["booking_session", "quote", "supplier_operation"]
+                                        },
+                                        "allowedGuarantees": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string",
+                                            "enum": [
+                                              "deposit",
+                                              "pre_auth",
+                                              "card_on_file",
+                                              "agency_letter"
+                                            ]
+                                          }
+                                        },
+                                        "paymentSession": {
+                                          "type": "object",
+                                          "properties": {
+                                            "id": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            },
+                                            "status": {
+                                              "type": "string",
+                                              "enum": [
+                                                "pending",
+                                                "requires_redirect",
+                                                "processing",
+                                                "authorized",
+                                                "paid",
+                                                "failed",
+                                                "cancelled",
+                                                "expired"
+                                              ]
+                                            },
+                                            "amountCents": {
+                                              "type": "integer",
+                                              "exclusiveMinimum": 0
+                                            },
+                                            "currency": {
+                                              "type": "string",
+                                              "minLength": 3,
+                                              "maxLength": 3
+                                            },
+                                            "redirectUrl": {
+                                              "type": ["string", "null"],
+                                              "format": "uri"
+                                            },
+                                            "checkout": {
+                                              "oneOf": [
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "kind": {
+                                                      "type": "string",
+                                                      "enum": ["hosted_checkout", "redirect"]
+                                                    },
+                                                    "url": {
+                                                      "type": "string"
+                                                    },
+                                                    "expiresAt": {
+                                                      "type": ["string", "null"]
+                                                    }
+                                                  },
+                                                  "required": ["kind", "url"]
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "kind": {
+                                                      "type": "string",
+                                                      "enum": ["embedded"]
+                                                    },
+                                                    "clientSecret": {
+                                                      "type": "string"
+                                                    },
+                                                    "publishableKey": {
+                                                      "type": "string"
+                                                    },
+                                                    "providerAccountId": {
+                                                      "type": ["string", "null"]
+                                                    },
+                                                    "expiresAt": {
+                                                      "type": ["string", "null"]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "kind",
+                                                    "clientSecret",
+                                                    "publishableKey"
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "expiresAt": {
+                                              "type": ["string", "null"],
+                                              "format": "date-time"
+                                            }
+                                          },
+                                          "required": [
+                                            "id",
+                                            "status",
+                                            "amountCents",
+                                            "currency",
+                                            "redirectUrl",
+                                            "checkout",
+                                            "expiresAt"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "nextAction",
+                                        "paymentTarget",
+                                        "allowedGuarantees",
+                                        "paymentSession"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["supplier_pending"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": [
+                                            "persist_and_dispatch_supplier_operation",
+                                            "await_supplier_operation"
+                                          ]
+                                        },
+                                        "supplierOperationId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "bookingId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "operatorBackedRiskAccepted": {
+                                          "type": "boolean",
+                                          "default": false
+                                        }
+                                      },
+                                      "required": ["kind", "nextAction", "supplierOperationId"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["supplier_in_doubt"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["reconcile_supplier_operation"]
+                                        },
+                                        "supplierOperationId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "bookingId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "operatorBackedRiskAccepted": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "nextAction",
+                                        "supplierOperationId",
+                                        "operatorBackedRiskAccepted"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["supplier_failed"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["select_alternative_inventory", "manual_review"]
+                                        },
+                                        "supplierOperationId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "bookingId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "operatorBackedRiskAccepted": {
+                                          "type": "boolean",
+                                          "default": false
+                                        }
+                                      },
+                                      "required": ["kind", "nextAction", "supplierOperationId"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["revision_mismatch"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["refresh_session_state"]
+                                        },
+                                        "expectedRevision": {
+                                          "type": "integer",
+                                          "exclusiveMinimum": 0
+                                        },
+                                        "actualRevision": {
+                                          "type": "integer",
+                                          "exclusiveMinimum": 0
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "nextAction",
+                                        "expectedRevision",
+                                        "actualRevision"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["quote_failure"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["request_fresh_quote"]
+                                        },
+                                        "reason": {
+                                          "type": "string",
+                                          "enum": [
+                                            "expired",
+                                            "superseded",
+                                            "mismatched_session",
+                                            "mismatched_revision"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["kind", "nextAction", "reason"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["hold_failure"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["request_new_hold"]
+                                        },
+                                        "reason": {
+                                          "type": "string",
+                                          "enum": [
+                                            "missing",
+                                            "expired",
+                                            "released",
+                                            "mismatched_session",
+                                            "capacity_unavailable"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["kind", "nextAction", "reason"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["proposal_acceptance_required"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["renew_proposal_version_acceptance"]
+                                        },
+                                        "proposalVersionId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        }
+                                      },
+                                      "required": ["kind", "nextAction", "proposalVersionId"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["idempotent_replay"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["return_idempotent_result"]
+                                        },
+                                        "originalCommitId": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "originalOutcome": {
+                                          "oneOf": [
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["committed"]
+                                                },
+                                                "nextAction": {
+                                                  "type": "string",
+                                                  "enum": ["none"]
+                                                },
+                                                "checkoutIntent": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "hold",
+                                                    "card",
+                                                    "bank_transfer",
+                                                    "ticket_on_credit",
+                                                    "inquiry"
+                                                  ]
+                                                },
+                                                "bankTransfer": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "paymentSessionId": {
+                                                      "type": ["string", "null"],
+                                                      "minLength": 1
+                                                    },
+                                                    "document": {
+                                                      "type": ["object", "null"],
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string",
+                                                          "minLength": 1
+                                                        },
+                                                        "number": {
+                                                          "type": "string",
+                                                          "minLength": 1
+                                                        },
+                                                        "type": {
+                                                          "type": "string",
+                                                          "enum": ["proforma", "invoice"]
+                                                        }
+                                                      },
+                                                      "required": ["id", "number", "type"]
+                                                    },
+                                                    "instructions": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "beneficiary": {
+                                                          "type": "string",
+                                                          "minLength": 1
+                                                        },
+                                                        "iban": {
+                                                          "type": "string",
+                                                          "minLength": 1
+                                                        },
+                                                        "bankName": {
+                                                          "type": ["string", "null"],
+                                                          "minLength": 1
+                                                        },
+                                                        "reference": {
+                                                          "type": "string",
+                                                          "minLength": 1
+                                                        },
+                                                        "amountCents": {
+                                                          "type": "integer",
+                                                          "exclusiveMinimum": 0
+                                                        },
+                                                        "currency": {
+                                                          "type": "string",
+                                                          "minLength": 3,
+                                                          "maxLength": 3
+                                                        },
+                                                        "dueAt": {
+                                                          "type": "string",
+                                                          "format": "date-time"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "beneficiary",
+                                                        "iban",
+                                                        "bankName",
+                                                        "reference",
+                                                        "amountCents",
+                                                        "currency",
+                                                        "dueAt"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "paymentSessionId",
+                                                    "document",
+                                                    "instructions"
+                                                  ]
+                                                },
+                                                "booking": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "id": {
+                                                      "type": "string",
+                                                      "minLength": 1
+                                                    },
+                                                    "status": {
+                                                      "type": "string",
+                                                      "enum": ["confirmed"]
+                                                    }
+                                                  },
+                                                  "required": ["id", "status"]
+                                                },
+                                                "allocationIds": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  }
+                                                },
+                                                "consumedSessionId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "consumedQuoteId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "convertedHoldId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "supplierOperationId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "operatorBackedRiskAccepted": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "kind",
+                                                "nextAction",
+                                                "booking",
+                                                "allocationIds",
+                                                "consumedSessionId",
+                                                "consumedQuoteId"
+                                              ]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["component_bookings_committed"]
+                                                },
+                                                "nextAction": {
+                                                  "type": "string",
+                                                  "enum": ["none"]
+                                                },
+                                                "checkoutIntent": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "hold",
+                                                    "card",
+                                                    "bank_transfer",
+                                                    "ticket_on_credit",
+                                                    "inquiry"
+                                                  ]
+                                                },
+                                                "bankTransfer": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "paymentSessionId": {
+                                                      "type": ["string", "null"],
+                                                      "minLength": 1
+                                                    },
+                                                    "document": {
+                                                      "type": ["object", "null"],
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string",
+                                                          "minLength": 1
+                                                        },
+                                                        "number": {
+                                                          "type": "string",
+                                                          "minLength": 1
+                                                        },
+                                                        "type": {
+                                                          "type": "string",
+                                                          "enum": ["proforma", "invoice"]
+                                                        }
+                                                      },
+                                                      "required": ["id", "number", "type"]
+                                                    },
+                                                    "instructions": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "beneficiary": {
+                                                          "type": "string",
+                                                          "minLength": 1
+                                                        },
+                                                        "iban": {
+                                                          "type": "string",
+                                                          "minLength": 1
+                                                        },
+                                                        "bankName": {
+                                                          "type": ["string", "null"],
+                                                          "minLength": 1
+                                                        },
+                                                        "reference": {
+                                                          "type": "string",
+                                                          "minLength": 1
+                                                        },
+                                                        "amountCents": {
+                                                          "type": "integer",
+                                                          "exclusiveMinimum": 0
+                                                        },
+                                                        "currency": {
+                                                          "type": "string",
+                                                          "minLength": 3,
+                                                          "maxLength": 3
+                                                        },
+                                                        "dueAt": {
+                                                          "type": "string",
+                                                          "format": "date-time"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "beneficiary",
+                                                        "iban",
+                                                        "bankName",
+                                                        "reference",
+                                                        "amountCents",
+                                                        "currency",
+                                                        "dueAt"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "paymentSessionId",
+                                                    "document",
+                                                    "instructions"
+                                                  ]
+                                                },
+                                                "bookings": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "componentId": {
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      },
+                                                      "bookingId": {
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      },
+                                                      "status": {
+                                                        "type": "string",
+                                                        "enum": ["confirmed"]
+                                                      },
+                                                      "allocationIds": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string",
+                                                          "minLength": 1
+                                                        }
+                                                      },
+                                                      "supplierOperationId": {
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "componentId",
+                                                      "bookingId",
+                                                      "status",
+                                                      "allocationIds"
+                                                    ]
+                                                  },
+                                                  "minItems": 1
+                                                },
+                                                "consumedSessionId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "consumedQuoteId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "convertedHoldId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "kind",
+                                                "nextAction",
+                                                "bookings",
+                                                "consumedSessionId",
+                                                "consumedQuoteId"
+                                              ]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["component_commit_pending"]
+                                                },
+                                                "nextAction": {
+                                                  "type": "string",
+                                                  "enum": ["continue_component_commit"]
+                                                },
+                                                "components": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "componentId": {
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      },
+                                                      "state": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "booking_confirmed",
+                                                          "supplier_pending",
+                                                          "supplier_in_doubt",
+                                                          "manual_confirmation_required"
+                                                        ]
+                                                      },
+                                                      "bookingId": {
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      },
+                                                      "supplierOperationId": {
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      }
+                                                    },
+                                                    "required": ["componentId", "state"]
+                                                  }
+                                                }
+                                              },
+                                              "required": ["kind", "nextAction", "components"]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["payment_required"]
+                                                },
+                                                "nextAction": {
+                                                  "type": "string",
+                                                  "enum": ["establish_payment_guarantee"]
+                                                },
+                                                "checkoutIntent": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "hold",
+                                                    "card",
+                                                    "bank_transfer",
+                                                    "ticket_on_credit",
+                                                    "inquiry"
+                                                  ]
+                                                },
+                                                "paymentTarget": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "booking_session",
+                                                    "quote",
+                                                    "supplier_operation"
+                                                  ]
+                                                },
+                                                "allowedGuarantees": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "deposit",
+                                                      "pre_auth",
+                                                      "card_on_file",
+                                                      "agency_letter"
+                                                    ]
+                                                  }
+                                                },
+                                                "paymentSession": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "id": {
+                                                      "type": "string",
+                                                      "minLength": 1
+                                                    },
+                                                    "status": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "pending",
+                                                        "requires_redirect",
+                                                        "processing",
+                                                        "authorized",
+                                                        "paid",
+                                                        "failed",
+                                                        "cancelled",
+                                                        "expired"
+                                                      ]
+                                                    },
+                                                    "amountCents": {
+                                                      "type": "integer",
+                                                      "exclusiveMinimum": 0
+                                                    },
+                                                    "currency": {
+                                                      "type": "string",
+                                                      "minLength": 3,
+                                                      "maxLength": 3
+                                                    },
+                                                    "redirectUrl": {
+                                                      "type": ["string", "null"],
+                                                      "format": "uri"
+                                                    },
+                                                    "checkout": {
+                                                      "oneOf": [
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "kind": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "hosted_checkout",
+                                                                "redirect"
+                                                              ]
+                                                            },
+                                                            "url": {
+                                                              "type": "string"
+                                                            },
+                                                            "expiresAt": {
+                                                              "type": ["string", "null"]
+                                                            }
+                                                          },
+                                                          "required": ["kind", "url"]
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "kind": {
+                                                              "type": "string",
+                                                              "enum": ["embedded"]
+                                                            },
+                                                            "clientSecret": {
+                                                              "type": "string"
+                                                            },
+                                                            "publishableKey": {
+                                                              "type": "string"
+                                                            },
+                                                            "providerAccountId": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "expiresAt": {
+                                                              "type": ["string", "null"]
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "kind",
+                                                            "clientSecret",
+                                                            "publishableKey"
+                                                          ]
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "expiresAt": {
+                                                      "type": ["string", "null"],
+                                                      "format": "date-time"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "id",
+                                                    "status",
+                                                    "amountCents",
+                                                    "currency",
+                                                    "redirectUrl",
+                                                    "checkout",
+                                                    "expiresAt"
+                                                  ]
+                                                }
+                                              },
+                                              "required": [
+                                                "kind",
+                                                "nextAction",
+                                                "paymentTarget",
+                                                "allowedGuarantees",
+                                                "paymentSession"
+                                              ]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["supplier_pending"]
+                                                },
+                                                "nextAction": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "persist_and_dispatch_supplier_operation",
+                                                    "await_supplier_operation"
+                                                  ]
+                                                },
+                                                "supplierOperationId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "bookingId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "operatorBackedRiskAccepted": {
+                                                  "type": "boolean",
+                                                  "default": false
+                                                }
+                                              },
+                                              "required": [
+                                                "kind",
+                                                "nextAction",
+                                                "supplierOperationId"
+                                              ]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["supplier_in_doubt"]
+                                                },
+                                                "nextAction": {
+                                                  "type": "string",
+                                                  "enum": ["reconcile_supplier_operation"]
+                                                },
+                                                "supplierOperationId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "bookingId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "operatorBackedRiskAccepted": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "kind",
+                                                "nextAction",
+                                                "supplierOperationId",
+                                                "operatorBackedRiskAccepted"
+                                              ]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["supplier_failed"]
+                                                },
+                                                "nextAction": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "select_alternative_inventory",
+                                                    "manual_review"
+                                                  ]
+                                                },
+                                                "supplierOperationId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "bookingId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "operatorBackedRiskAccepted": {
+                                                  "type": "boolean",
+                                                  "default": false
+                                                }
+                                              },
+                                              "required": [
+                                                "kind",
+                                                "nextAction",
+                                                "supplierOperationId"
+                                              ]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["revision_mismatch"]
+                                                },
+                                                "nextAction": {
+                                                  "type": "string",
+                                                  "enum": ["refresh_session_state"]
+                                                },
+                                                "expectedRevision": {
+                                                  "type": "integer",
+                                                  "exclusiveMinimum": 0
+                                                },
+                                                "actualRevision": {
+                                                  "type": "integer",
+                                                  "exclusiveMinimum": 0
+                                                }
+                                              },
+                                              "required": [
+                                                "kind",
+                                                "nextAction",
+                                                "expectedRevision",
+                                                "actualRevision"
+                                              ]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["quote_failure"]
+                                                },
+                                                "nextAction": {
+                                                  "type": "string",
+                                                  "enum": ["request_fresh_quote"]
+                                                },
+                                                "reason": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "expired",
+                                                    "superseded",
+                                                    "mismatched_session",
+                                                    "mismatched_revision"
+                                                  ]
+                                                }
+                                              },
+                                              "required": ["kind", "nextAction", "reason"]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["hold_failure"]
+                                                },
+                                                "nextAction": {
+                                                  "type": "string",
+                                                  "enum": ["request_new_hold"]
+                                                },
+                                                "reason": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "missing",
+                                                    "expired",
+                                                    "released",
+                                                    "mismatched_session",
+                                                    "capacity_unavailable"
+                                                  ]
+                                                }
+                                              },
+                                              "required": ["kind", "nextAction", "reason"]
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string",
+                                                  "enum": ["proposal_acceptance_required"]
+                                                },
+                                                "nextAction": {
+                                                  "type": "string",
+                                                  "enum": ["renew_proposal_version_acceptance"]
+                                                },
+                                                "proposalVersionId": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "kind",
+                                                "nextAction",
+                                                "proposalVersionId"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "nextAction",
+                                        "originalCommitId",
+                                        "originalOutcome"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": ["kind", "outcome"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["rejected"]
+                                },
+                                "error": {
+                                  "oneOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["revision_conflict"]
+                                        },
+                                        "expectedRevision": {
+                                          "type": "integer",
+                                          "exclusiveMinimum": 0
+                                        },
+                                        "actualRevision": {
+                                          "type": "integer",
+                                          "exclusiveMinimum": 0
+                                        },
+                                        "actualState": {
+                                          "type": "string",
+                                          "enum": [
+                                            "active",
+                                            "supplier_pending",
+                                            "component_pending",
+                                            "consumed",
+                                            "expired",
+                                            "abandoned"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "expectedRevision",
+                                        "actualRevision",
+                                        "actualState"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["session_expired"]
+                                        }
+                                      },
+                                      "required": ["kind"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["session_consumed"]
+                                        }
+                                      },
+                                      "required": ["kind"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["capability_required"]
+                                        }
+                                      },
+                                      "required": ["kind"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["capability_scope_required"]
+                                        },
+                                        "action": {
+                                          "type": "string",
+                                          "enum": [
+                                            "read",
+                                            "update",
+                                            "quote",
+                                            "hold",
+                                            "commit",
+                                            "abandon",
+                                            "adopt",
+                                            "renew"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["kind", "action"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["not_authorized"]
+                                        }
+                                      },
+                                      "required": ["kind"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["idempotency_conflict"]
+                                        }
+                                      },
+                                      "required": ["kind"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["supplier_operation_active"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["reconcile_supplier_operation"]
+                                        }
+                                      },
+                                      "required": ["kind", "nextAction"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["payment_in_flight"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["await_payment_outcome"]
+                                        }
+                                      },
+                                      "required": ["kind", "nextAction"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["quote_unavailable"]
+                                        },
+                                        "requirements": {
+                                          "type": "object",
+                                          "properties": {
+                                            "showsConfigure": {
+                                              "type": "boolean"
+                                            },
+                                            "showsBilling": {
+                                              "type": "boolean"
+                                            },
+                                            "showsTravelers": {
+                                              "type": "boolean"
+                                            },
+                                            "showsAccommodation": {
+                                              "type": "boolean"
+                                            },
+                                            "showsAddons": {
+                                              "type": "boolean"
+                                            },
+                                            "showsAncillaries": {
+                                              "type": "boolean",
+                                              "default": false
+                                            },
+                                            "showsPayment": {
+                                              "type": "boolean"
+                                            },
+                                            "showsReview": {
+                                              "type": "boolean",
+                                              "enum": [true]
+                                            },
+                                            "configureSubSteps": {
+                                              "type": "array",
+                                              "items": {
+                                                "oneOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["departure"]
+                                                      },
+                                                      "required": {
+                                                        "type": "boolean",
+                                                        "enum": [true]
+                                                      }
+                                                    },
+                                                    "required": ["kind", "required"]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["product-option"]
+                                                      },
+                                                      "options": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "code": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "description": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "isDefault": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "units": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "id": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "name": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "description": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "unitType": {
+                                                                    "type": ["string", "null"]
+                                                                  },
+                                                                  "minQuantity": {
+                                                                    "type": ["integer", "null"],
+                                                                    "minimum": 0
+                                                                  },
+                                                                  "maxQuantity": {
+                                                                    "type": ["integer", "null"],
+                                                                    "minimum": 0
+                                                                  }
+                                                                },
+                                                                "required": ["id", "name"]
+                                                              }
+                                                            }
+                                                          },
+                                                          "required": ["id", "name"]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": ["kind", "options"]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["option-units"]
+                                                      }
+                                                    },
+                                                    "required": ["kind"]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["cabin-category"]
+                                                      },
+                                                      "categories": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "code": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": {
+                                                              "type": "string"
+                                                            },
+                                                            "capacityMin": {
+                                                              "type": "integer",
+                                                              "minimum": 0
+                                                            },
+                                                            "capacityMax": {
+                                                              "type": "integer",
+                                                              "minimum": 0
+                                                            },
+                                                            "description": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": ["id", "name"]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": ["kind", "categories"]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["cabin-number"]
+                                                      },
+                                                      "perCategory": {
+                                                        "type": "object",
+                                                        "additionalProperties": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "id": {
+                                                                "type": "string"
+                                                              },
+                                                              "code": {
+                                                                "type": "string"
+                                                              },
+                                                              "label": {
+                                                                "type": "string"
+                                                              },
+                                                              "capacity": {
+                                                                "type": "integer",
+                                                                "minimum": 0
+                                                              },
+                                                              "hasAccessibilityFeatures": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": ["id", "label"]
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": ["kind", "perCategory"]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["date-range"]
+                                                      },
+                                                      "minNights": {
+                                                        "type": "integer",
+                                                        "exclusiveMinimum": 0
+                                                      },
+                                                      "maxNights": {
+                                                        "type": "integer",
+                                                        "exclusiveMinimum": 0
+                                                      }
+                                                    },
+                                                    "required": ["kind", "minNights", "maxNights"]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["occupancy"]
+                                                      },
+                                                      "bands": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "code": {
+                                                              "type": "string"
+                                                            },
+                                                            "label": {
+                                                              "type": "string"
+                                                            },
+                                                            "minAge": {
+                                                              "type": "integer",
+                                                              "minimum": 0
+                                                            },
+                                                            "maxAge": {
+                                                              "type": "integer",
+                                                              "minimum": 0
+                                                            },
+                                                            "minCount": {
+                                                              "type": "integer",
+                                                              "minimum": 0
+                                                            },
+                                                            "maxCount": {
+                                                              "type": "integer",
+                                                              "minimum": 0
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "code",
+                                                            "label",
+                                                            "minCount",
+                                                            "maxCount"
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": ["kind", "bands"]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": ["air-arrangement"]
+                                                      },
+                                                      "required": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": ["kind"]
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "paxBands": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "code": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "minAge": {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                  },
+                                                  "maxAge": {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                  },
+                                                  "minCount": {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                  },
+                                                  "maxCount": {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                  }
+                                                },
+                                                "required": [
+                                                  "code",
+                                                  "label",
+                                                  "minCount",
+                                                  "maxCount"
+                                                ]
+                                              }
+                                            },
+                                            "paxBandsAllowedTotal": {
+                                              "type": "object",
+                                              "properties": {
+                                                "min": {
+                                                  "type": "integer"
+                                                },
+                                                "max": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "required": ["min", "max"]
+                                            },
+                                            "paxBandDependencies": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "dependentCode": {
+                                                    "type": "string"
+                                                  },
+                                                  "masterCode": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "requires",
+                                                      "limits_per_master",
+                                                      "limits_sum",
+                                                      "excludes"
+                                                    ]
+                                                  },
+                                                  "maxPerMaster": {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                  },
+                                                  "maxDependentSum": {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                  }
+                                                },
+                                                "required": ["dependentCode", "masterCode", "type"]
+                                              }
+                                            },
+                                            "travelerFields": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "options": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "value": {
+                                                          "type": "string"
+                                                        },
+                                                        "label": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": ["value", "label"]
+                                                    }
+                                                  },
+                                                  "appliesToBands": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "maxLength": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  }
+                                                },
+                                                "required": ["key", "label", "type", "required"]
+                                              }
+                                            },
+                                            "bookingFields": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "required": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "group": {
+                                                    "type": "string",
+                                                    "enum": ["billing", "company", "preferences"]
+                                                  },
+                                                  "maxLength": {
+                                                    "type": "integer",
+                                                    "exclusiveMinimum": 0
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key",
+                                                  "label",
+                                                  "type",
+                                                  "required",
+                                                  "group"
+                                                ]
+                                              }
+                                            },
+                                            "accommodation": {
+                                              "type": "object",
+                                              "properties": {
+                                                "roomOptions": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "id": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "description": {
+                                                        "type": ["string", "null"]
+                                                      },
+                                                      "capacity": {
+                                                        "type": ["integer", "null"],
+                                                        "minimum": 0
+                                                      },
+                                                      "baseRateHint": {
+                                                        "type": ["number", "null"]
+                                                      },
+                                                      "ratePlans": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "description": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "chargeFrequency": {
+                                                              "type": "string",
+                                                              "enum": ["per_night", "per_stay"]
+                                                            },
+                                                            "cancellationPolicy": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "inclusions": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "currency": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": ["id", "name"]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": ["id", "name"]
+                                                  }
+                                                },
+                                                "sharedRoomAllowed": {
+                                                  "type": "boolean"
+                                                },
+                                                "subSteps": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "kind": {
+                                                            "type": "string",
+                                                            "enum": ["rooms"]
+                                                          },
+                                                          "options": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "id": {
+                                                                  "type": "string"
+                                                                },
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "description": {
+                                                                  "type": ["string", "null"]
+                                                                },
+                                                                "capacity": {
+                                                                  "type": ["integer", "null"],
+                                                                  "minimum": 0
+                                                                },
+                                                                "baseRateHint": {
+                                                                  "type": ["number", "null"]
+                                                                },
+                                                                "ratePlans": {
+                                                                  "type": "array",
+                                                                  "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                      "id": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "name": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "description": {
+                                                                        "type": ["string", "null"]
+                                                                      },
+                                                                      "chargeFrequency": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                          "per_night",
+                                                                          "per_stay"
+                                                                        ]
+                                                                      },
+                                                                      "cancellationPolicy": {
+                                                                        "type": ["string", "null"]
+                                                                      },
+                                                                      "inclusions": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "currency": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "required": ["id", "name"]
+                                                                  }
+                                                                }
+                                                              },
+                                                              "required": ["id", "name"]
+                                                            }
+                                                          },
+                                                          "sharedRoomAllowed": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "kind",
+                                                          "options",
+                                                          "sharedRoomAllowed"
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "kind": {
+                                                            "type": "string",
+                                                            "enum": ["extensions"]
+                                                          },
+                                                          "options": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "id": {
+                                                                  "type": "string"
+                                                                },
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "city": {
+                                                                  "type": ["string", "null"]
+                                                                },
+                                                                "side": {
+                                                                  "type": "string",
+                                                                  "enum": ["pre", "post"]
+                                                                },
+                                                                "nights": {
+                                                                  "type": ["integer", "null"],
+                                                                  "minimum": 0
+                                                                },
+                                                                "pricePerPersonHint": {
+                                                                  "type": ["number", "null"]
+                                                                }
+                                                              },
+                                                              "required": ["id", "name", "side"]
+                                                            }
+                                                          },
+                                                          "allowsPre": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "allowsPost": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "kind",
+                                                          "options",
+                                                          "allowsPre",
+                                                          "allowsPost"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              "required": ["sharedRoomAllowed"]
+                                            },
+                                            "addons": {
+                                              "type": "object",
+                                              "properties": {
+                                                "catalog": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "id": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "description": {
+                                                        "type": ["string", "null"]
+                                                      },
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "extras",
+                                                          "excursions",
+                                                          "insurance"
+                                                        ]
+                                                      },
+                                                      "groupKey": {
+                                                        "type": ["string", "null"]
+                                                      },
+                                                      "pricingMode": {
+                                                        "type": ["string", "null"]
+                                                      },
+                                                      "unitAmountCents": {
+                                                        "type": ["integer", "null"]
+                                                      },
+                                                      "currency": {
+                                                        "type": ["string", "null"]
+                                                      },
+                                                      "pricedPerPerson": {
+                                                        "type": ["boolean", "null"]
+                                                      },
+                                                      "selectionType": {
+                                                        "type": ["string", "null"],
+                                                        "enum": [
+                                                          "optional",
+                                                          "required",
+                                                          "default_selected",
+                                                          "unavailable",
+                                                          null
+                                                        ]
+                                                      },
+                                                      "minQuantity": {
+                                                        "type": ["integer", "null"],
+                                                        "minimum": 0
+                                                      },
+                                                      "maxQuantity": {
+                                                        "type": ["integer", "null"],
+                                                        "minimum": 0
+                                                      },
+                                                      "defaultQuantity": {
+                                                        "type": ["integer", "null"],
+                                                        "minimum": 0
+                                                      }
+                                                    },
+                                                    "required": ["id", "name", "kind"]
+                                                  }
+                                                },
+                                                "groups": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "extras",
+                                                          "excursions",
+                                                          "insurance"
+                                                        ]
+                                                      },
+                                                      "label": {
+                                                        "type": "string"
+                                                      },
+                                                      "groupBy": {
+                                                        "type": "string",
+                                                        "enum": ["port", "day"]
+                                                      },
+                                                      "perGuestSelection": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "items": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "id": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "description": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "kind": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "extras",
+                                                                "excursions",
+                                                                "insurance"
+                                                              ]
+                                                            },
+                                                            "groupKey": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "pricingMode": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "unitAmountCents": {
+                                                              "type": ["integer", "null"]
+                                                            },
+                                                            "currency": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "pricedPerPerson": {
+                                                              "type": ["boolean", "null"]
+                                                            },
+                                                            "selectionType": {
+                                                              "type": ["string", "null"],
+                                                              "enum": [
+                                                                "optional",
+                                                                "required",
+                                                                "default_selected",
+                                                                "unavailable",
+                                                                null
+                                                              ]
+                                                            },
+                                                            "minQuantity": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "maxQuantity": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            },
+                                                            "defaultQuantity": {
+                                                              "type": ["integer", "null"],
+                                                              "minimum": 0
+                                                            }
+                                                          },
+                                                          "required": ["id", "name", "kind"]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "kind",
+                                                      "label",
+                                                      "perGuestSelection",
+                                                      "items"
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "ancillaries": {
+                                              "type": "object",
+                                              "properties": {
+                                                "groups": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "label": {
+                                                        "type": "string"
+                                                      },
+                                                      "offers": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "offerId": {
+                                                              "type": "string"
+                                                            },
+                                                            "sourceId": {
+                                                              "type": "string"
+                                                            },
+                                                            "providerId": {
+                                                              "type": "string"
+                                                            },
+                                                            "providerLabel": {
+                                                              "type": "string"
+                                                            },
+                                                            "kind": {
+                                                              "type": "string"
+                                                            },
+                                                            "title": {
+                                                              "type": "string"
+                                                            },
+                                                            "summary": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "planLabel": {
+                                                              "type": ["string", "null"]
+                                                            },
+                                                            "price": {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "amountMinor": {
+                                                                  "type": "integer"
+                                                                },
+                                                                "currency": {
+                                                                  "type": "string",
+                                                                  "pattern": "^[A-Z]{3}$"
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "amountMinor",
+                                                                "currency"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            },
+                                                            "pricedPerPerson": {
+                                                              "type": "boolean",
+                                                              "default": false
+                                                            },
+                                                            "highlights": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "label": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "value": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": ["label"],
+                                                                "additionalProperties": false
+                                                              },
+                                                              "default": []
+                                                            },
+                                                            "eligibility": {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "status": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "eligible",
+                                                                    "ineligible",
+                                                                    "referral"
+                                                                  ]
+                                                                },
+                                                                "reasons": {
+                                                                  "type": "array",
+                                                                  "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                      "code": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "message": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "required": ["code", "message"],
+                                                                    "additionalProperties": false
+                                                                  },
+                                                                  "default": []
+                                                                }
+                                                              },
+                                                              "required": ["status"],
+                                                              "additionalProperties": false
+                                                            },
+                                                            "disclosures": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "kind": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "label": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "versionId": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "url": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "required": {
+                                                                    "type": "boolean"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "kind",
+                                                                  "label",
+                                                                  "versionId",
+                                                                  "required"
+                                                                ],
+                                                                "additionalProperties": false
+                                                              },
+                                                              "default": []
+                                                            },
+                                                            "requiredTravelerFields": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "key": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "label": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "type": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "required": {
+                                                                    "type": "boolean"
+                                                                  },
+                                                                  "sensitive": {
+                                                                    "type": "boolean",
+                                                                    "default": false
+                                                                  },
+                                                                  "options": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "value": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "label": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "value",
+                                                                        "label"
+                                                                      ],
+                                                                      "additionalProperties": false
+                                                                    }
+                                                                  },
+                                                                  "helpText": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "key",
+                                                                  "label",
+                                                                  "type",
+                                                                  "required"
+                                                                ],
+                                                                "additionalProperties": false
+                                                              },
+                                                              "default": []
+                                                            },
+                                                            "validUntil": {
+                                                              "type": "string"
+                                                            },
+                                                            "quoteRef": {
+                                                              "type": "string"
+                                                            },
+                                                            "metadata": {
+                                                              "type": "object",
+                                                              "additionalProperties": {}
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "offerId",
+                                                            "sourceId",
+                                                            "providerId",
+                                                            "providerLabel",
+                                                            "kind",
+                                                            "title",
+                                                            "price",
+                                                            "eligibility",
+                                                            "validUntil",
+                                                            "quoteRef"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "default": []
+                                                      },
+                                                      "diagnostics": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "sourceId": {
+                                                              "type": "string"
+                                                            },
+                                                            "providerId": {
+                                                              "type": "string"
+                                                            },
+                                                            "status": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "ok",
+                                                                "timeout",
+                                                                "error",
+                                                                "unavailable"
+                                                              ]
+                                                            },
+                                                            "message": {
+                                                              "type": "string"
+                                                            },
+                                                            "latencyMs": {
+                                                              "type": "integer",
+                                                              "minimum": 0
+                                                            }
+                                                          },
+                                                          "required": ["sourceId", "status"],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "default": []
+                                                      }
+                                                    },
+                                                    "required": ["kind", "label"],
+                                                    "additionalProperties": false
+                                                  },
+                                                  "default": []
+                                                }
+                                              }
+                                            },
+                                            "paymentIntents": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "hold",
+                                                  "card",
+                                                  "bank_transfer",
+                                                  "ticket_on_credit",
+                                                  "inquiry"
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": [
+                                            "showsConfigure",
+                                            "showsBilling",
+                                            "showsTravelers",
+                                            "showsAccommodation",
+                                            "showsAddons",
+                                            "showsPayment",
+                                            "showsReview",
+                                            "paxBands",
+                                            "paxBandsAllowedTotal",
+                                            "travelerFields",
+                                            "bookingFields",
+                                            "paymentIntents"
+                                          ]
+                                        },
+                                        "reason": {
+                                          "type": "string",
+                                          "enum": [
+                                            "target_not_found",
+                                            "target_not_bookable",
+                                            "price_unavailable",
+                                            "policy_unavailable",
+                                            "selection_unavailable"
+                                          ]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": [
+                                            "select_alternative_inventory",
+                                            "contact_operator",
+                                            "update_selection"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["kind", "reason", "nextAction"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["commit_rejected"]
+                                        },
+                                        "reason": {
+                                          "type": "string",
+                                          "enum": [
+                                            "entity_not_found",
+                                            "entity_not_bookable",
+                                            "incomplete_draft",
+                                            "price_changed"
+                                          ]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": [
+                                            "select_alternative_inventory",
+                                            "update_selection",
+                                            "request_fresh_quote"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["kind", "reason", "nextAction"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["selection_incomplete"]
+                                        },
+                                        "unsatisfied": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "requirementKey": {
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "reason": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "pax_band_below_min",
+                                                  "pax_band_above_max",
+                                                  "pax_total_below_min",
+                                                  "pax_total_above_max",
+                                                  "pax_band_master_required",
+                                                  "pax_band_excluded",
+                                                  "pax_band_per_master_exceeded",
+                                                  "pax_band_sum_exceeded",
+                                                  "departure_required",
+                                                  "option_units_required",
+                                                  "cabin_category_required",
+                                                  "cabin_number_required",
+                                                  "date_range_required",
+                                                  "date_range_too_short",
+                                                  "date_range_too_long",
+                                                  "occupancy_required",
+                                                  "air_arrangement_required",
+                                                  "traveler_field_required",
+                                                  "booking_field_required"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["requirementKey", "reason"]
+                                          },
+                                          "minItems": 1
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["update_selection"]
+                                        }
+                                      },
+                                      "required": ["kind", "unsatisfied", "nextAction"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["requirements_changed"]
+                                        },
+                                        "requirementsFingerprint": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["request_fresh_quote"]
+                                        }
+                                      },
+                                      "required": ["kind", "requirementsFingerprint", "nextAction"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["checkout_intent_not_offered"]
+                                        },
+                                        "checkoutIntent": {
+                                          "type": "string",
+                                          "enum": [
+                                            "hold",
+                                            "card",
+                                            "bank_transfer",
+                                            "ticket_on_credit",
+                                            "inquiry"
+                                          ]
+                                        },
+                                        "offeredCheckoutIntents": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string",
+                                            "enum": [
+                                              "hold",
+                                              "card",
+                                              "bank_transfer",
+                                              "ticket_on_credit",
+                                              "inquiry"
+                                            ]
+                                          }
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["select_supported_checkout_intent"]
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "checkoutIntent",
+                                        "offeredCheckoutIntents",
+                                        "nextAction"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["invalid_selection"]
+                                        },
+                                        "reason": {
+                                          "type": "string",
+                                          "enum": [
+                                            "unsupported_target",
+                                            "forbidden_field",
+                                            "value_too_long"
+                                          ]
+                                        },
+                                        "path": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "maxLength": {
+                                          "type": "integer",
+                                          "exclusiveMinimum": 0
+                                        }
+                                      },
+                                      "required": ["kind", "reason"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["renewal_not_allowed"]
+                                        },
+                                        "reason": {
+                                          "type": "string",
+                                          "enum": [
+                                            "session_not_active",
+                                            "extension_too_large",
+                                            "absolute_lifetime_exceeded"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["kind", "reason"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["quote_required"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["request_fresh_quote"]
+                                        }
+                                      },
+                                      "required": ["kind", "nextAction"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["quote_expired", "quote_superseded"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["request_fresh_quote"]
+                                        }
+                                      },
+                                      "required": ["kind", "nextAction"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "hold_required",
+                                            "hold_expired",
+                                            "availability_changed"
+                                          ]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["request_new_hold"]
+                                        }
+                                      },
+                                      "required": ["kind", "nextAction"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["hold_quantity_mismatch"]
+                                        },
+                                        "requestedQuantity": {
+                                          "type": "integer",
+                                          "exclusiveMinimum": 0
+                                        },
+                                        "expectedQuantity": {
+                                          "type": "integer",
+                                          "exclusiveMinimum": 0
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["request_hold_for_expected_quantity"]
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "requestedQuantity",
+                                        "expectedQuantity",
+                                        "nextAction"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["commit_already_consumed"]
+                                        },
+                                        "nextAction": {
+                                          "type": "string",
+                                          "enum": ["return_idempotent_result"]
+                                        }
+                                      },
+                                      "required": ["kind", "nextAction"]
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": ["kind", "error"]
+                            }
+                          ]
+                        }
+                      },
+                      "required": ["outcome"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The Trip could not be frozen and priced",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The Trip capability, owner, channel, or same-origin proof is invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Trip revision or idempotent request conflicts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The request body exceeded 64 KiB",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": ["request_body_too_large"]
+                    },
+                    "maxBytes": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["error", "code", "maxBytes"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The managed Trip booking runtime is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postPublicShoppingTripSelectionsBook",
+        "summary": "POST /v1/public/shopping/trip-selections/book",
         "tags": ["shopping"],
         "x-voyant-module": "shopping",
         "x-voyant-surface": "public-api",

--- a/packages/public-api/scripts/generate-shopping-openapi.ts
+++ b/packages/public-api/scripts/generate-shopping-openapi.ts
@@ -60,4 +60,16 @@ await writeFile(documentUrl, `${JSON.stringify(next, null, 2)}\n`)
 // Keep the committed document's canonical formatting. Without this step,
 // JSON.stringify expands every existing compact array and hides the two-path
 // semantic change inside thousands of formatting-only lines.
-await promisify(execFile)("biome", ["format", "--write", fileURLToPath(documentUrl)])
+//
+// The document passed biome's default 1 MiB ceiling as the public surface
+// grew, and biome refuses an oversized file rather than skipping it — so this
+// step started exiting non-zero, leaving an unformatted document behind and
+// making the generator unrunnable. The spec drifted from the routes while it
+// was broken. The ceiling is raised here rather than in biome.json so that
+// repo-wide runs keep skipping the 1.8 MiB migration snapshots.
+await promisify(execFile)("biome", [
+  "format",
+  "--write",
+  "--files-max-size=8388608",
+  fileURLToPath(documentUrl),
+])

--- a/scripts/checks/openapi/generated-specs.json
+++ b/scripts/checks/openapi/generated-specs.json
@@ -51,6 +51,10 @@
       "files": ["packages/operations/openapi/admin/operations.json"]
     },
     {
+      "command": "pnpm --filter @voyant-travel/public-api generate:shopping-openapi",
+      "files": ["packages/public-api/openapi/public-api/public-api.json"]
+    },
+    {
       "command": "pnpm --filter @voyant-travel/trips generate:openapi",
       "files": [
         "packages/trips/openapi/admin/trips.json",


### PR DESCRIPTION
## The endpoint that wasn't in the contract

`POST /v1/public/shopping/trip-selections/book` exists in the routes and was **missing entirely** from `packages/public-api/openapi/public-api/public-api.json` — the published public API contract, and the document the in-app API reference renders. `/v1/public/shopping/search` and `/v1/public/shopping/trip-selections` had also moved on.

## Why nobody could have noticed

Two independent failures lined up.

**The generator could not run.** `generate:shopping-openapi` writes the document and then formats it with biome — deliberately, so that a semantic change is not buried under thousands of formatting-only lines from `JSON.stringify` expanding compact arrays. The document crossed biome's default **1 MiB** ceiling as the public surface grew, and biome *refuses* an oversized file rather than skipping it:

```
× No files were processed in the specified paths.
! The size of the file is 1.3 MiB, which exceeds the configured maximum of 1.0 MiB
```

So the format step exited non-zero, the generator exited non-zero, and it left an **unformatted** document on disk when it failed.

**And it was the one generator not covered by drift.** `verify:openapi-drift` regenerates each registered document and diffs it. Every generator in the repository had its outputs registered in `generated-specs.json` — except this one. So the only document whose generator was broken was also the only one nothing was checking.

## The fix

`--files-max-size=8388608` on that one invocation, **not** in `biome.json`, so repo-wide runs keep skipping the 1.8 MiB migration snapshots in `framework-migrations`.

Registering the generator brings drift coverage to 16 documents. Verified in both directions: green on the regenerated document, and exit 1 when the `trip-selections/book` path is deleted from it.

## Scope of the regeneration

Confined to three paths — everything else is byte-identical:

| path | before | after |
|---|---|---|
| `/v1/public/shopping/trip-selections/book` | absent | 18,470 lines |
| `/v1/public/shopping/search` | 1,671 | 2,052 |
| `/v1/public/shopping/trip-selections` | 703 | 707 |

12 other paths unchanged, every top-level field unchanged. The line count is why the file is 1.3 MiB — the booking operation inlines its whole request schema.

## Latent elsewhere

Three other generated documents are already over 1 MiB: `operations/admin/operations.json` (1.35), `finance/admin/finance.json` (1.27), `catalog/admin/catalog-booking.json` (1.01). None is broken today — operations' generator never calls biome, finance formats only its smaller public document, and catalog passes two files at once so biome warns on the oversized one and processes the other. Left alone rather than reformatted: their drift checks pass byte-identically today, and adding formatting would be a large one-time diff for no gain. Worth knowing the shape, since the next single-file generator to cross the line fails the same way.

## Verification

- `pnpm verify:architecture` — full chain, exit 0
- `pnpm verify:openapi-drift` — 16 documents match; exit 1 with a path deleted
- generator is idempotent: a second run produces no further change

Part of #4256 P0 (make the specs trustworthy).