### PR TITLE
Build the operator webhooks document with the 3.1 builder it claims

### DIFF
--- a/packages/admin-api-client/src/generated/operator-webhooks.ts
+++ b/packages/admin-api-client/src/generated/operator-webhooks.ts
@@ -252,7 +252,7 @@ export interface operations {
               description: string | null
               createdAt: string
               updatedAt: string
-              lastDeliveryAt: string | unknown
+              lastDeliveryAt: string | null
               failureCount: number
             }[]
           }
@@ -322,7 +322,7 @@ export interface operations {
                 description: string | null
                 createdAt: string
                 updatedAt: string
-                lastDeliveryAt: string | unknown
+                lastDeliveryAt: string | null
                 failureCount: number
               }
               secret: string
@@ -403,7 +403,7 @@ export interface operations {
               description: string | null
               createdAt: string
               updatedAt: string
-              lastDeliveryAt: string | unknown
+              lastDeliveryAt: string | null
               failureCount: number
             }
           }
@@ -536,7 +536,7 @@ export interface operations {
               description: string | null
               createdAt: string
               updatedAt: string
-              lastDeliveryAt: string | unknown
+              lastDeliveryAt: string | null
               failureCount: number
             }
           }
@@ -615,7 +615,7 @@ export interface operations {
               description: string | null
               createdAt: string
               updatedAt: string
-              lastDeliveryAt: string | unknown
+              lastDeliveryAt: string | null
               failureCount: number
             }
           }
@@ -683,7 +683,7 @@ export interface operations {
               description: string | null
               createdAt: string
               updatedAt: string
-              lastDeliveryAt: string | unknown
+              lastDeliveryAt: string | null
               failureCount: number
             }
           }
@@ -752,7 +752,7 @@ export interface operations {
                 description: string | null
                 createdAt: string
                 updatedAt: string
-                lastDeliveryAt: string | unknown
+                lastDeliveryAt: string | null
                 failureCount: number
               }
               secret: string
@@ -830,7 +830,7 @@ export interface operations {
               responseStatus: number | null
               errorMessage: string | null
               createdAt: string
-              finishedAt: string | unknown
+              finishedAt: string | null
             }
           }
         }
@@ -922,7 +922,7 @@ export interface operations {
               responseStatus: number | null
               errorMessage: string | null
               createdAt: string
-              finishedAt: string | unknown
+              finishedAt: string | null
             }[]
           }
         }
@@ -980,7 +980,7 @@ export interface operations {
               responseStatus: number | null
               errorMessage: string | null
               createdAt: string
-              finishedAt: string | unknown
+              finishedAt: string | null
             }
           }
         }
@@ -1049,7 +1049,7 @@ export interface operations {
               responseStatus: number | null
               errorMessage: string | null
               createdAt: string
-              finishedAt: string | unknown
+              finishedAt: string | null
             }
           }
         }

--- a/packages/webhook-delivery/openapi/admin/operator-webhooks.json
+++ b/packages/webhook-delivery/openapi/admin/operator-webhooks.json
@@ -37,9 +37,7 @@
                           },
                           "payloadSchema": {
                             "type": "object",
-                            "additionalProperties": {
-                              "nullable": true
-                            }
+                            "additionalProperties": {}
                           }
                         },
                         "required": ["id", "eventType", "version", "payloadSchema"]
@@ -122,8 +120,7 @@
                             "type": "integer"
                           },
                           "description": {
-                            "type": "string",
-                            "nullable": true
+                            "type": ["string", "null"]
                           },
                           "createdAt": {
                             "anyOf": [
@@ -157,7 +154,7 @@
                                 "format": "date-time"
                               },
                               {
-                                "nullable": true
+                                "type": "null"
                               }
                             ]
                           },
@@ -255,8 +252,7 @@
                     "default": 5
                   },
                   "description": {
-                    "type": "string",
-                    "nullable": true,
+                    "type": ["string", "null"],
                     "maxLength": 500,
                     "default": null
                   }
