### PR TITLE
Name the pricing rule that refuses a booking, and stop calling it a 500

### DIFF
--- a/.changeset/booking-create-invalid-pricing-error.md
+++ b/.changeset/booking-create-invalid-pricing-error.md
@@ -1,0 +1,20 @@
+---
+"@voyant-travel/finance": patch
+"@voyant-travel/hono": patch
+---
+
+Surface a booking-create pricing refusal instead of hiding it behind a bare 500.
+
+`bookingCreateCommandError` had a case for 15 of the 16 `BookingCreateOutcome`
+refusals; `invalid_pricing` fell through to `default:` and became "The booking
+command failed validation." with its `issues[]` discarded, and the route turned
+that into a `500 Internal Server Error`. `invalid_pricing` now formats its
+issues like its two siblings, the switch is exhaustive so a new status fails the
+build rather than degrading to a generic message, and the six conflict outcomes
+name the booking, group or credit they conflict with.
+
+The framework error boundary now answers a client-answerable `ToolError` with
+its own status — `INVALID_INPUT` is a `400`, not a `500` — and reflects the
+message and next steps. Codes that report a mis-wired deployment or a
+server-side defect keep the opaque 500 they have today, and the API error log
+records the tool error code for all of them.

--- a/.changeset/booking-create-invalid-pricing-error.md
+++ b/.changeset/booking-create-invalid-pricing-error.md
@@ -13,6 +13,15 @@ issues like its two siblings, the switch is exhaustive so a new status fails the
 build rather than degrading to a generic message, and the six conflict outcomes
 name the booking, group or credit they conflict with.
 
+A refusal now states the audience it is written for, because the self-service
+entrypoint is reachable from the anonymous public Commit. A customer-facing
+refusal may describe the caller's own request and the product they are booking,
+but not another party's records or the operator's account state: the
+duplicate-booking outcome no longer names the existing booking (its guard
+resolves a person from the contact email without checking the caller owns it),
+and the monthly-limit outcome no longer reports the operator's plan usage. Staff
+keep both in full, and the whole outcome still reaches the server log.
+
 The framework error boundary now answers a client-answerable `ToolError` with
 its own status — `INVALID_INPUT` is a `400`, not a `500` — and reflects the
 message and next steps. Codes that report a mis-wired deployment or a

--- a/packages/finance/src/booking-create-command.ts
+++ b/packages/finance/src/booking-create-command.ts
@@ -66,7 +66,7 @@ export async function executeFinanceStaffBookingCreateCommand(
   input: FinanceBookingCreateCommandInput,
 ) {
   assertAdmittedActionPolicy(input.admitted, FINANCE_BOOKING_CREATE_HANDLER_POLICY)
-  return executeBookingCreateCommand(input)
+  return executeBookingCreateCommand("staff", input)
 }
 
 /**
@@ -82,7 +82,13 @@ export async function executeFinanceBookProductCommand(input: FinanceBookingCrea
   assertAdmittedActionPolicy(input.admitted, FINANCE_BOOK_PRODUCT_HANDLER_POLICY)
   // book_product mints its lease under its OWN action identity; the domain must
   // check against that, not against create_booking's (voyant#3992).
-  return executeBookingCreateCommand(input, undefined, undefined, FINANCE_BOOK_PRODUCT_ACTION)
+  return executeBookingCreateCommand(
+    "staff",
+    input,
+    undefined,
+    undefined,
+    FINANCE_BOOK_PRODUCT_ACTION,
+  )
 }
 
 /**
@@ -103,6 +109,7 @@ export async function executeFinanceSelfServiceBookingCreateCommand(
   // verified a contact, chosen a room and been quoted. Same defect voyant#3992
   // fixed for `book_product`; this entrypoint was missed.
   return executeBookingCreateCommand(
+    "customer",
     input,
     input.fallbackPrincipalId,
     input.consumeSources,
@@ -114,8 +121,15 @@ export async function executeFinanceSelfServiceBookingCreateCommand(
  * The shared mutation core. Deliberately not exported: an exported executor
  * that selected its expectation from caller-supplied admission metadata would
  * be exactly the confused deputy the two entrypoints above prevent.
+ *
+ * `audience` comes first and is required for the same reason. It is taken from
+ * the entrypoint — each of which already pins exactly one policy — and never
+ * derived from `input.context.actor`, which is an optional untyped string a
+ * caller supplies. Reading it from there would make an omitted field grant the
+ * staff-grade diagnostics, and silence must not be permission.
  */
 async function executeBookingCreateCommand(
+  audience: BookingCreateErrorAudience,
   input: FinanceBookingCreateCommandInput,
   fallbackPrincipalId?: string,
   consumeSources?: (tx: PostgresJsDatabase, bookingId: string) => Promise<void>,
@@ -152,7 +166,7 @@ async function executeBookingCreateCommand(
           runtime: input.runtime,
           userId: input.context.userId ?? undefined,
         })
