### PR TITLE
Generate the relationships admin document from its routes

### DIFF
--- a/packages/admin-api-client/src/generated/relationships.ts
+++ b/packages/admin-api-client/src/generated/relationships.ts
@@ -858,7 +858,9 @@ export interface operations {
               sourceRef: string | null
               tags: string[]
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               notes: string | null
               createdAt: string
@@ -904,7 +906,9 @@ export interface operations {
           /** @default [] */
           tags?: string[]
           customFields?: {
-            [key: string]: unknown
+            [key: string]: {
+              [key: string]: unknown
+            }
           }
           notes?: string | null
         }
@@ -937,7 +941,9 @@ export interface operations {
               sourceRef: string | null
               tags: string[]
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               notes: string | null
               createdAt: string
@@ -997,7 +1003,9 @@ export interface operations {
               sourceRef: string | null
               tags: string[]
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               notes: string | null
               createdAt: string
@@ -1096,7 +1104,9 @@ export interface operations {
           sourceRef?: string | null
           tags?: string[]
           customFields?: {
-            [key: string]: unknown
+            [key: string]: {
+              [key: string]: unknown
+            }
           }
           notes?: string | null
         }
@@ -1129,7 +1139,9 @@ export interface operations {
               sourceRef: string | null
               tags: string[]
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               notes: string | null
               createdAt: string
@@ -1206,7 +1218,9 @@ export interface operations {
               sourceRef: string | null
               tags: string[]
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               notes: string | null
               createdAt: string
@@ -1740,7 +1754,9 @@ export interface operations {
               sourceRef: string | null
               tags: string[]
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               dateOfBirth: string | null
               notes: string | null
@@ -1795,7 +1811,9 @@ export interface operations {
           /** @default [] */
           tags?: string[]
           customFields?: {
-            [key: string]: unknown
+            [key: string]: {
+              [key: string]: unknown
+            }
           }
           /** Format: date */
           dateOfBirth?: string | null
@@ -1846,7 +1864,9 @@ export interface operations {
               sourceRef: string | null
               tags: string[]
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               dateOfBirth: string | null
               notes: string | null
@@ -1914,7 +1934,9 @@ export interface operations {
               sourceRef: string | null
               tags: string[]
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               dateOfBirth: string | null
               notes: string | null
@@ -2011,7 +2033,9 @@ export interface operations {
           sourceRef?: string | null
           tags?: string[]
           customFields?: {
-            [key: string]: unknown
+            [key: string]: {
+              [key: string]: unknown
+            }
           }
           /** Format: date */
           dateOfBirth?: string | null
@@ -2062,7 +2086,9 @@ export interface operations {
               sourceRef: string | null
               tags: string[]
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               dateOfBirth: string | null
               notes: string | null
@@ -2147,7 +2173,9 @@ export interface operations {
               sourceRef: string | null
               tags: string[]
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               dateOfBirth: string | null
               notes: string | null
@@ -2665,12 +2693,17 @@ export interface operations {
             data: {
               id: string
               personId: string
+              /** @enum {string} */
+              source: "manual" | "payment"
               brand: string
               last4: string | null
               holderName: string | null
               expMonth: number | null
               expYear: number | null
-              processorToken: string
+              providerId: string | null
+              authorizedReuses: string[]
+              /** @enum {string} */
+              status: "usable" | "requires_new_agreement" | "expired" | "revoked"
               isDefault: boolean
               createdAt: string
             }[]
@@ -2726,12 +2759,17 @@ export interface operations {
             data: {
               id: string
               personId: string
+              /** @enum {string} */
+              source: "manual" | "payment"
               brand: string
               last4: string | null
               holderName: string | null
               expMonth: number | null
               expYear: number | null
-              processorToken: string
+              providerId: string | null
+              authorizedReuses: string[]
+              /** @enum {string} */
+              status: "usable" | "requires_new_agreement" | "expired" | "revoked"
               isDefault: boolean
               createdAt: string
             }
@@ -2833,12 +2871,17 @@ export interface operations {
             data: {
               id: string
               personId: string
+              /** @enum {string} */
+              source: "manual" | "payment"
               brand: string
               last4: string | null
               holderName: string | null
               expMonth: number | null
               expYear: number | null
-              processorToken: string
+              providerId: string | null
+              authorizedReuses: string[]
+              /** @enum {string} */
+              status: "usable" | "requires_new_agreement" | "expired" | "revoked"
               isDefault: boolean
               createdAt: string
             }
@@ -2906,7 +2949,10 @@ export interface operations {
               content: string | null
               sentAt: string | null
               createdAt: string
-              /** @enum {string} */
+              /**
+               * @default logged
+               * @enum {string}
+               */
               source: "logged" | "notification"
             }[]
           }
@@ -2958,7 +3004,10 @@ export interface operations {
               content: string | null
               sentAt: string | null
               createdAt: string
-              /** @enum {string} */
+              /**
+               * @default logged
+               * @enum {string}
+               */
               source: "logged" | "notification"
             }
           }
@@ -5103,7 +5152,7 @@ export interface operations {
         ownerId?: string
         status?: "planned" | "done" | "cancelled"
         type?: "call" | "email" | "meeting" | "task" | "follow_up" | "note"
-        entityType?: "organization" | "person" | "proposal" | "activity"
+        entityType?: "organization" | "person" | "proposal" | "activity" | "booking"
         entityId?: string
         search?: string
       }
@@ -5133,7 +5182,9 @@ export interface operations {
               location: string | null
               description: string | null
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               createdAt: string
               updatedAt: string
@@ -5195,7 +5246,9 @@ export interface operations {
               location: string | null
               description: string | null
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               createdAt: string
               updatedAt: string
@@ -5247,7 +5300,9 @@ export interface operations {
               location: string | null
               description: string | null
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               createdAt: string
               updatedAt: string
@@ -5355,7 +5410,9 @@ export interface operations {
               location: string | null
               description: string | null
               customFields: {
-                [key: string]: unknown
+                [key: string]: {
+                  [key: string]: unknown
+                }
               }
               createdAt: string
               updatedAt: string
@@ -5409,7 +5466,7 @@ export interface operations {
               id: string
               activityId: string
               /** @enum {string} */
-              entityType: "organization" | "person" | "proposal" | "activity"
+              entityType: "organization" | "person" | "proposal" | "activity" | "booking"
               entityId: string
               /** @enum {string} */
               role: "primary" | "related"
@@ -5433,7 +5490,7 @@ export interface operations {
       content: {
         "application/json": {
           /** @enum {string} */
-          entityType: "organization" | "person" | "proposal" | "activity"
+          entityType: "organization" | "person" | "proposal" | "activity" | "booking"
           entityId: string
           /**
            * @default related
@@ -5455,7 +5512,7 @@ export interface operations {
               id: string
               activityId: string
               /** @enum {string} */
-              entityType: "organization" | "person" | "proposal" | "activity"
+              entityType: "organization" | "person" | "proposal" | "activity" | "booking"
               entityId: string
               /** @enum {string} */
               role: "primary" | "related"

--- a/packages/relationships/openapi/admin/relationships.json
+++ b/packages/relationships/openapi/admin/relationships.json
@@ -287,7 +287,10 @@
                           },
                           "customFields": {
                             "type": "object",
-                            "additionalProperties": {}
+                            "additionalProperties": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            }
                           },
                           "notes": {
                             "type": ["string", "null"]
@@ -428,7 +431,10 @@
                   },
                   "customFields": {
                     "type": "object",
-                    "additionalProperties": {}
+                    "additionalProperties": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
                   },
                   "notes": {
                     "type": ["string", "null"]
@@ -502,7 +508,10 @@
                         },
                         "customFields": {
                           "type": "object",
-                          "additionalProperties": {}
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
                         },
                         "notes": {
                           "type": ["string", "null"]
@@ -648,7 +657,10 @@
                         },
                         "customFields": {
                           "type": "object",
-                          "additionalProperties": {}
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
                         },
                         "notes": {
                           "type": ["string", "null"]
@@ -803,7 +815,10 @@
                   },
                   "customFields": {
                     "type": "object",
-                    "additionalProperties": {}
+                    "additionalProperties": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
                   },
                   "notes": {
                     "type": ["string", "null"]
@@ -876,7 +891,10 @@
                         },
                         "customFields": {
                           "type": "object",
-                          "additionalProperties": {}
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
                         },
                         "notes": {
                           "type": ["string", "null"]
@@ -1126,7 +1144,10 @@
                         },
                         "customFields": {
                           "type": "object",
-                          "additionalProperties": {}
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
                         },
                         "notes": {
                           "type": ["string", "null"]
@@ -2308,7 +2329,10 @@
                           },
                           "customFields": {
                             "type": "object",
-                            "additionalProperties": {}
+                            "additionalProperties": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            }
                           },
                           "dateOfBirth": {
                             "type": ["string", "null"]
@@ -2454,7 +2478,10 @@
                   },
                   "customFields": {
                     "type": "object",
-                    "additionalProperties": {}
+                    "additionalProperties": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
                   },
                   "dateOfBirth": {
                     "type": ["string", "null"],
@@ -2594,7 +2621,10 @@
                         },
                         "customFields": {
                           "type": "object",
-                          "additionalProperties": {}
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
                         },
                         "dateOfBirth": {
                           "type": ["string", "null"]
@@ -2760,7 +2790,10 @@
                         },
                         "customFields": {
                           "type": "object",
-                          "additionalProperties": {}
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
                         },
                         "dateOfBirth": {
                           "type": ["string", "null"]
@@ -2920,7 +2953,10 @@
                   },
                   "customFields": {
                     "type": "object",
-                    "additionalProperties": {}
+                    "additionalProperties": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
                   },
                   "dateOfBirth": {
                     "type": ["string", "null"],
@@ -3059,7 +3095,10 @@
                         },
                         "customFields": {
                           "type": "object",
-                          "additionalProperties": {}
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
                         },
                         "dateOfBirth": {
                           "type": ["string", "null"]
@@ -3313,7 +3352,10 @@
                         },
                         "customFields": {
                           "type": "object",
-                          "additionalProperties": {}
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
                         },
                         "dateOfBirth": {
                           "type": ["string", "null"]
@@ -4394,6 +4436,10 @@
                           "personId": {
                             "type": "string"
                           },
+                          "source": {
+                            "type": "string",
+                            "enum": ["manual", "payment"]
+                          },
                           "brand": {
                             "type": "string"
                           },
@@ -4409,8 +4455,18 @@
                           "expYear": {
                             "type": ["integer", "null"]
                           },
-                          "processorToken": {
-                            "type": "string"
+                          "providerId": {
+                            "type": ["string", "null"]
+                          },
+                          "authorizedReuses": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": ["usable", "requires_new_agreement", "expired", "revoked"]
                           },
                           "isDefault": {
                             "type": "boolean"
@@ -4422,12 +4478,15 @@
                         "required": [
                           "id",
                           "personId",
+                          "source",
                           "brand",
                           "last4",
                           "holderName",
                           "expMonth",
                           "expYear",
-                          "processorToken",
+                          "providerId",
+                          "authorizedReuses",
+                          "status",
                           "isDefault",
                           "createdAt"
                         ]
@@ -4556,6 +4615,10 @@
                         "personId": {
                           "type": "string"
                         },
+                        "source": {
+                          "type": "string",
+                          "enum": ["manual", "payment"]
+                        },
                         "brand": {
                           "type": "string"
                         },
@@ -4571,8 +4634,18 @@
                         "expYear": {
                           "type": ["integer", "null"]
                         },
-                        "processorToken": {
-                          "type": "string"
+                        "providerId": {
+                          "type": ["string", "null"]
+                        },
+                        "authorizedReuses": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": ["usable", "requires_new_agreement", "expired", "revoked"]
                         },
                         "isDefault": {
                           "type": "boolean"
@@ -4584,12 +4657,15 @@
                       "required": [
                         "id",
                         "personId",
+                        "source",
                         "brand",
                         "last4",
                         "holderName",
                         "expMonth",
                         "expYear",
-                        "processorToken",
+                        "providerId",
+                        "authorizedReuses",
+                        "status",
                         "isDefault",
                         "createdAt"
                       ]
@@ -4715,6 +4791,10 @@
                         "personId": {
                           "type": "string"
                         },
+                        "source": {
+                          "type": "string",
+                          "enum": ["manual", "payment"]
+                        },
                         "brand": {
                           "type": "string"
                         },
@@ -4730,8 +4810,18 @@
                         "expYear": {
                           "type": ["integer", "null"]
                         },
-                        "processorToken": {
-                          "type": "string"
+                        "providerId": {
+                          "type": ["string", "null"]
+                        },
+                        "authorizedReuses": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": ["usable", "requires_new_agreement", "expired", "revoked"]
                         },
                         "isDefault": {
                           "type": "boolean"
@@ -4743,12 +4833,15 @@
                       "required": [
                         "id",
                         "personId",
+                        "source",
                         "brand",
                         "last4",
                         "holderName",
                         "expMonth",
                         "expYear",
-                        "processorToken",
+                        "providerId",
+                        "authorizedReuses",
+                        "status",
                         "isDefault",
                         "createdAt"
                       ]
@@ -4968,7 +5061,8 @@
                           },
                           "source": {
                             "type": "string",
-                            "enum": ["logged", "notification"]
+                            "enum": ["logged", "notification"],
+                            "default": "logged"
                           }
                         },
                         "required": [
@@ -4980,8 +5074,7 @@
                           "subject",
                           "content",
                           "sentAt",
-                          "createdAt",
-                          "source"
+                          "createdAt"
                         ]
                       }
                     }
@@ -5089,7 +5182,8 @@
                         },
                         "source": {
                           "type": "string",
-                          "enum": ["logged", "notification"]
+                          "enum": ["logged", "notification"],
+                          "default": "logged"
                         }
                       },
                       "required": [
@@ -5101,8 +5195,7 @@
                         "subject",
                         "content",
                         "sentAt",
-                        "createdAt",
-                        "source"
+                        "createdAt"
                       ]
                     }
                   },
@@ -9482,7 +9575,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["organization", "person", "proposal", "activity"]
+              "enum": ["organization", "person", "proposal", "activity", "booking"]
             },
             "required": false,
             "name": "entityType",
@@ -9549,7 +9642,10 @@
                           },
                           "customFields": {
                             "type": "object",
-                            "additionalProperties": {}
+                            "additionalProperties": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            }
                           },
                           "createdAt": {
                             "type": "string"
@@ -9685,7 +9781,10 @@
                         },
                         "customFields": {
                           "type": "object",
-                          "additionalProperties": {}
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
                         },
                         "createdAt": {
                           "type": "string"
@@ -9796,7 +9895,10 @@
                         },
                         "customFields": {
                           "type": "object",
-                          "additionalProperties": {}
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
                         },
                         "createdAt": {
                           "type": "string"
@@ -9947,7 +10049,10 @@
                         },
                         "customFields": {
                           "type": "object",
-                          "additionalProperties": {}
+                          "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
                         },
                         "createdAt": {
                           "type": "string"
@@ -10108,7 +10213,7 @@
                           },
                           "entityType": {
                             "type": "string",
-                            "enum": ["organization", "person", "proposal", "activity"]
+                            "enum": ["organization", "person", "proposal", "activity", "booking"]
                           },
                           "entityId": {
                             "type": "string"
@@ -10167,7 +10272,7 @@
                 "properties": {
                   "entityType": {
                     "type": "string",
-                    "enum": ["organization", "person", "proposal", "activity"]
+                    "enum": ["organization", "person", "proposal", "activity", "booking"]
                   },
                   "entityId": {
                     "type": "string"
@@ -10202,7 +10307,7 @@
                         },
                         "entityType": {
                           "type": "string",
-                          "enum": ["organization", "person", "proposal", "activity"]
+                          "enum": ["organization", "person", "proposal", "activity", "booking"]
                         },
                         "entityId": {
                           "type": "string"

--- a/packages/relationships/package.json
+++ b/packages/relationships/package.json
@@ -19,13 +19,14 @@
     "./openapi/admin": "./openapi/admin/relationships.json"
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.typecheck.json",
-    "lint": "biome check src/",
-    "test": "vitest run",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=relationships_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && biome format --write openapi/admin/relationships.json",
+    "lint": "biome check src/",
     "prepack": "pnpm run build",
-    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=relationships_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations"
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",

--- a/packages/relationships/scripts/generate-openapi.ts
+++ b/packages/relationships/scripts/generate-openapi.ts
@@ -1,0 +1,76 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written and nothing regenerated it, so it could describe
+ * a surface the deployment no longer has — the defect found in finance, legal
+ * and the public shopping document, each of which had drifted while a checker
+ * reported them as matching their routes.
+ *
+ * `relationshipsRoutes` composes every sub-app (accounts, person documents,
+ * person relationships, customer signals, activities), so one surface produces
+ * the whole document.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { relationshipsRoutes } from "../src/routes/index.js"
+
+const PREFIX = "/v1/admin/relationships"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/relationships.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+const live = relationshipsRoutes.getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// The route module mounts at `/`, so its own document is prefix-relative. The
+// published document is absolute, and `stampModuleMetadata` derives operation
+// ids, summaries and the owning module from the absolute path — so re-prefix
+// before stamping, not after.
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [
+      path === "/" ? PREFIX : `${PREFIX}${path}`,
+      item,
+    ]),
+  ),
+}
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, "relationships"]]))
+
+// `stampModuleMetadata` derives the module, surface and operation ids. The graph
+// stamps — which bundle an operation belongs to — are this document's own
+// convention and are not derived from the routes, so they are applied here
+// rather than silently dropped. Composition adds them again for the document a
+// deployment serves; a per-package artifact that carries them should keep
+// carrying them.
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+for (const pathItem of Object.values(stamped.paths ?? {})) {
+  if (!pathItem || typeof pathItem !== "object") continue
+  for (const method of OPERATION_METHODS) {
+    const operation = (pathItem as Record<string, unknown>)[method]
+    if (!operation || typeof operation !== "object") continue
+    Object.assign(operation, {
+      "x-voyant-api-id": "@voyant-travel/relationships#api.admin",
+      "x-voyant-unit-id": "@voyant-travel/relationships",
+      "x-voyant-package-name": "@voyant-travel/relationships",
+    })
+  }
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(
+  artifactPath,
+  `${JSON.stringify({ ...artifact, paths: stamped.paths ?? {} }, null, 2)}\n`,
+)

--- a/scripts/checks/openapi/generated-specs.json
+++ b/scripts/checks/openapi/generated-specs.json
@@ -123,6 +123,10 @@
       "files": ["packages/public-api/openapi/public-api/public-api.json"]
     },
     {
+      "command": "pnpm --filter @voyant-travel/relationships generate:openapi",
+      "files": ["packages/relationships/openapi/admin/relationships.json"]
+    },
+    {
       "command": "pnpm --filter @voyant-travel/trips generate:openapi",
       "files": [
         "packages/trips/openapi/admin/trips.json",


### PR DESCRIPTION
First of the 66 documents that had no generator at all — and the largest single-document package among them.

43 paths, hand-written, with nothing regenerating them. `relationshipsRoutes` already composes every sub-app (accounts, person documents, person relationships, customer signals, activities), so one surface produces the whole document.

## Twelve of the 43 had drifted

| drift | scale |
|---|---|
| `/v1/admin/relationships/activities` accepts `booking` as a subject type; the document listed four values without it | a valid input the contract declares invalid |
| response schemas less specific than the routes (`additionalProperties`, `type`) | 18 |
| `required` lists disagreeing | 5 |
| fields absent (`authorizedReuses`, `processorToken`, `providerId`, `source`) | 12 |

The enum is the same shape as finance's missing `booking_session` in #4819 — that's four for four on documents brought under generation today.

## Stamp conventions differ per document

My first version dropped `x-voyant-api-id`, `x-voyant-unit-id` and `x-voyant-package-name` from **77 operations**, and reported all 43 paths as changed. `stampModuleMetadata` derives the module, surface and operation ids but not which graph bundle an operation belongs to.

That convention is **not uniform**: `legal` never carried those stamps (checked — my #4821 dropped nothing), `relationships` does. So the generator applies them explicitly, and the diff falls to the honest 12 paths. Worth checking per package rather than assuming, for the remaining 65.

Paths are written from the live surface alone rather than merged into the artifact — same correction as #4819 and #4821.

## Verification

- `pnpm verify:architecture` — full chain, exit 0, zero failure markers
- `verify:openapi-drift` 80 documents (was 79); `verify:deployment-graph-openapi-coverage` 97 bundles, 0 gaps
- `verify:openapi-path-ownership` 562/574 — the outstanding 12 are public-api's, fixed in #4822
- relationships 190 tests pass; root `biome check .` clean at error level

Part of #4256 P0. 65 documents and 553 paths remain without a generator.