### PR TITLE
Stop a Docker Hub blip from failing the operator image publication

### DIFF
--- a/.github/workflows/operator-image.yml
+++ b/.github/workflows/operator-image.yml
@@ -54,6 +54,9 @@ permissions:
 
 env:
   IMAGE_NAME: ghcr.io/voyant-travel/operator
+  # buildx's own default for the docker-container driver. Naming it here lets the
+  # build job pre-pull the exact reference the builder will boot.
+  BUILDKIT_IMAGE: moby/buildkit:buildx-stable-1
 
 jobs:
   plan:
@@ -74,7 +77,14 @@ jobs:
         with:
           filter: blob:none
 
+      # This job only reads the registry through `docker buildx imagetools`,
+      # which addresses it directly and never dispatches a build. The default
+      # driver installs the buildx CLI without booting a BuildKit container, so
+      # the job no longer depends on Docker Hub being reachable to do work that
+      # never touches it.
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          driver: docker
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -172,9 +182,33 @@ jobs:
           fetch-depth: 0
           filter: blob:none
 
+      # This is the only job that needs a real builder, so it is the only one
+      # that boots the docker-container driver — and booting it pulls BuildKit
+      # from Docker Hub. A single 502 there failed the arm64 build before a line
+      # of the image existed, which failed the whole publication
+      # (https://github.com/voyant-travel/voyant/actions/runs/32034681045).
+      # buildx tolerates a failed pull when the image is already in the local
+      # store, so warm it here with retries and pin the driver to the exact
+      # reference that was warmed.
+      - name: Warm the BuildKit driver image
+        shell: bash
+        run: |
+          set -uo pipefail
+          for attempt in 1 2 3 4 5; do
+            if docker pull "$BUILDKIT_IMAGE"; then
+              exit 0
+            fi
+            delay=$(( attempt * 5 ))
+            echo "Pull of $BUILDKIT_IMAGE failed (attempt $attempt); retrying in ${delay}s."
+            sleep "$delay"
+          done
+          echo "::warning::Could not pre-pull $BUILDKIT_IMAGE; letting the builder boot pull it."
+
       # Each job runs on the same architecture it builds. Do not add QEMU: the
       # production deploy tree contains architecture-specific native modules.
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          driver-opts: image=${{ env.BUILDKIT_IMAGE }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -285,7 +319,10 @@ jobs:
         with:
           filter: blob:none
 
+      # Manifest assembly is `imagetools` all the way down; no builder required.
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          driver: docker
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -423,7 +460,10 @@ jobs:
         with:
           filter: blob:none
 
+      # Promotion only moves a tag with `imagetools`; no builder required.
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          driver: docker
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3


### PR DESCRIPTION
## What failed

[Run 32034681045](https://github.com/voyant-travel/voyant/actions/runs/32034681045) — `build-and-smoke-arm64` died 24 seconds in, inside `docker/setup-buildx-action`, before a single layer of the image was built:

```
#1 [internal] booting buildkit
#1 pulling image moby/buildkit:buildx-stable-1
#1 pulling image moby/buildkit:buildx-stable-1 0.3s done
#1 ERROR: received unexpected HTTP status: 502 Bad Gateway
```

Nothing in this repository is wrong. Booting buildx's `docker-container` driver pulls BuildKit from Docker Hub, Docker Hub returned a 502, and the job had no second attempt. `fail-fast: false` kept amd64 alive, but `finalize` needs both architectures' digest receipts, so one gateway error cost the whole publication of `sha-<commit>`.

## What changed

**Three of the four jobs never needed a builder.** `plan`, `finalize` and `promote-latest` reach the registry exclusively through `docker buildx imagetools` (`inspect`, `create`), which addresses the registry directly and never dispatches a build — `scripts/resolve-upgrade-baseline.mjs` already says as much in its header comment. They now pass `driver: docker`, which still installs the buildx CLI but skips `buildx create`/`--bootstrap` entirely. Three Docker Hub round trips removed from the release path, for work that never touched Docker Hub.

**The build job keeps the container driver** — it needs it for `type=gha` cache, `provenance: mode=max`, `sbom: true` and `push-by-digest` — and warms the image before setup, with five bounded retries. This works because of how buildx's driver behaves ([`driver/docker-container/driver.go`](https://github.com/docker/buildx/blob/v0.36.1/driver/docker-container/driver.go#L93-L118), the v0.36.1 the runner installs):

```go
pullErr := l.Wrap("pulling image "+imageRef, func() error { ... })
image, inspectErr := d.DockerAPI.ImageInspect(ctx, imageRef)
if inspectErr != nil {
    if pullErr != nil {
        return pullErr
    }
    ...
}
```

A failed pull is only fatal when the image is *also* absent from the local store. With the image warmed, the same 502 during boot becomes a no-op. `driver-opts: image=` pins the driver to the exact reference that was warmed, so the pre-pull cannot silently start warming a tag the driver no longer boots.

If all five attempts fail, the step emits a warning and exits 0 rather than failing — Docker Hub being genuinely down should surface as buildx's own error, not as a second, less informative one.

## Verification

- `node scripts/check-operator-image-publication.mjs` → OK. The publication contract is untouched: same registry, same native-runner matrix, same `provenance`/`sbom`/`push-by-digest`, still no QEMU.
- The workflow's own `paths:` filter includes `.github/workflows/operator-image.yml`, so merging this runs the changed workflow end to end against a real publication.

## Note on the run this came from

The `sha-` snapshot for `chore: release packages (#4815)` was never published. Main only ever cuts `sha-` snapshots automatically, so nothing consumer-facing is pinned to it, and the next push to main republishes from a newer commit. No re-run needed unless that specific snapshot is wanted.
