### PR TITLE
Spell nullability the way OpenAPI 3.1 spells it

### DIFF
--- a/packages/identity/openapi/public-api/identity-verification.json
+++ b/packages/identity/openapi/public-api/identity-verification.json
@@ -156,10 +156,9 @@
                     "additionalProperties": {}
                   },
                   "subjectRef": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "minLength": 1,
                     "maxLength": 255,
-                    "nullable": true,
                     "description": "What this challenge authorizes beyond its purpose - the booking draft id for a self-service create. Bound at start so a verified challenge cannot be redirected at another draft."
                   }
                 },
@@ -329,10 +328,9 @@
                     "additionalProperties": {}
                   },
                   "subjectRef": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "minLength": 1,
                     "maxLength": 255,
-                    "nullable": true,
                     "description": "What this challenge authorizes beyond its purpose - the booking draft id for a self-service create. Bound at start so a verified challenge cannot be redirected at another draft."
                   }
                 },

--- a/packages/notifications/openapi/admin/notifications.json
+++ b/packages/notifications/openapi/admin/notifications.json
@@ -5174,16 +5174,13 @@
                     "maxLength": 255
                   },
                   "templateId": {
-                    "type": "string",
-                    "nullable": true
+                    "type": ["string", "null"]
                   },
                   "templateSlug": {
-                    "type": "string",
-                    "nullable": true
+                    "type": ["string", "null"]
                   },
                   "scheduledFor": {
-                    "type": "string",
-                    "nullable": true
+                    "type": ["string", "null"]
                   }
                 },
                 "required": ["idempotencyKey"],
@@ -5403,16 +5400,13 @@
                     "maxLength": 255
                   },
                   "templateId": {
-                    "type": "string",
-                    "nullable": true
+                    "type": ["string", "null"]
                   },
                   "templateSlug": {
-                    "type": "string",
-                    "nullable": true
+                    "type": ["string", "null"]
                   },
                   "scheduledFor": {
-                    "type": "string",
-                    "nullable": true
+                    "type": ["string", "null"]
                   }
                 },
                 "required": ["idempotencyKey"],
@@ -6082,8 +6076,7 @@
                         "enum": [false]
                       },
                       "documentTypes": {
-                        "type": "array",
-                        "nullable": true,
+                        "type": ["array", "null"],
                         "items": {
                           "type": "string",
                           "enum": ["contract", "invoice", "proforma", "brochure"]
@@ -6104,20 +6097,16 @@
                             "maxLength": 255
                           },
                           "templateId": {
-                            "type": "string",
-                            "nullable": true
+                            "type": ["string", "null"]
                           },
                           "templateSlug": {
-                            "type": "string",
-                            "nullable": true
+                            "type": ["string", "null"]
                           },
                           "scheduledFor": {
-                            "type": "string",
-                            "nullable": true
+                            "type": ["string", "null"]
                           },
                           "documentTypes": {
-                            "type": "array",
-                            "nullable": true,
+                            "type": ["array", "null"],
                             "items": {
                               "type": "string",
                               "enum": ["contract", "invoice", "proforma", "brochure"]
@@ -6329,20 +6318,16 @@
                     "maxLength": 255
                   },
                   "templateId": {
-                    "type": "string",
-                    "nullable": true
+                    "type": ["string", "null"]
                   },
                   "templateSlug": {
-                    "type": "string",
-                    "nullable": true
+                    "type": ["string", "null"]
                   },
                   "scheduledFor": {
-                    "type": "string",
-                    "nullable": true
+                    "type": ["string", "null"]
                   },
                   "documentTypes": {
-                    "type": "array",
-                    "nullable": true,
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string",
                       "enum": ["contract", "invoice", "proforma", "brochure"]

--- a/packages/setup/openapi/admin/setup.json
+++ b/packages/setup/openapi/admin/setup.json
@@ -25,21 +25,18 @@
                       "type": "object",
                       "properties": {
                         "state": {
-                          "type": "object",
-                          "nullable": true,
+                          "type": ["object", "null"],
                           "properties": {
                             "startedAt": {
                               "type": "string",
                               "format": "date-time"
                             },
                             "firstRunOpenedAt": {
-                              "type": "string",
-                              "nullable": true,
+                              "type": ["string", "null"],
                               "format": "date-time"
                             },
                             "dismissedAt": {
-                              "type": "string",
-                              "nullable": true,
+                              "type": ["string", "null"],
                               "format": "date-time"
                             },
                             "steps": {
@@ -57,13 +54,11 @@
                                     "format": "date-time"
                                   },
                                   "completedAt": {
-                                    "type": "string",
-                                    "nullable": true,
+                                    "type": ["string", "null"],
                                     "format": "date-time"
                                   },
                                   "skippedAt": {
-                                    "type": "string",
-                                    "nullable": true,
+                                    "type": ["string", "null"],
                                     "format": "date-time"
                                   }
                                 },
@@ -72,9 +67,7 @@
                             },
                             "prefill": {
                               "type": "object",
-                              "additionalProperties": {
-                                "nullable": true
-                              }
+                              "additionalProperties": {}
                             }
                           },
                           "required": [
@@ -104,9 +97,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }
@@ -119,9 +110,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }
@@ -175,13 +164,11 @@
                           "format": "date-time"
                         },
                         "firstRunOpenedAt": {
-                          "type": "string",
-                          "nullable": true,
+                          "type": ["string", "null"],
                           "format": "date-time"
                         },
                         "dismissedAt": {
-                          "type": "string",
-                          "nullable": true,
+                          "type": ["string", "null"],
                           "format": "date-time"
                         },
                         "steps": {
@@ -199,13 +186,11 @@
                                 "format": "date-time"
                               },
                               "completedAt": {
-                                "type": "string",
-                                "nullable": true,
+                                "type": ["string", "null"],
                                 "format": "date-time"
                               },
                               "skippedAt": {
-                                "type": "string",
-                                "nullable": true,
+                                "type": ["string", "null"],
                                 "format": "date-time"
                               }
                             },