@@ -300,8 +296,7 @@
                               "type": "integer"
                             },
                             "description": {
-                              "type": "string",
-                              "nullable": true
+                              "type": ["string", "null"]
                             },
                             "createdAt": {
                               "anyOf": [
@@ -335,7 +330,7 @@
                                   "format": "date-time"
                                 },
                                 {
-                                  "nullable": true
+                                  "type": "null"
                                 }
                               ]
                             },
@@ -481,8 +476,7 @@
                           "type": "integer"
                         },
                         "description": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "createdAt": {
                           "anyOf": [
@@ -516,7 +510,7 @@
                               "format": "date-time"
                             },
                             {
-                              "nullable": true
+                              "type": "null"
                             }
                           ]
                         },
@@ -637,8 +631,7 @@
                     "default": 5
                   },
                   "description": {
-                    "type": "string",
-                    "nullable": true,
+                    "type": ["string", "null"],
                     "maxLength": 500,
                     "default": null
                   }
@@ -678,8 +671,7 @@
                           "type": "integer"
                         },
                         "description": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "createdAt": {
                           "anyOf": [
@@ -713,7 +705,7 @@
                               "format": "date-time"
                             },
                             {
-                              "nullable": true
+                              "type": "null"
                             }
                           ]
                         },
@@ -922,8 +914,7 @@
                           "type": "integer"
                         },
                         "description": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "createdAt": {
                           "anyOf": [
@@ -957,7 +948,7 @@
                               "format": "date-time"
                             },
                             {
-                              "nullable": true
+                              "type": "null"
                             }
                           ]
                         },
@@ -1081,8 +1072,7 @@
                           "type": "integer"
                         },
                         "description": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "createdAt": {
                           "anyOf": [
@@ -1116,7 +1106,7 @@
                               "format": "date-time"
                             },
                             {
-                              "nullable": true
+                              "type": "null"
                             }
                           ]
                         },
@@ -1243,8 +1233,7 @@
                               "type": "integer"
                             },
                             "description": {
-                              "type": "string",
-                              "nullable": true
+                              "type": ["string", "null"]
                             },
                             "createdAt": {
                               "anyOf": [
@@ -1278,7 +1267,7 @@
                                   "format": "date-time"
                                 },
                                 {
-                                  "nullable": true
+                                  "type": "null"
                                 }
                               ]
                             },
@@ -1411,8 +1400,7 @@
                           "type": "string"
                         },
                         "subscriptionId": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "sourceEvent": {
                           "type": "string"
@@ -1428,12 +1416,10 @@
                           "type": "integer"
                         },
                         "responseStatus": {
-                          "type": "integer",
-                          "nullable": true
+                          "type": ["integer", "null"]
                         },
                         "errorMessage": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "createdAt": {
                           "anyOf": [
@@ -1456,7 +1442,7 @@
                               "format": "date-time"
                             },
                             {
-                              "nullable": true
+                              "type": "null"
                             }
                           ]
                         }
@@ -1607,8 +1593,7 @@
                             "type": "string"
                           },
                           "subscriptionId": {
-                            "type": "string",
-                            "nullable": true
+                            "type": ["string", "null"]
                           },
                           "sourceEvent": {
                             "type": "string"
@@ -1624,12 +1609,10 @@
                             "type": "integer"
                           },
                           "responseStatus": {
-                            "type": "integer",
-                            "nullable": true
+                            "type": ["integer", "null"]
                           },
                           "errorMessage": {
-                            "type": "string",
-                            "nullable": true
+                            "type": ["string", "null"]
                           },
                           "createdAt": {
                             "anyOf": [
@@ -1652,7 +1635,7 @@
                                 "format": "date-time"
                               },
                               {
-                                "nullable": true
+                                "type": "null"
                               }
                             ]
                           }
@@ -1743,8 +1726,7 @@
                           "type": "string"
                         },
                         "subscriptionId": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "sourceEvent": {
                           "type": "string"
@@ -1760,12 +1742,10 @@
                           "type": "integer"
                         },
                         "responseStatus": {
-                          "type": "integer",
-                          "nullable": true
+                          "type": ["integer", "null"]
                         },
                         "errorMessage": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "createdAt": {
                           "anyOf": [
@@ -1788,7 +1768,7 @@
                               "format": "date-time"
                             },
                             {
-                              "nullable": true
+                              "type": "null"
                             }
                           ]
                         }
