### PR TITLE
Generate the apps and mice admin documents from their routes

### DIFF
--- a/packages/admin-api-client/src/generated/apps.ts
+++ b/packages/admin-api-client/src/generated/apps.ts
@@ -12,28 +12,10 @@ export interface paths {
       cookie?: never
     }
     /** List app registrations */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    get: operations["getAdminApps"]
     put?: never
     /** Create a custom app registration */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    post: operations["postAdminApps"]
     delete?: never
     options?: never
     head?: never
@@ -50,16 +32,7 @@ export interface paths {
     get?: never
     put?: never
     /** Approve app OAuth consent */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    post: operations["postAdminAppsOauthAuthorize"]
     delete?: never
     options?: never
     head?: never
@@ -76,16 +49,7 @@ export interface paths {
     get?: never
     put?: never
     /** Issue an app OAuth token */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    post: operations["postAdminAppsOauthToken"]
     delete?: never
     options?: never
     head?: never
@@ -102,16 +66,24 @@ export interface paths {
     get?: never
     put?: never
     /** Revoke installation credentials */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
+    post: operations["postAdminAppsOauthRevokeInstallation"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/v1/admin/apps/installations/{installationId}/session-token": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
     }
+    get?: never
+    put?: never
+    /** Issue an app extension session token */
+    post: operations["postAdminAppsInstallationsByInstallationIdSessionToken"]
     delete?: never
     options?: never
     head?: never
@@ -128,16 +100,7 @@ export interface paths {
     get?: never
     put?: never
     /** Exchange an app session token */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    post: operations["postAdminAppsOauthSessionTokenExchange"]
     delete?: never
     options?: never
     head?: never
@@ -154,16 +117,7 @@ export interface paths {
     get?: never
     put?: never
     /** Install an app release */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    post: operations["postAdminAppsInstall"]
     delete?: never
     options?: never
     head?: never
@@ -180,16 +134,24 @@ export interface paths {
     get?: never
     put?: never
     /** Resolve and admit an opaque Marketplace install intent */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
+    post: operations["postAdminAppsMarketplaceInstallIntentsResolve"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/v1/admin/apps/installations/{installationId}/setup-handoff": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
     }
+    get?: never
+    put?: never
+    /** Create a one-time Marketplace app setup handoff */
+    post: operations["postAdminAppsInstallationsByInstallationIdSetupHandoff"]
     delete?: never
     options?: never
     head?: never
@@ -204,16 +166,7 @@ export interface paths {
       cookie?: never
     }
     /** List app installations */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    get: operations["getAdminAppsInstallations"]
     put?: never
     post?: never
     delete?: never
@@ -230,16 +183,7 @@ export interface paths {
       cookie?: never
     }
     /** Get app installation detail */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    get: operations["getAdminAppsInstallationsByInstallationId"]
     put?: never
     post?: never
     delete?: never
@@ -256,16 +200,7 @@ export interface paths {
       cookie?: never
     }
     /** List app installation audit events */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    get: operations["getAdminAppsInstallationsByInstallationIdAudit"]
     put?: never
     post?: never
     delete?: never
@@ -284,16 +219,7 @@ export interface paths {
     get?: never
     put?: never
     /** Pause an app installation */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    post: operations["postAdminAppsInstallationsByInstallationIdPause"]
     delete?: never
     options?: never
     head?: never
@@ -310,16 +236,7 @@ export interface paths {
     get?: never
     put?: never
     /** Resume an app installation */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    post: operations["postAdminAppsInstallationsByInstallationIdResume"]
     delete?: never
     options?: never
     head?: never
@@ -336,16 +253,7 @@ export interface paths {
     get?: never
     put?: never
     /** Uninstall an app installation */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    post: operations["postAdminAppsInstallationsByInstallationIdUninstall"]
     delete?: never
     options?: never
     head?: never
@@ -362,16 +270,7 @@ export interface paths {
     get?: never
     put?: never
     /** Activate an app installation release */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    post: operations["postAdminAppsInstallationsByInstallationIdActivate"]
     delete?: never
     options?: never
     head?: never
@@ -388,23 +287,49 @@ export interface paths {
     get?: never
     put?: never
     /** Preview app installation purge impact */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    post: operations["postAdminAppsInstallationsByInstallationIdPurgePreview"]
     delete?: never
     options?: never
     head?: never
     patch?: never
     trace?: never
   }
-  "/v1/admin/apps/installations/{installationId}/session-token": {
+  "/v1/admin/apps/{appId}": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get an app registration */
+    get: operations["getAdminAppsByAppId"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/v1/admin/apps/{appId}/releases": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** List app releases */
+    get: operations["getAdminAppsByAppIdReleases"]
+    put?: never
+    /** Create an app release from an uploaded manifest */
+    post: operations["postAdminAppsByAppIdReleases"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/v1/admin/apps/{appId}/releases/fetch": {
     parameters: {
       query?: never
       header?: never
@@ -413,43 +338,8 @@ export interface paths {
     }
     get?: never
     put?: never
-    /** Issue an app extension session token */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/v1/admin/apps/installations/{installationId}/setup-handoff": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Create a one-time Marketplace app setup handoff */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    /** Create an app release from a fetched manifest */
+    post: operations["postAdminAppsByAppIdReleasesFetch"]
     delete?: never
     options?: never
     head?: never
@@ -464,16 +354,7 @@ export interface paths {
       cookie?: never
     }
     /** List app webhook delivery health */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    get: operations["getAdminAppsInstallationsByInstallationIdWebhooks"]
     put?: never
     post?: never
     delete?: never
@@ -492,104 +373,7 @@ export interface paths {
     get?: never
     put?: never
     /** Replay an app webhook delivery */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/v1/admin/apps/{appId}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get an app registration */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/v1/admin/apps/{appId}/releases": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** List app releases */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
-    put?: never
-    /** Create an app release from an uploaded manifest */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/v1/admin/apps/{appId}/releases/fetch": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Create an app release from a fetched manifest */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    post: operations["postAdminAppsInstallationsByInstallationIdWebhooksReplay"]
     delete?: never
     options?: never
     head?: never
@@ -607,4 +391,915 @@ export interface components {
   pathItems: never
 }
 export type $defs = Record<string, never>
-export type operations = Record<string, never>
+export interface operations {
+  getAdminApps: {
+    parameters: {
+      query?: {
+        ownerId?: string
+        distribution?: "custom" | "marketplace"
+        limit?: number
+        offset?: number | null
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Paginated app registrations */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: unknown[]
+            total: number
+            limit: number
+            offset: number
+          }
+        }
+      }
+    }
+  }
+  postAdminApps: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          ownerId: string
+          displayName: string
+          slug: string
+          /** @default [] */
+          redirectUris?: string[]
+          createdBy: string
+        }
+      }
+    }
+    responses: {
+      /** @description Created custom app registration */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+      /** @description Duplicate app registration */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsOauthAuthorize: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          /** @enum {string} */
+          response_type: "code"
+          client_id: string
+          release_id: string
+          /** Format: uri */
+          redirect_uri: string
+          state: string
+          nonce?: string
+          code_challenge: string
+          /** @enum {string} */
+          code_challenge_method: "S256"
+          actor_id?: string
+          /** @default  */
+          operator_scopes?: string
+          /** @default  */
+          optional_scopes?: string
+        }
+      }
+    }
+    responses: {
+      /** @description OAuth authorization redirect target */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              /** Format: uri */
+              redirectUrl: string
+              state: string
+            }
+          }
+        }
+      }
+      /** @description App OAuth is not configured */
+      501: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsOauthToken: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json":
+          | {
+              /** @enum {string} */
+              grant_type: "authorization_code"
+              code: string
+              /** Format: uri */
+              redirect_uri: string
+              code_verifier: string
+              client_id: string
+              client_secret?: string
+            }
+          | {
+              /** @enum {string} */
+              grant_type: "refresh_token"
+              refresh_token: string
+              client_id: string
+              client_secret?: string
+            }
+      }
+    }
+    responses: {
+      /** @description OAuth token response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            [key: string]: unknown
+          }
+        }
+      }
+      /** @description App OAuth is not configured */
+      501: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsOauthRevokeInstallation: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          installationId: string
+          actorId: string
+        }
+      }
+    }
+    responses: {
+      /** @description Revoked installation credential generation */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            installationId: string
+            generation: number
+          }
+        }
+      }
+      /** @description App OAuth is not configured */
+      501: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsInstallationsByInstallationIdSessionToken: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        installationId: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          entity?: {
+            type: string
+            id: string
+          }
+          slot?: string
+        }
+      }
+    }
+    responses: {
+      /** @description Issued app session token */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+      /** @description App session tokens are not configured */
+      501: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsOauthSessionTokenExchange: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          session_token: string
+          client_id: string
+          client_secret?: string
+          /** @default [] */
+          viewer_scopes?: string[]
+          contextual_scopes?: string[]
+        }
+      }
+    }
+    responses: {
+      /** @description Online app token response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            [key: string]: unknown
+          }
+        }
+      }
+      /** @description App session tokens are not configured */
+      501: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsInstall: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          appId: string
+          releaseId: string
+          actorId: string
+          grantedOptionalScopes?: string[]
+          /** @enum {string} */
+          updatePolicy?: "manual" | "compatible" | "patch" | "pinned"
+          deploymentId?: string
+        }
+      }
+    }
+    responses: {
+      /** @description Installed app */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsMarketplaceInstallIntentsResolve: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          intent: string
+        }
+      }
+    }
+    responses: {
+      /** @description Admitted Marketplace install intent */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              appId: string
+              releaseId: string
+              acquisitionId: string
+              created: boolean
+              existingInstallation: {
+                id: string
+                releaseId: string
+                /** @enum {string} */
+                status:
+                  | "pending"
+                  | "authorizing"
+                  | "active"
+                  | "paused"
+                  | "degraded"
+                  | "revoked"
+                  | "uninstalled"
+              } | null
+            }
+          }
+        }
+      }
+      /** @description Install intent unavailable */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+      /** @description Managed Marketplace is not configured */
+      501: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsInstallationsByInstallationIdSetupHandoff: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        installationId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Created one-time app setup handoff */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              /** Format: uri */
+              redirectUrl: string
+            }
+          }
+        }
+      }
+      /** @description Marketplace installation unavailable */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+      /** @description Managed Marketplace is not configured */
+      501: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  getAdminAppsInstallations: {
+    parameters: {
+      query?: {
+        appId?: string
+        status?:
+          | "pending"
+          | "authorizing"
+          | "active"
+          | "paused"
+          | "degraded"
+          | "revoked"
+          | "uninstalled"
+        deploymentId?: string
+        limit?: number
+        offset?: number | null
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Paginated app installations */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: unknown[]
+            total: number
+            limit: number
+            offset: number
+          }
+        }
+      }
+    }
+  }
+  getAdminAppsInstallationsByInstallationId: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        installationId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description App installation detail */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+      /** @description App installation not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  getAdminAppsInstallationsByInstallationIdAudit: {
+    parameters: {
+      query?: {
+        limit?: number
+      }
+      header?: never
+      path: {
+        installationId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description App installation audit events */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsInstallationsByInstallationIdPause: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        installationId: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          actorId: string
+        }
+      }
+    }
+    responses: {
+      /** @description Paused app installation */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsInstallationsByInstallationIdResume: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        installationId: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          actorId: string
+        }
+      }
+    }
+    responses: {
+      /** @description Resumed app installation */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsInstallationsByInstallationIdUninstall: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        installationId: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          actorId: string
+        }
+      }
+    }
+    responses: {
+      /** @description Uninstalled app installation */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsInstallationsByInstallationIdActivate: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        installationId: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          releaseId: string
+          actorId: string
+          grantedRequiredScopes?: string[]
+          grantedOptionalScopes?: string[]
+          /** @enum {string} */
+          updatePolicy?: "manual" | "compatible" | "patch" | "pinned"
+        }
+      }
+    }
+    responses: {
+      /** @description Activated app installation release */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsInstallationsByInstallationIdPurgePreview: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        installationId: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          actorId: string
+        }
+      }
+    }
+    responses: {
+      /** @description App installation purge preview */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+    }
+  }
+  getAdminAppsByAppId: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        appId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description App registration */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+      /** @description App not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  getAdminAppsByAppIdReleases: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        appId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description App releases */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsByAppIdReleases: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        appId: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          manifest?: unknown
+          createdBy: string
+          /**
+           * @default {
+           *       "source": "admin-upload"
+           *     }
+           */
+          provenance?: {
+            [key: string]: unknown
+          }
+        }
+      }
+    }
+    responses: {
+      /** @description Created app release */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+            digest: string
+            created: boolean
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsByAppIdReleasesFetch: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        appId: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          /** Format: uri */
+          manifestUrl: string
+          createdBy: string
+        }
+      }
+    }
+    responses: {
+      /** @description Fetched app release */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+            digest: string
+            created: boolean
+          }
+        }
+      }
+    }
+  }
+  getAdminAppsInstallationsByInstallationIdWebhooks: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        installationId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description App webhook delivery health */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+    }
+  }
+  postAdminAppsInstallationsByInstallationIdWebhooksReplay: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        installationId: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          deliveryId: string
+          actorId: string
+        }
+      }
+    }
+    responses: {
+      /** @description Replayed app webhook delivery */
+      202: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data?: unknown
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apps/openapi/admin/apps.json
+++ b/packages/apps/openapi/admin/apps.json
@@ -7,72 +7,1677 @@
   },
   "paths": {
     "/v1/admin/apps": {
-      "get": { "summary": "List app registrations" },
-      "post": { "summary": "Create a custom app registration" }
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false,
+            "name": "ownerId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["custom", "marketplace"]
+            },
+            "required": false,
+            "name": "distribution",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 100,
+              "default": 25
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": ["integer", "null"],
+              "minimum": 0,
+              "default": 0
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated app registrations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "total": {
+                      "type": "number"
+                    },
+                    "limit": {
+                      "type": "number"
+                    },
+                    "offset": {
+                      "type": "number"
+                    }
+                  },
+                  "required": ["data", "total", "limit", "offset"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminApps",
+        "summary": "List app registrations",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      },
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ownerId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  },
+                  "displayName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                  },
+                  "slug": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9][a-z0-9-]{0,78}[a-z0-9]$"
+                  },
+                  "redirectUris": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "default": []
+                  },
+                  "createdBy": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  }
+                },
+                "required": ["ownerId", "displayName", "slug", "createdBy"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created custom app registration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate app registration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminApps",
+        "summary": "Create a custom app registration",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
     },
     "/v1/admin/apps/oauth/authorize": {
-      "post": { "summary": "Approve app OAuth consent" }
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "response_type": {
+                    "type": "string",
+                    "enum": ["code"]
+                  },
+                  "client_id": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "release_id": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "redirect_uri": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "state": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "nonce": {
+                    "type": "string",
+                    "minLength": 43,
+                    "maxLength": 128
+                  },
+                  "code_challenge": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "code_challenge_method": {
+                    "type": "string",
+                    "enum": ["S256"]
+                  },
+                  "actor_id": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "operator_scopes": {
+                    "type": "string",
+                    "default": ""
+                  },
+                  "optional_scopes": {
+                    "type": "string",
+                    "default": ""
+                  }
+                },
+                "required": [
+                  "response_type",
+                  "client_id",
+                  "release_id",
+                  "redirect_uri",
+                  "state",
+                  "code_challenge",
+                  "code_challenge_method"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OAuth authorization redirect target",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "redirectUrl": {
+                          "type": "string",
+                          "format": "uri"
+                        },
+                        "state": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["redirectUrl", "state"]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "App OAuth is not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsOauthAuthorize",
+        "summary": "Approve app OAuth consent",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
     },
     "/v1/admin/apps/oauth/token": {
-      "post": { "summary": "Issue an app OAuth token" }
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "grant_type": {
+                        "type": "string",
+                        "enum": ["authorization_code"]
+                      },
+                      "code": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "redirect_uri": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "code_verifier": {
+                        "type": "string",
+                        "minLength": 43,
+                        "maxLength": 128
+                      },
+                      "client_id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "client_secret": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["grant_type", "code", "redirect_uri", "code_verifier", "client_id"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "grant_type": {
+                        "type": "string",
+                        "enum": ["refresh_token"]
+                      },
+                      "refresh_token": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "client_id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "client_secret": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["grant_type", "refresh_token", "client_id"]
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OAuth token response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "App OAuth is not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsOauthToken",
+        "summary": "Issue an app OAuth token",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
     },
     "/v1/admin/apps/oauth/revoke-installation": {
-      "post": { "summary": "Revoke installation credentials" }
-    },
-    "/v1/admin/apps/oauth/session-token/exchange": {
-      "post": { "summary": "Exchange an app session token" }
-    },
-    "/v1/admin/apps/install": {
-      "post": { "summary": "Install an app release" }
-    },
-    "/v1/admin/apps/marketplace/install-intents/resolve": {
-      "post": { "summary": "Resolve and admit an opaque Marketplace install intent" }
-    },
-    "/v1/admin/apps/installations": {
-      "get": { "summary": "List app installations" }
-    },
-    "/v1/admin/apps/installations/{installationId}": {
-      "get": { "summary": "Get app installation detail" }
-    },
-    "/v1/admin/apps/installations/{installationId}/audit": {
-      "get": { "summary": "List app installation audit events" }
-    },
-    "/v1/admin/apps/installations/{installationId}/pause": {
-      "post": { "summary": "Pause an app installation" }
-    },
-    "/v1/admin/apps/installations/{installationId}/resume": {
-      "post": { "summary": "Resume an app installation" }
-    },
-    "/v1/admin/apps/installations/{installationId}/uninstall": {
-      "post": { "summary": "Uninstall an app installation" }
-    },
-    "/v1/admin/apps/installations/{installationId}/activate": {
-      "post": { "summary": "Activate an app installation release" }
-    },
-    "/v1/admin/apps/installations/{installationId}/purge-preview": {
-      "post": { "summary": "Preview app installation purge impact" }
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "installationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "actorId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": ["installationId", "actorId"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Revoked installation credential generation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "installationId": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "number"
+                    }
+                  },
+                  "required": ["installationId", "generation"]
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "App OAuth is not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsOauthRevokeInstallation",
+        "summary": "Revoke installation credentials",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
     },
     "/v1/admin/apps/installations/{installationId}/session-token": {
-      "post": { "summary": "Issue an app extension session token" }
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "installationId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "entity": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 80
+                      },
+                      "id": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 200
+                      }
+                    },
+                    "required": ["type", "id"],
+                    "additionalProperties": false
+                  },
+                  "slot": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Issued app session token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "App session tokens are not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsInstallationsByInstallationIdSessionToken",
+        "summary": "Issue an app extension session token",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/apps/oauth/session-token/exchange": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "session_token": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "client_id": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "client_secret": {
+                    "type": "string"
+                  },
+                  "viewer_scopes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[a-z][a-z0-9-]*:[a-z][a-z0-9-]*$"
+                    },
+                    "default": []
+                  },
+                  "contextual_scopes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[a-z][a-z0-9-]*:[a-z][a-z0-9-]*$"
+                    }
+                  }
+                },
+                "required": ["session_token", "client_id"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Online app token response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "App session tokens are not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsOauthSessionTokenExchange",
+        "summary": "Exchange an app session token",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/apps/install": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "appId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "releaseId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "actorId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  },
+                  "grantedOptionalScopes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[a-z][a-z0-9-]*:[a-z][a-z0-9-]*$"
+                    }
+                  },
+                  "updatePolicy": {
+                    "type": "string",
+                    "enum": ["manual", "compatible", "patch", "pinned"]
+                  },
+                  "deploymentId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": ["appId", "releaseId", "actorId"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Installed app",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsInstall",
+        "summary": "Install an app release",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/apps/marketplace/install-intents/resolve": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "intent": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 2048
+                  }
+                },
+                "required": ["intent"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Admitted Marketplace install intent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "appId": {
+                          "type": "string"
+                        },
+                        "releaseId": {
+                          "type": "string"
+                        },
+                        "acquisitionId": {
+                          "type": "string"
+                        },
+                        "created": {
+                          "type": "boolean"
+                        },
+                        "existingInstallation": {
+                          "type": ["object", "null"],
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "releaseId": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "pending",
+                                "authorizing",
+                                "active",
+                                "paused",
+                                "degraded",
+                                "revoked",
+                                "uninstalled"
+                              ]
+                            }
+                          },
+                          "required": ["id", "releaseId", "status"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "appId",
+                        "releaseId",
+                        "acquisitionId",
+                        "created",
+                        "existingInstallation"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Install intent unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Managed Marketplace is not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsMarketplaceInstallIntentsResolve",
+        "summary": "Resolve and admit an opaque Marketplace install intent",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
     },
     "/v1/admin/apps/installations/{installationId}/setup-handoff": {
-      "post": { "summary": "Create a one-time Marketplace app setup handoff" }
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "installationId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created one-time app setup handoff",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "redirectUrl": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      },
+                      "required": ["redirectUrl"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Marketplace installation unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Managed Marketplace is not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsInstallationsByInstallationIdSetupHandoff",
+        "summary": "Create a one-time Marketplace app setup handoff",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
     },