-        if (outcome.status !== "ok") throw bookingCreateCommandError(outcome)
+        if (outcome.status !== "ok") throw bookingCreateCommandError(outcome, audience)
         const result = outcome.result
         await input.testHooks?.afterDomainCreate?.(transaction, result.booking.id)
         // Spend the draft, quote, hold, and challenge in the same transaction
@@ -249,8 +263,35 @@ async function insertBookingCreatedOutbox(
   await insertOutboxEvents(tx, events)
 }
 
+/**
+ * Who is going to read the refusal.
+ *
+ * `customer` covers the self-service entrypoint, which is reachable from
+ * `POST /v1/public/catalog/booking-sessions/:sessionId/commit` by an
+ * unauthenticated storefront caller — the session's own capability is the
+ * authority there, not a staff credential. It is the audience that may not own
+ * the records a diagnostic would name.
+ */
+export type BookingCreateErrorAudience = "staff" | "customer"
+
+/**
+ * What a `customer` refusal may say.
+ *
+ * It may describe the caller's own request and the product they are booking —
+ * that is the whole point of a typed refusal, and it is what makes the pricing
+ * failure this file exists to surface legible to a shopper. It may not describe
+ * **another party's records** or **the operator's account state**, neither of
+ * which the caller is entitled to and neither of which they can act on.
+ *
+ * Two outcomes fail that test, and both use the sentence below rather than a
+ * bespoke one, so the two are also indistinguishable from each other.
+ */
+const CUSTOMER_WITHHELD_REFUSAL =
+  "This booking could not be completed. Contact the operator to continue."
+
 export function bookingCreateCommandError(
   outcome: Exclude<Awaited<ReturnType<typeof createBookingMutation>>, { status: "ok" }>,
+  audience: BookingCreateErrorAudience,
 ) {
   switch (outcome.status) {
     // voyant#3921: these were one message — "A booking-create dependency was not
@@ -324,15 +365,40 @@ export function bookingCreateCommandError(
         "INVALID_INPUT",
         { outcome },
       )
+    // The domain's message names the operator's plan usage and renewal date
+    // ("This workspace has reached its monthly booking limit (3/5). Upgrade the
+    // plan..."). That is the operator's commercial state, it is not the
+    // shopper's to see, and there is nothing they could do with it.
     case "monthly_booking_limit_reached":
-      return new ToolError(outcome.message, "INVALID_INPUT", { outcome })
+      return new ToolError(
+        audience === "staff" ? outcome.message : CUSTOMER_WITHHELD_REFUSAL,
+        "INVALID_INPUT",
+        { outcome },
+      )
     // These six shared one sentence — "The booking command conflicts with
     // current state." — which is the same tautology in a different costume: it
     // names no record, no balance and no next step, and each of them carries
     // exactly the field that would.
+    //
+    // `duplicate_booking` is the one that cannot say so to everybody. The guard
+    // resolves its person from the contact email on the request
+    // (`upsertPersonFromContact` returns any existing CRM person matching it,
+    // with no ownership check), so on the anonymous public Commit the match may
+    // be a stranger the caller merely named. Naming their booking number and
+    // status there would hand one customer's record to another. The full
+    // outcome still reaches the server log through `meta`, which is where an
+    // operator reads it.
+    //
+    // The other five are not audience-dependent: each describes the caller's
+    // own request, or a record the request itself named. The travel-credit and
+    // group outcomes are additionally unreachable for a customer, because the
+    // self-service command carries neither a redemption nor a group — but that
+    // is a second reason, not the one they rely on.
     case "duplicate_booking":
       return new ToolError(
-        `This customer already holds booking ${outcome.existingBooking.bookingNumber} (${outcome.existingBooking.status}) on the same Slot. Open that booking instead of creating another, or set allowDuplicate if a second booking on the same Slot is intended.`,
+        audience === "staff"
+          ? `This customer already holds booking ${outcome.existingBooking.bookingNumber} (${outcome.existingBooking.status}) on the same Slot. Open that booking instead of creating another, or set allowDuplicate if a second booking on the same Slot is intended.`
+          : CUSTOMER_WITHHELD_REFUSAL,
         "INVALID_INPUT",
         { outcome },
       )

--- a/packages/finance/src/booking-create-command.ts
+++ b/packages/finance/src/booking-create-command.ts
@@ -311,19 +311,75 @@ export function bookingCreateCommandError(
         "INVALID_INPUT",
         { outcome },
       )
+    // voyant#4805: the third sibling of the two cases above had no case at all,
+    // so a pricing refusal fell through to `default:` and became "The booking
+    // command failed validation." with its `issues[]` discarded — a sentence
+    // that repeats what the caller already knew and withholds the only part
+    // that identifies the rule. Observed blocking a production operator from
+    // creating a booking by any route, storefront or admin, with the pricing
+    // diagnostic unrecoverable even from the server logs.
+    case "invalid_pricing":
+      return new ToolError(
+        `The pricing is invalid: ${formatBookingCreateIssues(outcome.issues)}`,
+        "INVALID_INPUT",
+        { outcome },
+      )
     case "monthly_booking_limit_reached":
       return new ToolError(outcome.message, "INVALID_INPUT", { outcome })
+    // These six shared one sentence — "The booking command conflicts with
+    // current state." — which is the same tautology in a different costume: it
+    // names no record, no balance and no next step, and each of them carries
+    // exactly the field that would.
     case "duplicate_booking":
+      return new ToolError(
+        `This customer already holds booking ${outcome.existingBooking.bookingNumber} (${outcome.existingBooking.status}) on the same Slot. Open that booking instead of creating another, or set allowDuplicate if a second booking on the same Slot is intended.`,
+        "INVALID_INPUT",
+        { outcome },
+      )
     case "travel_credit_inactive":
+      return new ToolError(
+        "A travel credit referenced by this booking is not active. Reactivate it, or remove it from the request and settle the balance another way.",
+        "INVALID_INPUT",
+        { outcome },
+      )
     case "travel_credit_not_started":
+      return new ToolError(
+        "A travel credit referenced by this booking cannot be spent yet — its validity period has not started. Remove it from the request, or retry once it is valid.",
+        "INVALID_INPUT",
+        { outcome },
+      )
     case "travel_credit_expired":
+      return new ToolError(
+        "A travel credit referenced by this booking has expired and can no longer be spent. Remove it from the request and settle the balance another way.",
+        "INVALID_INPUT",
+        { outcome },
+      )
     case "travel_credit_insufficient_balance":
+      return new ToolError(
+        "A travel credit referenced by this booking does not have enough balance to cover the amount requested from it. Lower the redeemed amount to the remaining balance, or remove the credit.",
+        "INVALID_INPUT",
+        { outcome },
+      )
     case "booking_already_in_group":
-      return new ToolError("The booking command conflicts with current state.", "INVALID_INPUT", {
-        outcome,
-      })
-    default:
-      return new ToolError("The booking command failed validation.", "INVALID_INPUT", { outcome })
+      return new ToolError(
+        `This booking is already a member of group ${outcome.currentGroupId}. Remove it from that group before assigning another, or omit the group from the request.`,
+        "INVALID_INPUT",
+        { outcome },
+      )
+    default: {
+      // Exhaustive: every `BookingCreateOutcome` refusal above is named, so
+      // adding a status to the union fails the build here instead of silently
+      // degrading to a generic message — which is how `invalid_pricing` stayed
+      // undiagnosable. The runtime arm still names the status it could not map,
+      // because a published copy of this package may be paired with a newer
+      // `service-booking-create` that returns one this build has never seen.
+      const unmapped: never = outcome
+      return new ToolError(
+        `The booking command failed with an unrecognized outcome: ${(unmapped as { status?: string }).status ?? "unknown"}.`,
+        "INVALID_INPUT",
+        { outcome },
+      )
+    }
   }
 }
 