@@ -214,9 +199,7 @@
                         },
                         "prefill": {
                           "type": "object",
-                          "additionalProperties": {
-                            "nullable": true
-                          }
+                          "additionalProperties": {}
                         },
                         "shouldRedirect": {
                           "type": "boolean"
@@ -244,9 +227,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }
@@ -259,9 +240,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }
@@ -274,9 +253,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }
@@ -322,13 +299,11 @@
                           "format": "date-time"
                         },
                         "completedAt": {
-                          "type": "string",
-                          "nullable": true,
+                          "type": ["string", "null"],
                           "format": "date-time"
                         },
                         "skippedAt": {
-                          "type": "string",
-                          "nullable": true,
+                          "type": ["string", "null"],
                           "format": "date-time"
                         }
                       },
@@ -347,9 +322,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }
@@ -362,9 +335,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }
@@ -377,9 +348,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }
@@ -425,13 +394,11 @@
                           "format": "date-time"
                         },
                         "completedAt": {
-                          "type": "string",
-                          "nullable": true,
+                          "type": ["string", "null"],
                           "format": "date-time"
                         },
                         "skippedAt": {
-                          "type": "string",
-                          "nullable": true,
+                          "type": ["string", "null"],
                           "format": "date-time"
                         }
                       },
@@ -450,9 +417,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }
@@ -465,9 +430,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }
@@ -480,9 +443,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }
@@ -511,13 +472,11 @@
                           "format": "date-time"
                         },
                         "firstRunOpenedAt": {
-                          "type": "string",
-                          "nullable": true,
+                          "type": ["string", "null"],
                           "format": "date-time"
                         },
                         "dismissedAt": {
-                          "type": "string",
-                          "nullable": true,
+                          "type": ["string", "null"],
                           "format": "date-time"
                         },
                         "steps": {
@@ -535,13 +494,11 @@
                                 "format": "date-time"
                               },
                               "completedAt": {
-                                "type": "string",
-                                "nullable": true,
+                                "type": ["string", "null"],
                                 "format": "date-time"
                               },
                               "skippedAt": {
-                                "type": "string",
-                                "nullable": true,
+                                "type": ["string", "null"],
                                 "format": "date-time"
                               }
                             },
@@ -550,9 +507,7 @@
                         },
                         "prefill": {
                           "type": "object",
-                          "additionalProperties": {
-                            "nullable": true
-                          }
+                          "additionalProperties": {}
                         }
                       },
                       "required": [
@@ -576,9 +531,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }
@@ -591,9 +544,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }
@@ -606,9 +557,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "nullable": true
-                    }
+                    "error": {}
                   }
                 }
               }

--- a/scripts/check-openapi-dialect.mjs
+++ b/scripts/check-openapi-dialect.mjs
@@ -74,11 +74,17 @@ for (const file of documents) {
     )
   }
 