-    "/v1/admin/apps/installations/{installationId}/webhooks": {
-      "get": { "summary": "List app webhook delivery health" }
+    "/v1/admin/apps/installations": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false,
+            "name": "appId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "authorizing",
+                "active",
+                "paused",
+                "degraded",
+                "revoked",
+                "uninstalled"
+              ]
+            },
+            "required": false,
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false,
+            "name": "deploymentId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 100,
+              "default": 25
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": ["integer", "null"],
+              "minimum": 0,
+              "default": 0
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated app installations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "total": {
+                      "type": "number"
+                    },
+                    "limit": {
+                      "type": "number"
+                    },
+                    "offset": {
+                      "type": "number"
+                    }
+                  },
+                  "required": ["data", "total", "limit", "offset"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminAppsInstallations",
+        "summary": "List app installations",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
     },
-    "/v1/admin/apps/installations/{installationId}/webhooks/replay": {
-      "post": { "summary": "Replay an app webhook delivery" }
+    "/v1/admin/apps/installations/{installationId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "installationId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "App installation detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "App installation not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminAppsInstallationsByInstallationId",
+        "summary": "Get app installation detail",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/apps/installations/{installationId}/audit": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "installationId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 200,
+              "default": 50
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "App installation audit events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminAppsInstallationsByInstallationIdAudit",
+        "summary": "List app installation audit events",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/apps/installations/{installationId}/pause": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "installationId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "actorId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  }
+                },
+                "required": ["actorId"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Paused app installation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsInstallationsByInstallationIdPause",
+        "summary": "Pause an app installation",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/apps/installations/{installationId}/resume": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "installationId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "actorId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  }
+                },
+                "required": ["actorId"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Resumed app installation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsInstallationsByInstallationIdResume",
+        "summary": "Resume an app installation",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/apps/installations/{installationId}/uninstall": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "installationId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "actorId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  }
+                },
+                "required": ["actorId"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Uninstalled app installation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsInstallationsByInstallationIdUninstall",
+        "summary": "Uninstall an app installation",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/apps/installations/{installationId}/activate": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "installationId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "releaseId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "actorId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  },
+                  "grantedRequiredScopes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[a-z][a-z0-9-]*:[a-z][a-z0-9-]*$"
+                    }
+                  },
+                  "grantedOptionalScopes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[a-z][a-z0-9-]*:[a-z][a-z0-9-]*$"
+                    }
+                  },
+                  "updatePolicy": {
+                    "type": "string",
+                    "enum": ["manual", "compatible", "patch", "pinned"]
+                  }
+                },
+                "required": ["releaseId", "actorId"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Activated app installation release",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsInstallationsByInstallationIdActivate",
+        "summary": "Activate an app installation release",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/apps/installations/{installationId}/purge-preview": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "installationId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "actorId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  }
+                },
+                "required": ["actorId"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "App installation purge preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsInstallationsByInstallationIdPurgePreview",
+        "summary": "Preview app installation purge impact",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
     },
     "/v1/admin/apps/{appId}": {
-      "get": { "summary": "Get an app registration" }
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "appId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "App registration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "App not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminAppsByAppId",
+        "summary": "Get an app registration",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
     },
     "/v1/admin/apps/{appId}/releases": {
-      "get": { "summary": "List app releases" },
-      "post": { "summary": "Create an app release from an uploaded manifest" }
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "appId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "App releases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminAppsByAppIdReleases",
+        "summary": "List app releases",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      },
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "appId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "manifest": {},
+                  "createdBy": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  },
+                  "provenance": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "default": {
+                      "source": "admin-upload"
+                    }
+                  }
+                },
+                "required": ["createdBy"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created app release",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {},
+                    "digest": {
+                      "type": "string"
+                    },
+                    "created": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["digest", "created"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsByAppIdReleases",
+        "summary": "Create an app release from an uploaded manifest",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
     },
     "/v1/admin/apps/{appId}/releases/fetch": {
-      "post": { "summary": "Create an app release from a fetched manifest" }
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "appId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "manifestUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "createdBy": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  }
+                },
+                "required": ["manifestUrl", "createdBy"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Fetched app release",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {},
+                    "digest": {
+                      "type": "string"
+                    },
+                    "created": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["digest", "created"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsByAppIdReleasesFetch",
+        "summary": "Create an app release from a fetched manifest",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/apps/installations/{installationId}/webhooks": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "installationId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "App webhook delivery health",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminAppsInstallationsByInstallationIdWebhooks",
+        "summary": "List app webhook delivery health",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/apps/installations/{installationId}/webhooks/replay": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "installationId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "deliveryId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "actorId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  }
+                },
+                "required": ["deliveryId", "actorId"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Replayed app webhook delivery",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminAppsInstallationsByInstallationIdWebhooksReplay",
+        "summary": "Replay an app webhook delivery",
+        "tags": ["apps"],
+        "x-voyant-module": "apps",
+        "x-voyant-surface": "admin"
+      }
     }
   }
 }

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -32,12 +32,13 @@
     "./openapi/admin": "./openapi/admin/apps.json"
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.typecheck.json",
-    "lint": "biome check src/",
-    "test": "vitest run",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
-    "prepack": "pnpm run build"
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && biome format --write openapi/admin/apps.json",
+    "lint": "biome check src/",
+    "prepack": "pnpm run build",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",

