### PR TITLE
Let the legal generator own the surface it already documents

### DIFF
--- a/packages/admin-api-client/src/generated/legal.ts
+++ b/packages/admin-api-client/src/generated/legal.ts
@@ -303,6 +303,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/v1/admin/legal/contracts/{id}/booking-review": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** GET /v1/admin/legal/contracts/{id}/booking-review */
+    get: operations["getAdminLegalContractsByIdBookingReview"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/v1/admin/legal/contracts/{id}/signatures": {
     parameters: {
       query?: never
@@ -675,17 +692,17 @@ export interface paths {
     patch: operations["patchAdminLegalTermsById"]
     trace?: never
   }
-  "/v1/admin/legal/contracts/{id}/booking-review": {
+  "/v1/admin/legal/terms/{id}/acceptance": {
     parameters: {
       query?: never
       header?: never
       path?: never
       cookie?: never
     }
-    /** GET /v1/admin/legal/contracts/{id}/booking-review */
-    get: operations["getAdminLegalContractsByIdBookingReview"]
+    get?: never
     put?: never
-    post?: never
+    /** POST /v1/admin/legal/terms/{id}/acceptance */
+    post: operations["postAdminLegalTermsByIdAcceptance"]
     delete?: never
     options?: never
     head?: never
@@ -2883,6 +2900,113 @@ export interface operations {
       }
     }
   }
+  getAdminLegalContractsByIdBookingReview: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description The booking-contract revision under review */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              contract: {
+                id: string
+                contractNumber: string | null
+                /** @enum {string} */
+                scope: "customer" | "supplier" | "partner" | "channel" | "other"
+                /** @enum {string} */
+                status: "draft" | "issued" | "sent" | "signed" | "executed" | "expired" | "void"
+                title: string
+                bookingId: string | null
+                language: string
+                templateVersionId: string | null
+                /** @enum {string} */
+                renderedBodyFormat: "markdown" | "html" | "lexical_json"
+                renderedBody: string | null
+                variables: {
+                  [key: string]: unknown
+                } | null
+                metadata: {
+                  [key: string]: unknown
+                } | null
+                issuedAt: string | null
+                sentAt: string | null
+                executedAt: string | null
+                expiresAt: string | null
+                voidedAt: string | null
+                createdAt: string
+                updatedAt: string
+              }
+              contentFingerprint: string
+              /** @enum {string} */
+              effectiveStatus: "draft" | "sent" | "viewed" | "declined" | "signed" | "void"
+              revision: number
+              previousRevisionId: string | null
+              booking: {
+                id: string
+                reference: string
+                customerName: string | null
+                customerEmail: string | null
+                language: string
+                currency: string
+                totalAmountCents: number | null
+                startDate: string | null
+                endDate: string | null
+              }
+              products: {
+                title: string
+                quantity: number
+                amountCents: number | null
+                currency: string
+              }[]
+              template: {
+                id: string
+                name: string
+                versionId: string
+                version: number
+                language: string
+              }
+              commercialTerms: {
+                [key: string]: unknown
+              }
+              delivery: {
+                recipient: string | null
+                /** @enum {string|null} */
+                channel: "email" | "sms" | "whatsapp" | null
+                sentRevision: number | null
+                sentAt: string | null
+                viewedAt: string | null
+                declinedAt: string | null
+                notificationsSuppressed: boolean
+              }
+              voidConsequences: string[]
+            }
+          }
+        }
+      }
+      /** @description Contract not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
   getAdminLegalContractsByIdSignatures: {
     parameters: {
       query?: never
@@ -5015,8 +5139,12 @@ export interface operations {
           | "payment"
           | "pricing"
           | "commission"
+          | "insurer_product_information"
+          | "insurer_terms"
+          | "demands_and_needs"
           | "other"
         acceptanceStatus?: "not_required" | "pending" | "accepted" | "declined"
+        sourceVersionId?: string
       }
       header?: never
       path?: never
@@ -5058,6 +5186,9 @@ export interface operations {
                 | "payment"
                 | "pricing"
                 | "commission"
+                | "insurer_product_information"
+                | "insurer_terms"
+                | "demands_and_needs"
                 | "other"
               title: string
               body: string
@@ -5068,6 +5199,9 @@ export interface operations {
               acceptanceStatus: "not_required" | "pending" | "accepted" | "declined"
               acceptedAt: string | null
               acceptedBy: string | null
+              sourceVersionId: string | null
+              archivedStorageKey: string | null
+              archivedChecksum: string | null
               metadata?: unknown
               createdAt: string
               updatedAt: string
@@ -5118,6 +5252,9 @@ export interface operations {
             | "payment"
             | "pricing"
             | "commission"
+            | "insurer_product_information"
+            | "insurer_terms"
+            | "demands_and_needs"
             | "other"
           title: string
           body: string
@@ -5133,6 +5270,9 @@ export interface operations {
           acceptanceStatus?: "not_required" | "pending" | "accepted" | "declined"
           acceptedAt?: string | null
           acceptedBy?: string | null
+          sourceVersionId?: "" | string | null
+          archivedStorageKey?: "" | string | null
+          archivedChecksum?: "" | string | null
           metadata?: {
             [key: string]: unknown
           } | null
@@ -5174,6 +5314,9 @@ export interface operations {
                 | "payment"
                 | "pricing"
                 | "commission"
+                | "insurer_product_information"
+                | "insurer_terms"
+                | "demands_and_needs"
                 | "other"
               title: string
               body: string
@@ -5184,6 +5327,9 @@ export interface operations {
               acceptanceStatus: "not_required" | "pending" | "accepted" | "declined"
               acceptedAt: string | null
               acceptedBy: string | null
+              sourceVersionId: string | null
+              archivedStorageKey: string | null
+              archivedChecksum: string | null
               metadata?: unknown
               createdAt: string
               updatedAt: string
@@ -5249,6 +5395,9 @@ export interface operations {
                 | "payment"
                 | "pricing"
                 | "commission"
+                | "insurer_product_information"
+                | "insurer_terms"
+                | "demands_and_needs"
                 | "other"
               title: string
               body: string
@@ -5259,6 +5408,9 @@ export interface operations {
               acceptanceStatus: "not_required" | "pending" | "accepted" | "declined"
               acceptedAt: string | null
               acceptedBy: string | null
+              sourceVersionId: string | null
+              archivedStorageKey: string | null
+              archivedChecksum: string | null
               metadata?: unknown
               createdAt: string
               updatedAt: string
@@ -5354,6 +5506,9 @@ export interface operations {
             | "payment"
             | "pricing"
             | "commission"
+            | "insurer_product_information"
+            | "insurer_terms"
+            | "demands_and_needs"
             | "other"
           title?: string
           body?: string
@@ -5369,6 +5524,9 @@ export interface operations {
           acceptanceStatus?: "not_required" | "pending" | "accepted" | "declined"
           acceptedAt?: string | null
           acceptedBy?: string | null
+          sourceVersionId?: "" | string | null
+          archivedStorageKey?: "" | string | null
+          archivedChecksum?: "" | string | null
           metadata?: {
             [key: string]: unknown
           } | null
@@ -5410,6 +5568,9 @@ export interface operations {
                 | "payment"
                 | "pricing"
                 | "commission"
+                | "insurer_product_information"
+                | "insurer_terms"
+                | "demands_and_needs"
                 | "other"
               title: string
               body: string
@@ -5420,6 +5581,9 @@ export interface operations {
               acceptanceStatus: "not_required" | "pending" | "accepted" | "declined"
               acceptedAt: string | null
               acceptedBy: string | null
+              sourceVersionId: string | null
+              archivedStorageKey: string | null
+              archivedChecksum: string | null
               metadata?: unknown
               createdAt: string
               updatedAt: string
@@ -5451,7 +5615,7 @@ export interface operations {
       }
     }
   }
-  getAdminLegalContractsByIdBookingReview: {
+  postAdminLegalTermsByIdAcceptance: {
     parameters: {
       query?: never
       header?: never
@@ -5460,9 +5624,17 @@ export interface operations {
       }
       cookie?: never
     }
-    requestBody?: never
+    requestBody: {
+      content: {
+        "application/json": {
+          acceptedBy: string
+          /** Format: date-time */
+          acceptedAt?: string
+        }
+      }
+    }
     responses: {
-      /** @description The booking-contract revision under review */
+      /** @description The accepted legal term */
       200: {
         headers: {
           [name: string]: unknown
@@ -5470,82 +5642,67 @@ export interface operations {
         content: {
           "application/json": {
             data: {
-              contract: {
-                id: string
-                contractNumber: string | null
-                /** @enum {string} */
-                scope: "customer" | "supplier" | "partner" | "channel" | "other"
-                /** @enum {string} */
-                status: "draft" | "issued" | "sent" | "signed" | "executed" | "expired" | "void"
-                title: string
-                bookingId: string | null
-                language: string
-                templateVersionId: string | null
-                /** @enum {string} */
-                renderedBodyFormat: "markdown" | "html" | "lexical_json"
-                renderedBody: string | null
-                variables: {
-                  [key: string]: unknown
-                } | null
-                metadata: {
-                  [key: string]: unknown
-                } | null
-                issuedAt: string | null
-                sentAt: string | null
-                executedAt: string | null
-                expiresAt: string | null
-                voidedAt: string | null
-                createdAt: string
-                updatedAt: string
-              }
-              contentFingerprint: string
+              id: string
+              contractId: string | null
+              policyVersionId: string | null
+              /** @enum {string|null} */
+              targetKind:
+                | "booking"
+                | "proposal_version"
+                | "program"
+                | "product"
+                | "inventory_item"
+                | "supplier_channel_relationship"
+                | "provider_source_ref"
+                | null
+              targetId: string | null
+              targetProvider: string | null
+              targetSourceRef: string | null
+              legacyTransactionOfferId: string | null
+              legacyTransactionOrderId: string | null
               /** @enum {string} */
-              effectiveStatus: "draft" | "sent" | "viewed" | "declined" | "signed" | "void"
-              revision: number
-              previousRevisionId: string | null
-              booking: {
-                id: string
-                reference: string
-                customerName: string | null
-                customerEmail: string | null
-                language: string
-                currency: string
-                totalAmountCents: number | null
-                startDate: string | null
-                endDate: string | null
-              }
-              products: {
-                title: string
-                quantity: number
-                amountCents: number | null
-                currency: string
-              }[]
-              template: {
-                id: string
-                name: string
-                versionId: string
-                version: number
-                language: string
-              }
-              commercialTerms: {
-                [key: string]: unknown
-              }
-              delivery: {
-                recipient: string | null
-                /** @enum {string|null} */
-                channel: "email" | "sms" | "whatsapp" | null
-                sentRevision: number | null
-                sentAt: string | null
-                viewedAt: string | null
-                declinedAt: string | null
-                notificationsSuppressed: boolean
-              }
-              voidConsequences: string[]
+              termType:
+                | "terms_and_conditions"
+                | "cancellation"
+                | "guarantee"
+                | "payment"
+                | "pricing"
+                | "commission"
+                | "insurer_product_information"
+                | "insurer_terms"
+                | "demands_and_needs"
+                | "other"
+              title: string
+              body: string
+              language: string | null
+              required: boolean
+              sortOrder: number
+              /** @enum {string} */
+              acceptanceStatus: "not_required" | "pending" | "accepted" | "declined"
+              acceptedAt: string | null
+              acceptedBy: string | null
+              sourceVersionId: string | null
+              archivedStorageKey: string | null
+              archivedChecksum: string | null
+              metadata?: unknown
+              createdAt: string
+              updatedAt: string
             }
           }
         }
       }
-      /** @description Contract not found */
+      /** @description Invalid request body, or the term carries no archived disclosure */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+      /** @description Legal term not found */
       404: {
         headers: {
           [name: string]: unknown

--- a/packages/legal/openapi/admin/legal.json
+++ b/packages/legal/openapi/admin/legal.json
@@ -5468,6 +5468,318 @@
         "x-voyant-surface": "admin"
       }
     },
+    "/v1/admin/legal/contracts/{id}/booking-review": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The booking-contract revision under review",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "contract": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "contractNumber": {
+                              "type": ["string", "null"]
+                            },
+                            "scope": {
+                              "type": "string",
+                              "enum": ["customer", "supplier", "partner", "channel", "other"]
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "draft",
+                                "issued",
+                                "sent",
+                                "signed",
+                                "executed",
+                                "expired",
+                                "void"
+                              ]
+                            },
+                            "title": {
+                              "type": "string"
+                            },
+                            "bookingId": {
+                              "type": ["string", "null"]
+                            },
+                            "language": {
+                              "type": "string"
+                            },
+                            "templateVersionId": {
+                              "type": ["string", "null"]
+                            },
+                            "renderedBodyFormat": {
+                              "type": "string",
+                              "enum": ["markdown", "html", "lexical_json"]
+                            },
+                            "renderedBody": {
+                              "type": ["string", "null"]
+                            },
+                            "variables": {
+                              "type": ["object", "null"],
+                              "additionalProperties": {}
+                            },
+                            "metadata": {
+                              "type": ["object", "null"],
+                              "additionalProperties": {}
+                            },
+                            "issuedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "sentAt": {
+                              "type": ["string", "null"]
+                            },
+                            "executedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "expiresAt": {
+                              "type": ["string", "null"]
+                            },
+                            "voidedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "createdAt": {
+                              "type": "string"
+                            },
+                            "updatedAt": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "contractNumber",
+                            "scope",
+                            "status",
+                            "title",
+                            "bookingId",
+                            "language",
+                            "templateVersionId",
+                            "renderedBodyFormat",
+                            "renderedBody",
+                            "variables",
+                            "metadata",
+                            "issuedAt",
+                            "sentAt",
+                            "executedAt",
+                            "expiresAt",
+                            "voidedAt",
+                            "createdAt",
+                            "updatedAt"
+                          ]
+                        },
+                        "contentFingerprint": {
+                          "type": "string"
+                        },
+                        "effectiveStatus": {
+                          "type": "string",
+                          "enum": ["draft", "sent", "viewed", "declined", "signed", "void"]
+                        },
+                        "revision": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        "previousRevisionId": {
+                          "type": ["string", "null"]
+                        },
+                        "booking": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "reference": {
+                              "type": "string"
+                            },
+                            "customerName": {
+                              "type": ["string", "null"]
+                            },
+                            "customerEmail": {
+                              "type": ["string", "null"]
+                            },
+                            "language": {
+                              "type": "string"
+                            },
+                            "currency": {
+                              "type": "string"
+                            },
+                            "totalAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "startDate": {
+                              "type": ["string", "null"]
+                            },
+                            "endDate": {
+                              "type": ["string", "null"]
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "reference",
+                            "customerName",
+                            "customerEmail",
+                            "language",
+                            "currency",
+                            "totalAmountCents",
+                            "startDate",
+                            "endDate"
+                          ]
+                        },
+                        "products": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "quantity": {
+                                "type": "integer",
+                                "exclusiveMinimum": 0
+                              },
+                              "amountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "currency": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["title", "quantity", "amountCents", "currency"]
+                          }
+                        },
+                        "template": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "versionId": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
+                            },
+                            "language": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["id", "name", "versionId", "version", "language"]
+                        },
+                        "commercialTerms": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "delivery": {
+                          "type": "object",
+                          "properties": {
+                            "recipient": {
+                              "type": ["string", "null"]
+                            },
+                            "channel": {
+                              "type": ["string", "null"],
+                              "enum": ["email", "sms", "whatsapp", null]
+                            },
+                            "sentRevision": {
+                              "type": ["integer", "null"],
+                              "exclusiveMinimum": 0
+                            },
+                            "sentAt": {
+                              "type": ["string", "null"]
+                            },
+                            "viewedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "declinedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "notificationsSuppressed": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "recipient",
+                            "channel",
+                            "sentRevision",
+                            "sentAt",
+                            "viewedAt",
+                            "declinedAt",
+                            "notificationsSuppressed"
+                          ]
+                        },
+                        "voidConsequences": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contract",
+                        "contentFingerprint",
+                        "effectiveStatus",
+                        "revision",
+                        "previousRevisionId",
+                        "booking",
+                        "products",
+                        "template",
+                        "commercialTerms",
+                        "delivery",
+                        "voidConsequences"
+                      ]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Contract not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminLegalContractsByIdBookingReview",
+        "summary": "GET /v1/admin/legal/contracts/{id}/booking-review",
+        "tags": ["legal"],
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
+      }
+    },
     "/v1/admin/legal/contracts/{id}/signatures": {
       "get": {
         "parameters": [
@@ -10270,6 +10582,9 @@
                 "payment",
                 "pricing",
                 "commission",
+                "insurer_product_information",
+                "insurer_terms",
+                "demands_and_needs",
                 "other"
               ]
             },
@@ -10284,6 +10599,14 @@
             },
             "required": false,
             "name": "acceptanceStatus",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "sourceVersionId",
             "in": "query"
           }
         ],