@@ -1894,8 +1874,7 @@
                           "type": "string"
                         },
                         "subscriptionId": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "sourceEvent": {
                           "type": "string"
@@ -1911,12 +1890,10 @@
                           "type": "integer"
                         },
                         "responseStatus": {
-                          "type": "integer",
-                          "nullable": true
+                          "type": ["integer", "null"]
                         },
                         "errorMessage": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "createdAt": {
                           "anyOf": [
@@ -1939,7 +1916,7 @@
                               "format": "date-time"
                             },
                             {
-                              "nullable": true
+                              "type": "null"
                             }
                           ]
                         }
@@ -2030,5 +2007,6 @@
         }
       }
     }
-  }
+  },
+  "webhooks": {}
 }

--- a/packages/webhook-delivery/scripts/generate-openapi.ts
+++ b/packages/webhook-delivery/scripts/generate-openapi.ts
@@ -14,7 +14,13 @@ app.route(
   }),
 )
 
-const document = app.getOpenAPIDocument({
+// `getOpenAPI31Document`, not `getOpenAPIDocument`. The latter builds a 3.0
+// document, and passing `openapi: "3.1.0"` only relabels it — the body still
+// used 3.0's `nullable: true`, which 3.1 has no such keyword for and silently
+// ignores. Every `z.string().nullable()` therefore published as a plain
+// non-nullable string, and a client generated from this document would be typed
+// to expect a value the API may not send.
+const document = app.getOpenAPI31Document({
   openapi: "3.1.0",
   info: {
     title: "Voyant Operator Webhooks Admin API",


### PR DESCRIPTION
A one-word bug with a measurable consequence.

```ts
const document = app.getOpenAPIDocument({   // ← the 3.0 builder
  openapi: "3.1.0",                          // ← a label, not an instruction
```

`getOpenAPIDocument` builds a **3.0** document. Passing `openapi: "3.1.0"` only relabels it. So every `z.string().nullable()` published as 3.0's `nullable: true` — a keyword **3.1 does not have and silently ignores**.

## What it cost

Regenerating the admin client against the corrected document:

| | before | after |
|---|---|---|
| fields typed `string \| null` | 17 | **28** |

Eleven fields the API can return as null were typed as never null. A consumer repointed onto those types would be told, with full type-checker confidence, that a value is always present. This is the concrete form of the argument for doing #4256 P0 before P3.

## Why nothing caught it

- **`verify:openapi-drift` can't**: it regenerates and compares. The generator produced `nullable` exactly as consistently as the artifact contained it, so both sides were wrong in the same way and agreed. A round-trip check proves reproducibility, not correctness.
- **A 3.1 parser can't**: `openapi-typescript` accepts the old document, because `nullable` is simply an unknown keyword to it, not an error. It parsed fine and produced wrong types.
- **The version string can't**: it was declared, not derived.

## Scope of the change, verified

Only nullability moved:

- paths identical (10), no top-level field changed except 3.1's empty `webhooks: {}`
- `nullable` 33 → 0; `type` +11
- every remaining difference is an `anyOf` branch that was a bare `{nullable: true}` becoming `{type: "null"}` — the 3.1 spelling of the same thing

I diffed the two documents with 3.0 `nullable` normalised into the 3.1 union to confirm nothing else changed, rather than reading the raw diff and assuming.

## Verification

- `pnpm verify:architecture` — full chain, exit 0
- `verify:openapi-drift` green after regenerating the client (it correctly went red first — the document and its generated module are wired together)
- `openapi-typescript` parses the result; `webhook-delivery` 57 tests pass
- root `biome check .` clean at error level

No changeset: `webhook-delivery` and `admin-api-client` are both private.

## Follow-on

This is the only generator using the 3.0 builder; the other six already call `getOpenAPI31Document`. It clears **33 of the 87** `nullable` keywords across the corpus, leaving 54 in four documents — `setup` (34), `notifications` (15), `finance` (3), `identity` (2). Three are hand-written. `finance`'s three sit in regions its generator does not own, which is worth understanding before #4256 P0 adds 24 more generators using the same merge pattern.