--- a/packages/apps/scripts/generate-openapi.ts
+++ b/packages/apps/scripts/generate-openapi.ts
@@ -1,0 +1,75 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createAppsAdminRoutes } from "../src/routes.js"
+
+const PREFIX = "/v1/admin/apps"
+const MODULE = "apps"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/apps.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+const live = createAppsAdminRoutes().getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// The route module mounts at `/`, so its own document is prefix-relative, while
+// the published document is absolute and `stampModuleMetadata` derives ids from
+// the absolute path — so re-prefix before stamping, not after.
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [
+      path === "/" ? PREFIX : `${PREFIX}${path}`,
+      item,
+    ]),
+  ),
+}
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (key.startsWith("x-voyant-") || CARRIED.includes(key)) operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/mice/package.json
+++ b/packages/mice/package.json
@@ -19,13 +19,14 @@
     "./openapi/admin/mice-booking": "./openapi/admin/mice-booking.json"
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.typecheck.json",
-    "lint": "biome check src/",
-    "test": "vitest run",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=mice_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && biome format --write openapi/admin/mice.json",
+    "lint": "biome check src/",
     "prepack": "pnpm run build",
-    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=mice_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations"
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",

--- a/packages/mice/scripts/generate-openapi.ts
+++ b/packages/mice/scripts/generate-openapi.ts
@@ -1,0 +1,75 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { miceAdminRoutes } from "../src/routes.js"
+
+const PREFIX = "/v1/admin/mice"
+const MODULE = "mice"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/mice.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+const live = miceAdminRoutes.getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// The route module mounts at `/`, so its own document is prefix-relative, while
+// the published document is absolute and `stampModuleMetadata` derives ids from
+// the absolute path — so re-prefix before stamping, not after.
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [
+      path === "/" ? PREFIX : `${PREFIX}${path}`,
+      item,
+    ]),
+  ),
+}
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (key.startsWith("x-voyant-") || CARRIED.includes(key)) operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/scripts/checks/openapi/generated-specs.json
+++ b/scripts/checks/openapi/generated-specs.json
@@ -9,6 +9,10 @@
   ],
   "generators": [
     {
+      "command": "pnpm --filter @voyant-travel/apps generate:openapi",
+      "files": ["packages/apps/openapi/admin/apps.json"]
+    },
+    {
       "command": "pnpm --filter @voyant-travel/catalog generate:openapi",
       "files": [
         "packages/catalog/openapi/admin/catalog-booking.json",
@@ -45,6 +49,10 @@
     {
       "command": "pnpm --filter @voyant-travel/media generate:openapi",
       "files": ["packages/media/openapi/admin/media-library.json"]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/mice generate:openapi",
+      "files": ["packages/mice/openapi/admin/mice.json"]
     },
     {
       "command": "pnpm --filter @voyant-travel/operations generate:openapi",


### PR DESCRIPTION
Two more of the 66 hand-written documents — and a third that must stay hand-written, which is the more useful finding.

| package | paths | outcome |
|---|---|---|
| `apps` | 22 | **24 response definitions, 17 parameter sets, 16 request bodies absent** from the document; `operationId` and `tags` missing |
| `mice` | 20 | **byte-identical** — zero drift |
| `mice-booking` | 1 | **not generated** — see below |

`mice` is worth having as a control: it shows the generators are not rewriting documents into their own idiom, and that a hand-written document can simply be correct.

## Not every document can be generated

`mice-booking.json` looked like an easy win. Generating it **stripped real content**:

| | document | routes produce |
|---|---|---|
| `parameters` | `bookingId` path param | nothing |
| `requestBody` | full PUT schema | nothing |
| `responses` | per-status detail including a 404 | one generic description |

`miceBookingExtensionRoutes` uses **plain Hono handlers**, not `createRoute` with zod schemas, so the routes carry no OpenAPI definitions. The document is hand-written precisely because they cannot produce one. The generator was dropped rather than ship a regression.

Package-level, only four packages have no `createRoute` anywhere — `reporting`, `storage`, `realtime`, `public-document-delivery` (13 paths between them). But `mice` shows the real granularity is **per module**: it uses `createRoute` heavily and still has a module that does not. The only reliable detector is to generate and read the diff.

For those, "add a generator" is really "migrate the routes to zod-openapi first" — a different and much larger change than P0 assumed.

## Prose and stamps are carried forward, not overwritten

My first version replaced curated summaries with derived placeholders — `stampModuleMetadata` produces `"GET /v1/admin/apps"` where a human wrote `"List app registrations"` — across 24 operations. Schemas come from the routes; prose does not, and neither do the `x-voyant-*` graph stamps, whose presence varies by document (full set, one key, or none).

So `operationId`, `summary`, `tags` and `x-voyant-*` are carried forward from the committed operation, exactly as the finance generator already did.

## Verification

- `pnpm verify:architecture` — full chain, exit 0, zero failure markers
- `verify:openapi-drift` **82 documents**; `verify:openapi-path-ownership` 604/616 (the 12 outstanding are public-api's, in #4822)
- apps 144 tests, mice 56 tests; root `biome check .` clean at error level

Part of #4256 P0.