@@ -10346,6 +10669,9 @@
                               "payment",
                               "pricing",
                               "commission",
+                              "insurer_product_information",
+                              "insurer_terms",
+                              "demands_and_needs",
                               "other"
                             ]
                           },
@@ -10372,6 +10698,15 @@
                             "type": ["string", "null"]
                           },
                           "acceptedBy": {
+                            "type": ["string", "null"]
+                          },
+                          "sourceVersionId": {
+                            "type": ["string", "null"]
+                          },
+                          "archivedStorageKey": {
+                            "type": ["string", "null"]
+                          },
+                          "archivedChecksum": {
                             "type": ["string", "null"]
                           },
                           "metadata": {},
@@ -10401,6 +10736,9 @@
                           "acceptanceStatus",
                           "acceptedAt",
                           "acceptedBy",
+                          "sourceVersionId",
+                          "archivedStorageKey",
+                          "archivedChecksum",
                           "createdAt",
                           "updatedAt"
                         ]
@@ -10560,6 +10898,9 @@
                       "payment",
                       "pricing",
                       "commission",
+                      "insurer_product_information",
+                      "insurer_terms",
+                      "demands_and_needs",
                       "other"
                     ],
                     "default": "terms_and_conditions"
@@ -10596,6 +10937,54 @@
                   "acceptedBy": {
                     "type": ["string", "null"],
                     "maxLength": 255
+                  },
+                  "sourceVersionId": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [""]
+                      },
+                      {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 255
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "archivedStorageKey": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [""]
+                      },
+                      {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 1024
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "archivedChecksum": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [""]
+                      },
+                      {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 255
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "metadata": {
                     "type": ["object", "null"],
@@ -10664,6 +11053,9 @@
                             "payment",
                             "pricing",
                             "commission",
+                            "insurer_product_information",
+                            "insurer_terms",
+                            "demands_and_needs",
                             "other"
                           ]
                         },