--- a/packages/finance/tests/unit/booking-create-command-errors.test.ts
+++ b/packages/finance/tests/unit/booking-create-command-errors.test.ts
@@ -4,12 +4,15 @@ import { bookingCreateCommandError } from "../../src/booking-create-command.js"
 
 describe("booking create command errors", () => {
   it("explains room capacity failures as a corrective action", () => {
-    const error = bookingCreateCommandError({
-      status: "room_occupancy_insufficient",
-      pax: 3,
-      occupancyMax: 2,
-      shortfall: 1,
-    })
+    const error = bookingCreateCommandError(
+      {
+        status: "room_occupancy_insufficient",
+        pax: 3,
+        occupancyMax: 2,
+        shortfall: 1,
+      },
+      "staff",
+    )
 
     expect(error.message).toMatch(/fit 2 traveler/)
     expect(error.message).toMatch(/Add room capacity for 1 more traveler/)
@@ -17,20 +20,23 @@ describe("booking create command errors", () => {
   })
 
   it("explains traveler and room payload mismatches", () => {
-    const error = bookingCreateCommandError({
-      status: "payload_resolver_mismatch",
-      mismatches: [],
-    })
+    const error = bookingCreateCommandError(
+      { status: "payload_resolver_mismatch", mismatches: [] },
+      "staff",
+    )
 
     expect(error.message).toMatch(/traveler-to-room assignments/)
     expect(error.message).toMatch(/assign each traveler key/)
   })
 
   it("includes the invalid payment field and reason", () => {
-    const error = bookingCreateCommandError({
-      status: "invalid_payment_schedules",
-      issues: [{ path: ["paymentSchedules", 0, "amountCents"], message: "Total is too high" }],
-    })
+    const error = bookingCreateCommandError(
+      {
+        status: "invalid_payment_schedules",
+        issues: [{ path: ["paymentSchedules", 0, "amountCents"], message: "Total is too high" }],
+      },
+      "staff",
+    )
 
     expect(error.message).toContain("paymentSchedules.0.amountCents: Total is too high")
   })
@@ -39,16 +45,22 @@ describe("booking create command errors", () => {
   // so it reached the caller as "The booking command failed validation." with
   // its issues dropped — and because that is the only status that could produce
   // that sentence, the message named nothing the caller did not already know.
-  it("names the pricing rule that refused the booking", () => {
-    const error = bookingCreateCommandError({
-      status: "invalid_pricing",
-      issues: [
-        {
-          path: ["itemLines"],
-          message: "Booking item unit_twin has no active persisted price rule.",
-        },
-      ],
-    })
+  it.each([
+    "staff",
+    "customer",
+  ] as const)("names the pricing rule that refused the booking for %s", (audience) => {
+    const error = bookingCreateCommandError(
+      {
+        status: "invalid_pricing",
+        issues: [
+          {
+            path: ["itemLines"],
+            message: "Booking item unit_twin has no active persisted price rule.",
+          },
+        ],
+      },
+      audience,
+    )
 
     expect(error.code).toBe("INVALID_INPUT")
     expect(error.message).toContain(
@@ -57,18 +69,91 @@ describe("booking create command errors", () => {
     expect(error.message).not.toContain("The booking command failed validation")
   })
 
-  it("names the conflicting record instead of reporting a bare conflict", () => {
-    const duplicate = bookingCreateCommandError({
-      status: "duplicate_booking",
-      existingBooking: { id: "bkg_1", bookingNumber: "BK-1042", status: "confirmed" },
-    })
-    const grouped = bookingCreateCommandError({
-      status: "booking_already_in_group",
-      currentGroupId: "grp_7",
-    })
+  it("names the conflicting record for staff instead of reporting a bare conflict", () => {
+    const duplicate = bookingCreateCommandError(
+      {
+        status: "duplicate_booking",
+        existingBooking: { id: "bkg_1", bookingNumber: "BK-1042", status: "confirmed" },
+      },
+      "staff",
+    )
+    const grouped = bookingCreateCommandError(
+      { status: "booking_already_in_group", currentGroupId: "grp_7" },
+      "staff",
+    )
 
     expect(duplicate.message).toContain("BK-1042")
     expect(grouped.message).toContain("grp_7")
+  })
+
+  // The duplicate guard resolves its person from the contact email on the
+  // request, and `upsertPersonFromContact` returns any existing CRM person that
+  // matches without checking that the caller owns it. On the anonymous public
+  // Commit the match can therefore be a stranger, so this message must never
+  // name their booking — the identifier stays in `meta` for the server log.
+  it("withholds the existing booking from a customer-facing duplicate refusal", () => {
+    const error = bookingCreateCommandError(
+      {
+        status: "duplicate_booking",
+        existingBooking: { id: "bkg_1", bookingNumber: "BK-1042", status: "confirmed" },
+      },
+      "customer",
+    )
+
+    expect(error.message).not.toContain("BK-1042")
+    expect(error.message).not.toContain("bkg_1")
+    expect(error.message).not.toContain("confirmed")
+    expect(error.message).toMatch(/Contact the operator/)
+    // The operator still has everything, through the detail that never reaches
+    // the response body.
+    expect(error.meta).toMatchObject({
+      outcome: { existingBooking: { bookingNumber: "BK-1042" } },
+    })
+  })
+
+  // The domain's message is "This workspace has reached its monthly booking
+  // limit (3/5). Upgrade the plan or wait until ...". That is the operator's
+  // commercial state, and the public Commit would have shown it to a shopper.
+  it("withholds the operator's plan usage from a customer-facing limit refusal", () => {
+    const outcome = {
+      status: "monthly_booking_limit_reached",
+      limit: 5,
+      current: 5,
+      periodStart: "2026-08-01",
+      periodEnd: "2026-08-31",
+      message: "This workspace has reached its monthly booking limit (5/5). Upgrade the plan.",
+    } as const
+
+    expect(bookingCreateCommandError(outcome, "staff").message).toBe(outcome.message)
+
+    const customer = bookingCreateCommandError(outcome, "customer")
+    expect(customer.message).not.toMatch(/limit|plan|workspace|5\/5/i)
+    expect(customer.meta).toMatchObject({ outcome: { limit: 5, current: 5 } })
+  })
+
+  // Both withheld refusals are the same sentence, so the message does not
+  // distinguish them either.
+  it("gives the two withheld outcomes an identical customer-facing message", () => {
+    const duplicate = bookingCreateCommandError(
+      {
+        status: "duplicate_booking",
+        existingBooking: { id: "bkg_1", bookingNumber: "BK-1042", status: "confirmed" },
+      },
+      "customer",
+    )
+    const limited = bookingCreateCommandError(
+      {
+        status: "monthly_booking_limit_reached",
+        limit: 5,
+        current: 5,
+        periodStart: "2026-08-01",
+        periodEnd: "2026-08-31",
+        message: "This workspace has reached its monthly booking limit (5/5).",
+      },
+      "customer",
+    )
+
+    expect(duplicate.message).toBe(limited.message)
   })
 
   // The three `issues[]` siblings must stay formatted the same way; the defect
@@ -78,10 +163,10 @@ describe("booking create command errors", () => {
     ["invalid_tax_lines", "The tax lines are invalid"],
     ["invalid_pricing", "The pricing is invalid"],
   ] as const)("formats %s issues", (status, prefix) => {
-    const error = bookingCreateCommandError({
-      status,
-      issues: [{ path: ["a", 1], message: "why" }],
-    })
+    const error = bookingCreateCommandError(
+      { status, issues: [{ path: ["a", 1], message: "why" }] },
+      "staff",
+    )
 
     expect(error.message).toBe(`${prefix}: a.1: why`)
   })

--- a/packages/finance/tests/unit/booking-create-command-errors.test.ts
+++ b/packages/finance/tests/unit/booking-create-command-errors.test.ts
@@ -34,4 +34,55 @@ describe("booking create command errors", () => {
 
     expect(error.message).toContain("paymentSchedules.0.amountCents: Total is too high")
   })
+
+  // voyant#4805. `invalid_pricing` was the one refusal with no case of its own,
+  // so it reached the caller as "The booking command failed validation." with
+  // its issues dropped — and because that is the only status that could produce
+  // that sentence, the message named nothing the caller did not already know.
+  it("names the pricing rule that refused the booking", () => {
+    const error = bookingCreateCommandError({
+      status: "invalid_pricing",
+      issues: [
+        {
+          path: ["itemLines"],
+          message: "Booking item unit_twin has no active persisted price rule.",
+        },
+      ],
+    })
+
+    expect(error.code).toBe("INVALID_INPUT")
+    expect(error.message).toContain(
+      "itemLines: Booking item unit_twin has no active persisted price rule.",
+    )
+    expect(error.message).not.toContain("The booking command failed validation")
+  })
+
+  it("names the conflicting record instead of reporting a bare conflict", () => {
+    const duplicate = bookingCreateCommandError({
+      status: "duplicate_booking",
+      existingBooking: { id: "bkg_1", bookingNumber: "BK-1042", status: "confirmed" },
+    })
+    const grouped = bookingCreateCommandError({
+      status: "booking_already_in_group",
+      currentGroupId: "grp_7",
+    })
+
+    expect(duplicate.message).toContain("BK-1042")
+    expect(grouped.message).toContain("grp_7")
+  })
+
+  // The three `issues[]` siblings must stay formatted the same way; the defect
+  // was one of them silently not being.
+  it.each([
+    ["invalid_payment_schedules", "The payment schedule is invalid"],
+    ["invalid_tax_lines", "The tax lines are invalid"],
+    ["invalid_pricing", "The pricing is invalid"],
+  ] as const)("formats %s issues", (status, prefix) => {
+    const error = bookingCreateCommandError({
+      status,
+      issues: [{ path: ["a", 1], message: "why" }],
+    })
+
+    expect(error.message).toBe(`${prefix}: a.1: why`)
+  })
 })

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -42,6 +42,7 @@
     "@hono/zod-openapi": "catalog:",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/db": "workspace:^",
+    "@voyant-travel/tools": "workspace:^",
     "@voyant-travel/types": "workspace:^",
     "@voyant-travel/utils": "workspace:^",
     "drizzle-orm": "catalog:",

--- a/packages/hono/src/middleware/error-boundary.ts
+++ b/packages/hono/src/middleware/error-boundary.ts
@@ -1,3 +1,4 @@
+import { isToolError } from "@voyant-travel/tools"
 import { apiErrorSchema } from "@voyant-travel/types"
 import type { Context, MiddlewareHandler } from "hono"
 
@@ -99,6 +100,11 @@ export function handleApiError(
       id,
       status,
       code,
+      // The tool layer's own code. `code` above is the HTTP error contract's,
+      // and is `undefined` for the ToolError codes that stay an opaque 500 —
+      // exactly the ones being triaged from this line. voyant#4805 reported it
+      // as `code: undefined` with nothing else to go on.
+      toolErrorCode: isToolError(err) ? err.code : undefined,
       path: c.req.path,
       method: c.req.method,
       headers,

--- a/packages/hono/src/validation.ts
+++ b/packages/hono/src/validation.ts
@@ -1,3 +1,4 @@
+import { isToolError, type ToolErrorCode } from "@voyant-travel/tools"
 import type { Context } from "hono"
 import { HTTPException } from "hono/http-exception"
 import { ZodError, type ZodType } from "zod"
@@ -124,6 +125,50 @@ function isZodError(error: unknown): error is ZodError {
     (error as Error).name === "ZodError" &&
     Array.isArray((error as ZodError).issues)
   )
+}
+
+/**
+ * The client-answerable {@link ToolErrorCode}s, and the status each one is.
+ *
+ * A `ToolError` is the tool layer's *typed* refusal, and the domain services
+ * behind a route throw it directly — so one reaching this boundary is usually a
+ * decision, not a crash. Until voyant#4805 the boundary did not recognise it at
+ * all: every code fell through to the generic arm and answered
+ * `500 {"error":"Internal Server Error"}`, which tells the caller the product
+ * is broken when the input was merely rejected, and drops the message that says
+ * why. Observed on
+ * `POST /v1/admin/catalog/booking-sessions/:sessionId/commit`, where a pricing
+ * refusal read as a server fault and left an operator with no way — from the
+ * product, the API, or the logs — to see which rule had been violated.
+ *
+ * The table is here rather than in `@voyant-travel/tools` because HTTP is this
+ * package's vocabulary; `tools` owns the code union and stays
+ * transport-neutral.
+ *
+ * Deliberately partial, and a missing code is not an oversight. The five it
+ * omits — `MISSING_SERVICE`, `ACTION_POLICY_REQUIRED`, `INVALID_OUTPUT`,
+ * `PROVIDER_ERROR`, `PROVIDER_UNAVAILABLE` — report a deployment wired wrong, a
+ * server-side defect, or an upstream fault. None of them is answerable by
+ * changing the request, and each one's message describes internals, so they keep
+ * today's behaviour unchanged: the opaque 500 that reflects nothing and still
+ * reaches the observability sink. `handleApiError` must never mirror an internal
+ * message back on a server fault.
+ */
+const TOOL_ERROR_HTTP_STATUS: Partial<Record<ToolErrorCode, number>> = {
+  INVALID_INPUT: 400,
+  AUTHORIZATION_DENIED: 403,
+  NOT_FOUND: 404,
+  APPROVAL_REQUIRED: 409,
+  CONFIRMATION_REQUIRED: 409,
+}
+
+/**
+ * Error-body `code` for a `ToolError`. A 400 keeps `invalid_request`, the code
+ * the framework's own validation failures already carry, so a caller matching
+ * on it does not have to learn a second spelling for the same answer.
+ */
+function toolErrorResponseCode(code: ToolErrorCode, status: number): string {
+  return status === 400 ? "invalid_request" : code.toLowerCase()
 }
 
 function isHttpException(error: unknown): error is HTTPException {
@@ -257,6 +302,36 @@ export function parseQuery<T>(
   )
 }
 
+/**
+ * Translates a client-answerable {@link ToolErrorCode} onto the framework error
+ * contract, or returns `undefined` so the caller keeps its existing handling.
+ *
+ * `isToolError` rather than `instanceof`: the managed runtime inlines a copy of
+ * every `@voyant-travel/*` package into the SSR bundle while runtime-composed
+ * modules resolve their own from `node_modules`, so the error almost never
+ * comes from the class this file's copy would compare against — the same
+ * cross-copy trap `API_HTTP_ERROR_BRAND` exists for.
+ *
+ * `meta` is not reflected. It carries the raw domain outcome — ids, balances,
+ * the whole rejected command — which belongs in the server log, not in the
+ * response body. The message and `nextSteps` are written to be read by the
+ * caller and are the actionable part.
+ */
+function toolErrorToApiHttpError(error: unknown): ApiHttpError | undefined {
+  if (!isToolError(error)) return undefined
+  const status = TOOL_ERROR_HTTP_STATUS[error.code]
+  if (status === undefined) return undefined
+  return new ApiHttpError(error.message, {
+    status,
+    code: toolErrorResponseCode(error.code, status),
+    details: {
+      toolErrorCode: error.code,
+      retryable: error.retryable,
+      ...(error.nextSteps?.length ? { nextSteps: error.nextSteps } : {}),
+    },
+  })
+}
+
 export function normalizeValidationError(error: unknown): ApiHttpError | undefined {
   if (isApiHttpError(error)) {
     return error
@@ -265,6 +340,9 @@ export function normalizeValidationError(error: unknown): ApiHttpError | undefin
   if (isZodError(error)) {
     return toValidationError(error)
   }
+
+  const toolError = toolErrorToApiHttpError(error)
+  if (toolError) return toolError
 
   if (isHttpException(error)) {
     // Hono's request validators throw HTTPException before our validation hook

--- a/packages/hono/tests/unit/error-boundary.test.ts
+++ b/packages/hono/tests/unit/error-boundary.test.ts
@@ -1,3 +1,4 @@
+import { ToolError } from "@voyant-travel/tools"
 import { Hono } from "hono"
 import { describe, expect, it } from "vitest"
 
@@ -163,6 +164,113 @@ describe("handleApiError", () => {
 
     expect(isApiHttpError(new PreBrandRequestValidationError("real"))).toBe(true)
     expect(isApiHttpError(new RequestValidationError("real"))).toBe(true)
+  })
+
+  // voyant#4805. A `ToolError` is a domain's typed refusal, not a crash. The
+  // boundary did not recognise it, so a rejected booking-session commit
+  // answered `500 {"error":"Internal Server Error"}` and the message naming the
+  // violated pricing rule never left the process.
+  it.each([
+    ["INVALID_INPUT", 400, "invalid_request"],
+    ["AUTHORIZATION_DENIED", 403, "authorization_denied"],
+    ["NOT_FOUND", 404, "not_found"],
+    ["APPROVAL_REQUIRED", 409, "approval_required"],
+    ["CONFIRMATION_REQUIRED", 409, "confirmation_required"],
+  ] as const)("answers a %s ToolError with %i", async (code, status, responseCode) => {
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.get("/bad", () => {
+      throw new ToolError("The pricing is invalid: itemLines: no active price rule.", code, {
+        outcome: { status: "invalid_pricing" },
+      })
+    })
+
+    const response = await app.request("/bad")
+    const body = (await response.json()) as {
+      error: string
+      code?: string
+      details?: Record<string, unknown>
+    }
+
+    expect(response.status).toBe(status)
+    expect(body.code).toBe(responseCode)
+    expect(body.error).toBe("The pricing is invalid: itemLines: no active price rule.")
+    expect(body.details?.toolErrorCode).toBe(code)
+    expect(body.details?.retryable).toBe(false)
+    // `meta` carries the raw domain outcome — ids, balances, the rejected
+    // command — and belongs in the log, not the response body.
+    expect(JSON.stringify(body)).not.toContain("outcome")
+  })
+
+  // A deployment wired wrong is not something the caller can fix by changing
+  // the request, and its message describes internals. Those codes must keep the
+  // opaque 500 the boundary has always given them.
+  it.each([
+    "MISSING_SERVICE",
+    "ACTION_POLICY_REQUIRED",
+    "INVALID_OUTPUT",
+    "PROVIDER_ERROR",
+  ] as const)("keeps a %s ToolError an opaque 500", async (code) => {
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.get("/bad", () => {
+      throw new ToolError("database hostname leaked", code)
+    })
+
+    const response = await app.request("/bad")
+    const body = (await response.json()) as { error: string; details?: unknown }
+
+    expect(response.status).toBe(500)
+    expect(body.error).toBe("Internal Server Error")
+    expect(body.details).toBeUndefined()
+  })
+
+  // The managed runtime inlines `@voyant-travel/tools` into the SSR bundle
+  // while runtime-composed modules resolve their own, so the ToolError reaching
+  // the boundary is virtually never an instance of the class this file loaded.
+  // Matching by `instanceof` would fix nothing in production. Both shapes below
+  // are what a second copy actually presents: the brand resolves through the
+  // global symbol registry, and a copy published before the brand identifies
+  // itself by `name` plus a string `code`.
+  it.each([
+    [
+      "a branded copy",
+      () => {
+        const error = new Error("The pricing is invalid: a.1: why")
+        error.name = "ToolError"
+        return Object.assign(error, {
+          code: "INVALID_INPUT",
+          retryable: false,
+          [Symbol.for("@voyant-travel/tools.ToolError")]: true,
+        })
+      },
+    ],
+    [
+      "a pre-brand copy",
+      () => {
+        const error = new Error("The pricing is invalid: a.1: why")
+        error.name = "ToolError"
+        return Object.assign(error, { code: "INVALID_INPUT" })
+      },
+    ],
+  ])("answers a ToolError thrown by %s", async (_label, make) => {
+    const error = make()
+
+    // Guard the premise: an `instanceof` match would pass for the wrong reason.
+    expect(error instanceof ToolError).toBe(false)
+
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.get("/bad", () => {
+      throw error
+    })
+
+    const response = await app.request("/bad")
+    const body = (await response.json()) as { error: string; code?: string }
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe("The pricing is invalid: a.1: why")
+    expect(body.code).toBe("invalid_request")
   })
 
   it("reflects a ZodError thrown by a duplicate zod copy", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,7 +258,7 @@ importers:
         version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@better-auth/api-key':
         specifier: 1.6.23
-        version: 1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)
+        version: 1.6.23(4cc07405e1e664eaf96048bc4329d318)
       '@fontsource-variable/inter-tight':
         specifier: ^5.2.7
         version: 5.2.7
@@ -3102,6 +3102,9 @@ importers:
       '@voyant-travel/db':
         specifier: workspace:^
         version: link:../db
+      '@voyant-travel/tools':
+        specifier: workspace:^
+        version: link:../tools
       '@voyant-travel/types':
         specifier: workspace:^
         version: link:../types
@@ -13654,6 +13657,14 @@ snapshots:
   '@better-auth/api-key@1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
+      better-call: 1.3.7(zod@4.4.3)
+      zod: 4.4.3
+
+  '@better-auth/api-key@1.6.23(4cc07405e1e664eaf96048bc4329d318)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
       better-call: 1.3.7(zod@4.4.3)


### PR DESCRIPTION
Fixes #4805.

## What was wrong

`bookingCreateCommandError` mapped 15 of the 16 non-`ok` `BookingCreateOutcome`
statuses to a specific message. `invalid_pricing` — the third of three siblings
carrying the same `issues[]` payload, next to `invalid_payment_schedules` and
`invalid_tax_lines` — had no `case`, so it fell through to `default:` and became
`"The booking command failed validation."` with its issues discarded.

Because it was the *only* status that could reach that arm, the sentence was a
tautology, and the pricing diagnostic was unrecoverable from the product, the
API, or the server log. The route then answered `500 Internal Server Error`, so
the operator was told the product was broken when the input had merely been
rejected.

## What changed

**`@voyant-travel/finance`**

- `case "invalid_pricing"` formats its issues exactly like its two siblings.
- `default:` now assigns to a `never`, so a status added to
  `BookingCreateOutcome` fails the build instead of silently degrading. The
  runtime arm is kept and names the status it could not map, because a published
  copy of this package can be paired with a newer `service-booking-create`.
- The six outcomes that shared `"The booking command conflicts with current
  state."` now name what they conflict with. Each already carried the field that
  identifies it — the existing booking number, the current group id, the credit's
  state — and none of it was reaching the caller.

**`@voyant-travel/hono`**

The framework error boundary did not recognise a `ToolError` at all, so every
code fell through to the generic 500. It now maps the client-answerable codes
onto the error contract and reflects the message and `nextSteps`:

| code | status |
|---|---|
| `INVALID_INPUT` | 400 `invalid_request` |
| `AUTHORIZATION_DENIED` | 403 |
| `NOT_FOUND` | 404 |
| `APPROVAL_REQUIRED` / `CONFIRMATION_REQUIRED` | 409 |

The table is deliberately partial. `MISSING_SERVICE`, `ACTION_POLICY_REQUIRED`,
`INVALID_OUTPUT`, `PROVIDER_ERROR` and `PROVIDER_UNAVAILABLE` report a
mis-wired deployment, a server-side defect or an upstream fault: none is
answerable by changing the request and each one's message describes internals,
so they keep today's opaque 500 and still reach the observability sink.
`meta` is never reflected — it carries the raw domain outcome and belongs in the
log. The API error log gains `toolErrorCode` for every `ToolError`, which is
what the issue observed as `code: undefined`.

Matching is by `isToolError` rather than `instanceof`, for the same cross-copy
reason `API_HTTP_ERROR_BRAND` exists: the managed runtime inlines a copy of each
`@voyant-travel/*` package into the SSR bundle while runtime-composed modules
resolve their own, so the error is virtually never an instance of the class the
boundary loaded. Both the branded and pre-brand shapes are covered by tests.

The table lives in `hono` rather than `tools` because HTTP is this package's
vocabulary; `tools` keeps owning the code union and stays transport-neutral.
This adds one workspace edge, `hono -> tools`; `tools` has no dependencies, so
there is no cycle, and `verify:boundary` and `verify:public-surface` both pass.

Ask 4 in the issue — the underlying pricing defect for per-person-priced room
units — is deliberately **not** in this PR. It is a separate fix, and it is now
diagnosable: the real `invalid_pricing` issues reach the operator.

## Verification

- `pnpm verify:architecture` — full chain, exit 0
- `build` of `tools`, `hono`, `finance` — exit 0, `grep -c "error TS"` = 0
- Negative control on the exhaustiveness check: deleting `case
  "group_not_found"` fails the build with
  `TS2322: Type '{ status: "group_not_found"; }' is not assignable to type 'never'`,
  and the case was restored
- Tests: `hono` 405, `finance` unit 681, `catalog` 912, `mcp` 122, `apps` 144,
  `distribution` 171, `auth` 310 — all green. New coverage: the pricing issues
  are formatted, the three `issues[]` siblings format identically, conflicts name
  their record, each mapped code answers its status with `meta` withheld, each
  unmapped code stays an opaque 500, and both cross-copy shapes are recognised
- `biome check` clean on every touched file
- `pnpm install --frozen-lockfile` succeeds against the committed lockfile