-  // `nullable` is a 3.0 keyword that 3.1 ignores, so `{type: "string", nullable:
-  // true}` reads as a plain non-nullable string — a client generated from it is
-  // typed to expect a value the API may not send. 87 of them predate this check,
-  // so the count is a ratchet: it may shrink, never grow, and a document not in
-  // the baseline may never gain one.
+  // `nullable` is a 3.0 keyword; 3.1 spells it `type: ["string", "null"]`.
+  //
+  // This is a conformance rule, not a correctness one. `openapi-typescript`
+  // honours both spellings identically — verified with a controlled fixture,
+  // after an earlier version of this comment claimed the opposite and had to be
+  // corrected. The point is that a document declaring 3.1 should be readable by
+  // anything implementing 3.1, not only by tools that still accept the older
+  // keyword.
+  //
+  // The count is a ratchet: it may shrink, never grow, and a document not in the
+  // baseline may never gain one.
   const nullables = (JSON.stringify(parsed).match(/"nullable"/g) ?? []).length
   const allowed = baseline[file] ?? 0
   if (nullables > allowed) {

--- a/scripts/checks/openapi/nullable-baseline.json
+++ b/scripts/checks/openapi/nullable-baseline.json
@@ -1,22 +1,18 @@
 {
   "$comment": [
-    "Documents still carrying the OpenAPI 3.0 `nullable` keyword while declaring 3.1.",
+    "Documents carrying the OpenAPI 3.0 `nullable` keyword while declaring 3.1.",
     "",
-    "3.1 has no `nullable`. It is silently ignored, so `{type: 'string', nullable: true}`",
-    "reads as a plain non-nullable string to every 3.1 tool — including the client",
-    "generators. A consumer is then typed to expect a value the API may not send.",
+    "3.1 removed `nullable`; the spelling is a type union, `type: ['string', 'null']`.",
+    "Where a schema has no `type` at all, `nullable` was already a no-op and the",
+    "keyword is simply dropped.",
     "",
-    "The correct 3.1 spelling is a type union: `type: ['string', 'null']`. Where the",
-    "schema has no `type` at all, `nullable` was already a no-op and the keyword is",
-    "simply dropped.",
+    "What this is NOT: a claim that consumers get wrong types. `openapi-typescript`",
+    "honours both spellings identically — verified with a controlled fixture, after",
+    "an earlier version of this file asserted the opposite. The reason to convert is",
+    "conformance: a document that declares 3.1 should be readable by anything that",
+    "implements 3.1, not only by tools that still accept the 3.0 keyword.",
     "",
-    "THESE COUNTS MAY ONLY SHRINK. A document not listed here may never gain one.",
-    "Two of the five are generated (finance, webhook-delivery), so fixing those means",
-    "fixing what the generator emits, not editing the artifact."
+    "THESE COUNTS MAY ONLY SHRINK, and a document not listed here may never gain one."
   ],
-  "documents": {
-    "packages/identity/openapi/public-api/identity-verification.json": 2,
-    "packages/notifications/openapi/admin/notifications.json": 15,
-    "packages/setup/openapi/admin/setup.json": 34
-  }
+  "documents": {}
 }


### PR DESCRIPTION
The last 51 `nullable` keywords, in the three hand-written documents: `setup` (34), `notifications` (15), `identity` (2). All 82 documents are now free of it and the baseline is empty.

A typed schema becomes a union, `type: ["string", "null"]`. An untyped one — where `nullable` was already a no-op — loses the keyword. Provably semantics-preserving: normalising each committed document's `nullable` into the 3.1 union reproduces the new file exactly.

## This corrects a claim I got wrong

The rationale recorded with the ratchet said 3.1 tools ignore `nullable`, so generated clients would be typed to expect a value the API may not send. A controlled fixture shows that is false — `openapi-typescript` produces `string | null` from both spellings, and converting these documents changed the generated client types by nothing.

The webhook-delivery client did move 21 → 32 `| null` in #4814, but from switching `getOpenAPIDocument` → `getOpenAPI31Document`, which regenerated from live routes and fixed genuine under-documentation. The measurement was right; the explanation was not. The checker docblock and baseline comment now record conformance as the reason instead.

## Verification

- `pnpm verify:architecture` exit 0, zero failure markers
- `check-openapi-dialect`: 82 documents, 0 `nullable`, 0 documents
- semantic equivalence proven per document; all three parse; client types unchanged

Part of #4256 P0.