@@ -10690,6 +11082,15 @@
                           "type": ["string", "null"]
                         },
                         "acceptedBy": {
+                          "type": ["string", "null"]
+                        },
+                        "sourceVersionId": {
+                          "type": ["string", "null"]
+                        },
+                        "archivedStorageKey": {
+                          "type": ["string", "null"]
+                        },
+                        "archivedChecksum": {
                           "type": ["string", "null"]
                         },
                         "metadata": {},
@@ -10719,6 +11120,9 @@
                         "acceptanceStatus",
                         "acceptedAt",
                         "acceptedBy",
+                        "sourceVersionId",
+                        "archivedStorageKey",
+                        "archivedChecksum",
                         "createdAt",
                         "updatedAt"
                       ]
@@ -10822,6 +11226,9 @@
                             "payment",
                             "pricing",
                             "commission",
+                            "insurer_product_information",
+                            "insurer_terms",
+                            "demands_and_needs",
                             "other"
                           ]
                         },
@@ -10848,6 +11255,15 @@
                           "type": ["string", "null"]
                         },
                         "acceptedBy": {
+                          "type": ["string", "null"]
+                        },
+                        "sourceVersionId": {
+                          "type": ["string", "null"]
+                        },
+                        "archivedStorageKey": {
+                          "type": ["string", "null"]
+                        },
+                        "archivedChecksum": {
                           "type": ["string", "null"]
                         },
                         "metadata": {},
