### PR TITLE
Retire the last user-visible storefront wording from the admin UI

### DIFF
--- a/.changeset/storefront-ui-vocabulary.md
+++ b/.changeset/storefront-ui-vocabulary.md
@@ -1,0 +1,17 @@
+---
+"@voyant-travel/auth-react": patch
+"@voyant-travel/media-react": patch
+"@voyant-travel/distribution-react": patch
+---
+
+Retire the last user-visible "storefront" wording from the admin UI.
+
+The storefront entity is gone and its pages were replaced — the nav is Public API with
+a keys view and a sites seam — but seven strings still said "storefront" to an operator:
+the allowed-origin field label and its validation message, the media translation hint,
+and a publication-rule explanation.
+
+The media hint had also drifted between languages: English said "used by your
+storefronts" while Romanian already said "site-urile tale". English now follows Romanian
+rather than introducing a third term, and the origin examples use `site.example.com` /
+`site.exemplu.ro` in place of `shop.example.com` / `magazin.exemplu.ro`.

--- a/packages/auth-react/src/i18n/en.ts
+++ b/packages/auth-react/src/i18n/en.ts
@@ -227,9 +227,9 @@ export const authUiEn: AuthUiMessages = {
       title: "Provision business access",
       description:
         "Create business access for an existing customer, optionally linking an existing organization.",
-      publicApiOriginLabel: "Storefront origin",
-      publicApiOriginPlaceholder: "https://shop.example.com",
-      publicApiOriginRequired: "A valid storefront origin is required.",
+      publicApiOriginLabel: "Allowed origin",
+      publicApiOriginPlaceholder: "https://site.example.com",
+      publicApiOriginRequired: "A valid origin is required.",
       customerEmailLabel: "Customer email",
       customerEmailPlaceholder: "customer@example.com",
       businessNameLabel: "Business name",

--- a/packages/auth-react/src/i18n/ro.ts
+++ b/packages/auth-react/src/i18n/ro.ts
@@ -229,9 +229,9 @@ export const authUiRo: AuthUiMessages = {
       title: "Acorda acces business",
       description:
         "Creeaza acces business pentru un client existent si, optional, leaga o organizatie existenta.",
-      publicApiOriginLabel: "Originea magazinului",
-      publicApiOriginPlaceholder: "https://magazin.exemplu.ro",
-      publicApiOriginRequired: "Este necesara o origine valida a magazinului.",
+      publicApiOriginLabel: "Origine permisa",
+      publicApiOriginPlaceholder: "https://site.exemplu.ro",
+      publicApiOriginRequired: "Este necesara o origine valida.",
       customerEmailLabel: "Email client",
       customerEmailPlaceholder: "client@example.com",
       businessNameLabel: "Numele companiei",

--- a/packages/distribution-react/src/i18n/en.ts
+++ b/packages/distribution-react/src/i18n/en.ts
@@ -503,7 +503,7 @@ export const distributionUiEn = {
         suppliersTitle: "Suppliers Include/Exclude",
         sourcesTitle: "Supply sources Include/Exclude",
         sourcesDescription:
-          "Choose which connected suppliers this channel sells. Connecting a supplier does not publish it — inventory stays out of the storefront until an Include rule applies here.",
+          "Choose which connected suppliers this channel sells. Connecting a supplier does not publish it — inventory stays unpublished until an Include rule applies here.",
         sourceLabel: "Supply source",
         sourcePlaceholder: "Select supply source",
         sourceEntryCount: "{count} entries",

--- a/packages/distribution-react/src/i18n/ro.ts
+++ b/packages/distribution-react/src/i18n/ro.ts
@@ -508,7 +508,7 @@ export const distributionUiRo = {
         suppliersTitle: "Furnizori Include/Exclude",
         sourcesTitle: "Surse de aprovizionare Include/Exclude",
         sourcesDescription:
-          "Alege ce furnizori conectati vinde acest canal. Conectarea unui furnizor nu il publica — stocul ramane in afara magazinului pana cand se aplica aici o regula Include.",
+          "Alege ce furnizori conectati vinde acest canal. Conectarea unui furnizor nu il publica — stocul ramane nepublicat pana cand se aplica aici o regula Include.",
         sourceLabel: "Sursa de aprovizionare",
         sourcePlaceholder: "Selecteaza sursa de aprovizionare",
         sourceEntryCount: "{count} intrari",

--- a/packages/media-react/src/i18n/en.ts
+++ b/packages/media-react/src/i18n/en.ts
@@ -69,7 +69,7 @@ export const mediaUiEn: MediaUiMessages = {
       defaultLanguageLabel: "Default language",
       languageTagPlaceholder: "e.g. en or en-GB",
       translationsTitle: "Alt text translations",
-      translationsHint: "Add localized alt text for each language used by your storefronts.",
+      translationsHint: "Add localized alt text for each language your sites use.",
       languageTagLabel: "Language tag",
       addTranslation: "Add translation",
       removeTranslation: "Remove translation",


### PR DESCRIPTION
The storefront **entity** is gone and its UI was replaced — the nav registers `public-api` with a keys view (`/public-api`) and a sites seam (`/public-api/sites`), and no storefront CRUD component exists. But seven strings still said "storefront" to an operator.

| where | was | now |
|---|---|---|
| `auth-react` origin label | "Storefront origin" / "Originea magazinului" | "Allowed origin" / "Origine permisa" |
| `auth-react` validation | "A valid storefront origin is required." | "A valid origin is required." |
| `auth-react` placeholder | `shop.example.com` / `magazin.exemplu.ro` | `site.example.com` / `site.exemplu.ro` |
| `media-react` hint | "each language used by your storefronts" | "each language your sites use" |
| `distribution-react` rule help | "inventory stays out of the storefront until…" | "inventory stays unpublished until…" |

**The media hint had drifted between languages** — English said "used by your storefronts" while Romanian already said "site-urile tale" (your sites). English now follows Romanian rather than introducing a third term for the same thing.

Scope note: #4624 §7 leaves operator-facing *product* vocabulary (nav labels, Website vs. site) to platform. These are framework-package strings this repo owns, so they are in scope here.

Verified: `pnpm i18n:check` passes across 24 i18n roots, en/ro parity kept, `auth-react` 69 tests, `distribution-react` 55, `media-react` 7, root `biome check .` clean at error level. No remaining `storefront`/`magazin` strings in any `src/i18n/*.ts`.