@@ -10877,6 +11293,9 @@
                         "acceptanceStatus",
                         "acceptedAt",
                         "acceptedBy",
+                        "sourceVersionId",
+                        "archivedStorageKey",
+                        "archivedChecksum",
                         "createdAt",
                         "updatedAt"
                       ]
@@ -11052,6 +11471,9 @@
                       "payment",
                       "pricing",
                       "commission",
+                      "insurer_product_information",
+                      "insurer_terms",
+                      "demands_and_needs",
                       "other"
                     ],
                     "default": "terms_and_conditions"
@@ -11088,6 +11510,54 @@
                   "acceptedBy": {
                     "type": ["string", "null"],
                     "maxLength": 255
+                  },
+                  "sourceVersionId": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [""]
+                      },
+                      {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 255
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "archivedStorageKey": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [""]
+                      },
+                      {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 1024
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "archivedChecksum": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [""]
+                      },
+                      {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 255
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "metadata": {
                     "type": ["object", "null"],
@@ -11155,6 +11625,9 @@
                             "payment",
                             "pricing",
                             "commission",
+                            "insurer_product_information",
+                            "insurer_terms",
+                            "demands_and_needs",
                             "other"
                           ]
                         },
@@ -11181,6 +11654,15 @@
                           "type": ["string", "null"]
                         },
                         "acceptedBy": {
+                          "type": ["string", "null"]
+                        },
+                        "sourceVersionId": {
+                          "type": ["string", "null"]
+                        },
+                        "archivedStorageKey": {
+                          "type": ["string", "null"]
+                        },
+                        "archivedChecksum": {
                           "type": ["string", "null"]
                         },
                         "metadata": {},
@@ -11210,6 +11692,9 @@
                         "acceptanceStatus",
                         "acceptedAt",
                         "acceptedBy",
+                        "sourceVersionId",
+                        "archivedStorageKey",
+                        "archivedChecksum",
                         "createdAt",
                         "updatedAt"
                       ]
@@ -11311,8 +11796,8 @@
         "x-voyant-surface": "admin"
       }
     },
-    "/v1/admin/legal/contracts/{id}/booking-review": {
-      "get": {
+    "/v1/admin/legal/terms/{id}/acceptance": {
+      "post": {
         "parameters": [
           {
             "schema": {
@@ -11323,9 +11808,31 @@
             "in": "path"
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "acceptedBy": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255
+                  },
+                  "acceptedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                },
+                "required": ["acceptedBy"]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "The booking-contract revision under review",
+            "description": "The accepted legal term",
             "content": {
               "application/json": {
                 "schema": {
@@ -11334,263 +11841,124 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "contract": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "contractNumber": {
-                              "type": ["string", "null"]
-                            },
-                            "scope": {
-                              "type": "string",
-                              "enum": ["customer", "supplier", "partner", "channel", "other"]
-                            },
-                            "status": {
-                              "type": "string",
-                              "enum": [
-                                "draft",
-                                "issued",
-                                "sent",
-                                "signed",
-                                "executed",
-                                "expired",
-                                "void"
-                              ]
-                            },
-                            "title": {
-                              "type": "string"
-                            },
-                            "bookingId": {
-                              "type": ["string", "null"]
-                            },
-                            "language": {
-                              "type": "string"
-                            },
-                            "templateVersionId": {
-                              "type": ["string", "null"]
-                            },
-                            "renderedBodyFormat": {
-                              "type": "string",
-                              "enum": ["markdown", "html", "lexical_json"]
-                            },
-                            "renderedBody": {
-                              "type": ["string", "null"]
-                            },
-                            "variables": {
-                              "type": ["object", "null"],
-                              "additionalProperties": {}
-                            },
-                            "metadata": {
-                              "type": ["object", "null"],
-                              "additionalProperties": {}
-                            },
-                            "issuedAt": {
-                              "type": ["string", "null"]
-                            },
-                            "sentAt": {
-                              "type": ["string", "null"]
-                            },
-                            "executedAt": {
-                              "type": ["string", "null"]
-                            },
-                            "expiresAt": {
-                              "type": ["string", "null"]
-                            },
-                            "voidedAt": {
-                              "type": ["string", "null"]
-                            },
-                            "createdAt": {
-                              "type": "string"
-                            },
-                            "updatedAt": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "id",
-                            "contractNumber",
-                            "scope",
-                            "status",
-                            "title",
-                            "bookingId",
-                            "language",
-                            "templateVersionId",
-                            "renderedBodyFormat",
-                            "renderedBody",
-                            "variables",
-                            "metadata",
-                            "issuedAt",
-                            "sentAt",
-                            "executedAt",
-                            "expiresAt",
-                            "voidedAt",
-                            "createdAt",
-                            "updatedAt"
-                          ]
-                        },
-                        "contentFingerprint": {
+                        "id": {
                           "type": "string"
                         },
-                        "effectiveStatus": {
-                          "type": "string",
-                          "enum": ["draft", "sent", "viewed", "declined", "signed", "void"]
-                        },
-                        "revision": {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        "previousRevisionId": {
+                        "contractId": {
                           "type": ["string", "null"]
                         },
-                        "booking": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "reference": {
-                              "type": "string"
-                            },
-                            "customerName": {
-                              "type": ["string", "null"]
-                            },
-                            "customerEmail": {
-                              "type": ["string", "null"]
-                            },
-                            "language": {
-                              "type": "string"
-                            },
-                            "currency": {
-                              "type": "string"
-                            },
-                            "totalAmountCents": {
-                              "type": ["integer", "null"]
-                            },
-                            "startDate": {
-                              "type": ["string", "null"]
-                            },
-                            "endDate": {
-                              "type": ["string", "null"]
-                            }
-                          },
-                          "required": [
-                            "id",
-                            "reference",
-                            "customerName",
-                            "customerEmail",
-                            "language",
-                            "currency",
-                            "totalAmountCents",
-                            "startDate",
-                            "endDate"
+                        "policyVersionId": {
+                          "type": ["string", "null"]
+                        },
+                        "targetKind": {
+                          "type": ["string", "null"],
+                          "enum": [
+                            "booking",
+                            "proposal_version",
+                            "program",
+                            "product",
+                            "inventory_item",
+                            "supplier_channel_relationship",
+                            "provider_source_ref",
+                            null
                           ]
                         },
-                        "products": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "title": {
-                                "type": "string"
-                              },
-                              "quantity": {
-                                "type": "integer",
-                                "exclusiveMinimum": 0
-                              },
-                              "amountCents": {
-                                "type": ["integer", "null"]
-                              },
-                              "currency": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["title", "quantity", "amountCents", "currency"]
-                          }
+                        "targetId": {
+                          "type": ["string", "null"]
                         },
-                        "template": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "name": {
-                              "type": "string"
-                            },
-                            "versionId": {
-                              "type": "string"
-                            },
-                            "version": {
-                              "type": "integer",
-                              "exclusiveMinimum": 0
-                            },
-                            "language": {
-                              "type": "string"
-                            }
-                          },
-                          "required": ["id", "name", "versionId", "version", "language"]
+                        "targetProvider": {
+                          "type": ["string", "null"]
                         },
-                        "commercialTerms": {
-                          "type": "object",
-                          "additionalProperties": {}
+                        "targetSourceRef": {
+                          "type": ["string", "null"]
                         },
-                        "delivery": {
-                          "type": "object",
-                          "properties": {
-                            "recipient": {
-                              "type": ["string", "null"]
-                            },
-                            "channel": {
-                              "type": ["string", "null"],
-                              "enum": ["email", "sms", "whatsapp", null]
-                            },
-                            "sentRevision": {
-                              "type": ["integer", "null"],
-                              "exclusiveMinimum": 0
-                            },
-                            "sentAt": {
-                              "type": ["string", "null"]
-                            },
-                            "viewedAt": {
-                              "type": ["string", "null"]
-                            },
-                            "declinedAt": {
-                              "type": ["string", "null"]
-                            },
-                            "notificationsSuppressed": {
-                              "type": "boolean"
-                            }
-                          },
-                          "required": [
-                            "recipient",
-                            "channel",
-                            "sentRevision",
-                            "sentAt",
-                            "viewedAt",
-                            "declinedAt",
-                            "notificationsSuppressed"
+                        "legacyTransactionOfferId": {
+                          "type": ["string", "null"]
+                        },
+                        "legacyTransactionOrderId": {
+                          "type": ["string", "null"]
+                        },
+                        "termType": {
+                          "type": "string",
+                          "enum": [
+                            "terms_and_conditions",
+                            "cancellation",
+                            "guarantee",
+                            "payment",
+                            "pricing",
+                            "commission",
+                            "insurer_product_information",
+                            "insurer_terms",
+                            "demands_and_needs",
+                            "other"
                           ]
                         },
-                        "voidConsequences": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
+                        "title": {
+                          "type": "string"
+                        },
+                        "body": {
+                          "type": "string"
+                        },
+                        "language": {
+                          "type": ["string", "null"]
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "sortOrder": {
+                          "type": "integer"
+                        },
+                        "acceptanceStatus": {
+                          "type": "string",
+                          "enum": ["not_required", "pending", "accepted", "declined"]
+                        },
+                        "acceptedAt": {
+                          "type": ["string", "null"]
+                        },
+                        "acceptedBy": {
+                          "type": ["string", "null"]
+                        },
+                        "sourceVersionId": {
+                          "type": ["string", "null"]
+                        },
+                        "archivedStorageKey": {
+                          "type": ["string", "null"]
+                        },
+                        "archivedChecksum": {
+                          "type": ["string", "null"]
+                        },
+                        "metadata": {},
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "string"
                         }
                       },
                       "required": [
-                        "contract",
-                        "contentFingerprint",
-                        "effectiveStatus",
-                        "revision",
-                        "previousRevisionId",
-                        "booking",
-                        "products",
-                        "template",
-                        "commercialTerms",
-                        "delivery",
-                        "voidConsequences"
+                        "id",
+                        "contractId",
+                        "policyVersionId",
+                        "targetKind",
+                        "targetId",
+                        "targetProvider",
+                        "targetSourceRef",
+                        "legacyTransactionOfferId",
+                        "legacyTransactionOrderId",
+                        "termType",
+                        "title",
+                        "body",
+                        "language",
+                        "required",
+                        "sortOrder",
+                        "acceptanceStatus",
+                        "acceptedAt",
+                        "acceptedBy",
+                        "sourceVersionId",
+                        "archivedStorageKey",
+                        "archivedChecksum",
+                        "createdAt",
+                        "updatedAt"
                       ]
                     }
                   },
@@ -11599,8 +11967,24 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body, or the term carries no archived disclosure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Contract not found",
+            "description": "Legal term not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -11616,8 +12000,8 @@
             }
           }
         },
-        "operationId": "getAdminLegalContractsByIdBookingReview",
-        "summary": "GET /v1/admin/legal/contracts/{id}/booking-review",
+        "operationId": "postAdminLegalTermsByIdAcceptance",
+        "summary": "POST /v1/admin/legal/terms/{id}/acceptance",
         "tags": ["legal"],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"

--- a/packages/legal/scripts/generate-openapi.ts
+++ b/packages/legal/scripts/generate-openapi.ts
@@ -1,6 +1,6 @@
 /**
- * Regenerates the contracts slice of this package's published admin OpenAPI
- * document from the live route module.
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route modules.
  *
  * `openapi/admin/legal.json` says "Do not edit by hand", but nothing in the
  * repository regenerated it — so adding a route left the published contract
@@ -8,9 +8,12 @@
  * drives the real routes through the same composition the operator app applies
  * (`stampModuleMetadata`), so the artifact is generated rather than transcribed.
  *
- * Only the `/v1/admin/legal/contracts` paths are owned here; the policies and
- * terms paths in the same document come from their own route modules and are
- * left untouched.
+ * It used to own the `/contracts` paths only, and the other 15 — policies and
+ * terms — were carried through from the committed artifact untouched. The file
+ * was registered for drift, so `verify:openapi-drift` reported the whole
+ * document as matching its routes while 15 of its 39 paths were compared to
+ * nothing. All three surfaces are driven here now, and
+ * `verify:openapi-path-ownership` holds it that way.
  *
  * Registered in `scripts/checks/openapi/generated-specs.json`, so
  * `verify:openapi-drift` fails when the artifact and the routes disagree.
@@ -21,38 +24,51 @@ import { resolve } from "node:path"
 import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
 
 import { createContractsAdminRoutes } from "../src/contracts/routes.js"
+import { policiesAdminRoutes } from "../src/policies/routes.js"
+import { legalTermsAdminRoutes } from "../src/terms/routes.js"
 
-const PREFIX = "/v1/admin/legal/contracts"
 const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/legal.json")
 const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
 
-const live = createContractsAdminRoutes().getOpenAPI31Document({
-  openapi: artifact.openapi,
-  info: artifact.info,
-})
+const surfaces = [
+  { prefix: "/v1/admin/legal/contracts", routes: createContractsAdminRoutes() },
+  { prefix: "/v1/admin/legal/policies", routes: policiesAdminRoutes },
+  { prefix: "/v1/admin/legal/terms", routes: legalTermsAdminRoutes },
+]
 
-// The route module mounts at `/`, so its own document is prefix-relative. The
-// published document is absolute, and `stampModuleMetadata` derives operation
-// ids, summaries and the owning module from the absolute path — so re-prefix
-// before stamping, not after.
-const prefixed = {
-  ...live,
-  paths: Object.fromEntries(
-    Object.entries(live.paths ?? {}).map(([path, item]) => [
-      path === "/" ? PREFIX : `${PREFIX}${path}`,
-      item,
-    ]),
-  ),
-}
-const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, "legal"]]))
-
-const generated = stamped.paths ?? {}
 const paths: Record<string, unknown> = {}
-for (const [path, item] of Object.entries(artifact.paths)) {
-  paths[path] = path in generated ? generated[path] : item
-}
-for (const [path, item] of Object.entries(generated)) {
-  if (!(path in paths)) paths[path] = item
+
+for (const surface of surfaces) {
+  const live = surface.routes.getOpenAPI31Document({
+    openapi: artifact.openapi,
+    info: artifact.info,
+  })
+
+  // Each route module mounts at `/`, so its own document is prefix-relative. The
+  // published document is absolute, and `stampModuleMetadata` derives operation
+  // ids, summaries and the owning module from the absolute path — so re-prefix
+  // before stamping, not after.
+  const prefixed = {
+    ...live,
+    paths: Object.fromEntries(
+      Object.entries(live.paths ?? {}).map(([path, item]) => [
+        path === "/" ? surface.prefix : `${surface.prefix}${path}`,
+        item,
+      ]),
+    ),
+  }
+  const stamped = stampModuleMetadata(prefixed, new Map([[surface.prefix, "legal"]]))
+
+  for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+    if (path in paths) {
+      throw new Error(`legal generate:openapi: ${path} is produced by two surfaces`)
+    }
+    paths[path] = item
+  }
 }
 
+// Built from the live surfaces alone, never merged into what the artifact already
+// held. Merging only ever adds, so a path a surface stopped serving survived
+// forever with nothing regenerating or comparing it — which is the defect this
+// generator was widened to close, and it must not leave a residue of its own.
 writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/scripts/agent-write-coverage-baseline.json
+++ b/scripts/agent-write-coverage-baseline.json
@@ -13,7 +13,7 @@
   "@voyant-travel/finance": 45,
   "@voyant-travel/flights": 3,
   "@voyant-travel/inventory": 42,
-  "@voyant-travel/legal": 16,
+  "@voyant-travel/legal": 17,
   "@voyant-travel/mcp": 1,
   "@voyant-travel/media": 4,
   "@voyant-travel/mice": 14,

--- a/scripts/checks/openapi/path-ownership-baseline.json
+++ b/scripts/checks/openapi/path-ownership-baseline.json
@@ -11,7 +11,6 @@
     "document so each half is owned by the route module that produces it."
   ],
   "unownedPaths": {
-    "packages/legal/openapi/admin/legal.json": 15,
     "packages/public-api/openapi/public-api/public-api.json": 12
   }
 }


### PR DESCRIPTION
Same shape as #4819, in the next document.

The generator drove `/v1/admin/legal/contracts` only. `policies` (13 paths) and `terms` (2) sat in the same **registered** document, carried through from the committed artifact untouched — so `verify:openapi-drift` reported all 39 paths as matching their routes while 15 were compared to nothing. Both surfaces had route modules the whole time; the generator's own docblock said as much.

## What the merge was hiding

| drift | scale |
|---|---|
| `/v1/admin/legal/terms/{id}/acceptance` **missing from the document entirely** | 1 route |
| `archivedChecksum`, `archivedStorageKey`, `sourceVersionId` absent from operations that return them | 3 fields × 6 operations |
| `termType` enum and `required` lists disagreeing with the routes | 10 |

## The pattern, now three for three

`finance` (#4819), `legal`, and the public shopping document (#4798) each had a generator, each was registered for drift, and each concealed real drift for the same reason: the generator owned part of the file and the check registered the whole file.

## Changes

**All three surfaces are driven**, and `paths` is built from the live surfaces rather than merged into the artifact — the same correction #4819 made, for the same reason: merging only ever adds, so a path a surface stopped serving survives forever with nothing comparing it. A path produced by two surfaces now **throws** rather than letting one quietly win.

## Ratchets

- **path ownership** `27 → 12`; repo-wide **519/531** paths produced by their generator
- **agent write coverage** `legal 16 → 17`

That second one again reflects the denominator, not the coverage: `legal/term/acceptance` has always existed and has always lacked a Tool. It was invisible to the counter because the document omitted it.

## Verification

- `pnpm verify:architecture` — full chain, exit 0, zero failure markers
- `verify:openapi-path-ownership` 519/531; `verify:openapi-drift` 79 documents; `check-openapi-dialect` 51 in 3
- legal 219 tests pass; root `biome check .` clean at error level

Part of #4256 P0. After this, `public-api/public-api.json` (12 paths) is the last unowned document.