### PR TITLE
Generate six more admin documents from their routes

### DIFF
--- a/packages/action-ledger/openapi/admin/action-ledger-health.json
+++ b/packages/action-ledger/openapi/admin/action-ledger-health.json
@@ -7,29 +7,305 @@
   "paths": {
     "/v1/admin/action-ledger/health": {
       "get": {
-        "summary": "Inspect action ledger drift and health",
         "x-voyant-api-id": "@voyant-travel/action-ledger#health-extension.api",
         "parameters": [
           {
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "required": false,
             "name": "createdAtFrom",
-            "in": "query",
-            "schema": { "type": "string", "format": "date-time" }
+            "in": "query"
           },
           {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "required": false,
             "name": "sampleLimit",
-            "in": "query",
-            "schema": { "type": "integer", "minimum": 1 }
+            "in": "query"
           }
         ],
         "responses": {
-          "200": { "description": "The ledger and its domain projections are healthy" },
-          "503": { "description": "A ledger or domain projection health check failed" }
-        }
+          "200": {
+            "description": "The action ledger and domain projections are healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean"
+                        },
+                        "canary": {
+                          "type": ["object", "null"],
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "actionId": {
+                              "type": "string"
+                            },
+                            "replayed": {
+                              "type": "boolean"
+                            },
+                            "observedWrite": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": ["ok", "actionId", "replayed", "observedWrite"]
+                        },
+                        "bookingDrift": {
+                          "type": "object",
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "rows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "check": {
+                                    "type": "string"
+                                  },
+                                  "missingCount": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "sampleIds": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["check", "missingCount", "sampleIds"]
+                              }
+                            }
+                          },
+                          "required": ["ok", "rows"]
+                        },
+                        "financeDrift": {
+                          "type": "object",
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "rows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "check": {
+                                    "type": "string"
+                                  },
+                                  "missingCount": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "sampleIds": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["check", "missingCount", "sampleIds"]
+                              }
+                            }
+                          },
+                          "required": ["ok", "rows"]
+                        },
+                        "productDrift": {
+                          "type": "object",
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "rows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "check": {
+                                    "type": "string"
+                                  },
+                                  "missingCount": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "sampleIds": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["check", "missingCount", "sampleIds"]
+                              }
+                            }
+                          },
+                          "required": ["ok", "rows"]
+                        }
+                      },
+                      "required": ["ok", "canary", "bookingDrift", "financeDrift", "productDrift"]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "An action ledger or domain projection health check failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean"
+                        },
+                        "canary": {
+                          "type": ["object", "null"],
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "actionId": {
+                              "type": "string"
+                            },
+                            "replayed": {
+                              "type": "boolean"
+                            },
+                            "observedWrite": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": ["ok", "actionId", "replayed", "observedWrite"]
+                        },
+                        "bookingDrift": {
+                          "type": "object",
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "rows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "check": {
+                                    "type": "string"
+                                  },
+                                  "missingCount": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "sampleIds": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["check", "missingCount", "sampleIds"]
+                              }
+                            }
+                          },
+                          "required": ["ok", "rows"]
+                        },
+                        "financeDrift": {
+                          "type": "object",
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "rows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "check": {
+                                    "type": "string"
+                                  },
+                                  "missingCount": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "sampleIds": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["check", "missingCount", "sampleIds"]
+                              }
+                            }
+                          },
+                          "required": ["ok", "rows"]
+                        },
+                        "productDrift": {
+                          "type": "object",
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "rows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "check": {
+                                    "type": "string"
+                                  },
+                                  "missingCount": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "sampleIds": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["check", "missingCount", "sampleIds"]
+                              }
+                            }
+                          },
+                          "required": ["ok", "rows"]
+                        }
+                      },
+                      "required": ["ok", "canary", "bookingDrift", "financeDrift", "productDrift"]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminActionLedgerHealth",
+        "summary": "Inspect action ledger drift and health",
+        "tags": ["action-ledger"],
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/health/check": {
       "post": {
-        "summary": "Run action ledger drift checks and a write canary",
         "x-voyant-api-id": "@voyant-travel/action-ledger#health-extension.api",
         "requestBody": {
           "required": true,
@@ -38,20 +314,305 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "createdAtFrom": { "type": "string", "format": "date-time" },
-                  "sampleLimit": { "type": "integer", "minimum": 1 },
-                  "organizationId": { "type": "string" },
-                  "principalId": { "type": "string" },
-                  "idempotencyKey": { "type": "string" }
+                  "createdAtFrom": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "sampleLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100
+                  },
+                  "organizationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "principalId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "idempotencyKey": {
+                    "type": "string",
+                    "minLength": 1
+                  }
                 }
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "The canary and all drift checks passed" },
-          "503": { "description": "The canary or a drift check failed" }
-        }
+          "200": {
+            "description": "The canary and all drift checks passed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean"
+                        },
+                        "canary": {
+                          "type": ["object", "null"],
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "actionId": {
+                              "type": "string"
+                            },
+                            "replayed": {
+                              "type": "boolean"
+                            },
+                            "observedWrite": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": ["ok", "actionId", "replayed", "observedWrite"]
+                        },
+                        "bookingDrift": {
+                          "type": "object",
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "rows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "check": {
+                                    "type": "string"
+                                  },
+                                  "missingCount": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "sampleIds": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["check", "missingCount", "sampleIds"]
+                              }
+                            }
+                          },
+                          "required": ["ok", "rows"]
+                        },
+                        "financeDrift": {
+                          "type": "object",
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "rows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "check": {
+                                    "type": "string"
+                                  },
+                                  "missingCount": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "sampleIds": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["check", "missingCount", "sampleIds"]
+                              }
+                            }
+                          },
+                          "required": ["ok", "rows"]
+                        },
+                        "productDrift": {
+                          "type": "object",
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "rows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "check": {
+                                    "type": "string"
+                                  },
+                                  "missingCount": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "sampleIds": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["check", "missingCount", "sampleIds"]
+                              }
+                            }
+                          },
+                          "required": ["ok", "rows"]
+                        }
+                      },
+                      "required": ["ok", "canary", "bookingDrift", "financeDrift", "productDrift"]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The canary or a drift check failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean"
+                        },
+                        "canary": {
+                          "type": ["object", "null"],
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "actionId": {
+                              "type": "string"
+                            },
+                            "replayed": {
+                              "type": "boolean"
+                            },
+                            "observedWrite": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": ["ok", "actionId", "replayed", "observedWrite"]
+                        },
+                        "bookingDrift": {
+                          "type": "object",
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "rows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "check": {
+                                    "type": "string"
+                                  },
+                                  "missingCount": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "sampleIds": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["check", "missingCount", "sampleIds"]
+                              }
+                            }
+                          },
+                          "required": ["ok", "rows"]
+                        },
+                        "financeDrift": {
+                          "type": "object",
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "rows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "check": {
+                                    "type": "string"
+                                  },
+                                  "missingCount": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "sampleIds": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["check", "missingCount", "sampleIds"]
+                              }
+                            }
+                          },
+                          "required": ["ok", "rows"]
+                        },
+                        "productDrift": {
+                          "type": "object",
+                          "properties": {
+                            "ok": {
+                              "type": "boolean"
+                            },
+                            "rows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "check": {
+                                    "type": "string"
+                                  },
+                                  "missingCount": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "sampleIds": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["check", "missingCount", "sampleIds"]
+                              }
+                            }
+                          },
+                          "required": ["ok", "rows"]
+                        }
+                      },
+                      "required": ["ok", "canary", "bookingDrift", "financeDrift", "productDrift"]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminActionLedgerHealthCheck",
+        "summary": "Run action ledger drift checks and a write canary",
+        "tags": ["action-ledger"],
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     }
   }

--- a/packages/action-ledger/openapi/admin/action-ledger.json
+++ b/packages/action-ledger/openapi/admin/action-ledger.json
@@ -129,6 +129,7 @@
   "paths": {
     "/v1/admin/action-ledger": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "parameters": [
           {
             "schema": {
@@ -770,13 +771,13 @@
         "tags": ["action-ledger"],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin",
-        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "x-voyant-unit-id": "@voyant-travel/action-ledger",
         "x-voyant-package-name": "@voyant-travel/action-ledger"
       }
     },
     "/v1/admin/action-ledger/entries": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "parameters": [
           {
             "schema": {
@@ -1418,13 +1419,13 @@
         "tags": ["action-ledger"],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin",
-        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "x-voyant-unit-id": "@voyant-travel/action-ledger",
         "x-voyant-package-name": "@voyant-travel/action-ledger"
       }
     },
     "/v1/admin/action-ledger/entries/{id}/reversals": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "parameters": [
           {
             "schema": {
@@ -2075,13 +2076,13 @@
         "tags": ["action-ledger"],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin",
-        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "x-voyant-unit-id": "@voyant-travel/action-ledger",
         "x-voyant-package-name": "@voyant-travel/action-ledger"
       }
     },
     "/v1/admin/action-ledger/entries/{id}": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "parameters": [
           {
             "schema": {
@@ -2454,13 +2455,13 @@
         "tags": ["action-ledger"],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin",
-        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "x-voyant-unit-id": "@voyant-travel/action-ledger",
         "x-voyant-package-name": "@voyant-travel/action-ledger"
       }
     },
     "/v1/admin/action-ledger/approvals": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "parameters": [
           {
             "schema": {
@@ -2776,13 +2777,13 @@
         "tags": ["action-ledger"],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin",
-        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "x-voyant-unit-id": "@voyant-travel/action-ledger",
         "x-voyant-package-name": "@voyant-travel/action-ledger"
       }
     },
     "/v1/admin/action-ledger/approvals/request": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "requestBody": {
           "required": true,
           "description": "The requested action plus the approval policy snapshot. Replays the existing approval when the requested action's idempotency key already exists.",
@@ -3281,13 +3282,13 @@
         "tags": ["action-ledger"],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin",
-        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "x-voyant-unit-id": "@voyant-travel/action-ledger",
         "x-voyant-package-name": "@voyant-travel/action-ledger"
       }
     },
     "/v1/admin/action-ledger/approvals/{id}": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "parameters": [
           {
             "schema": {
@@ -3737,13 +3738,13 @@
         "tags": ["action-ledger"],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin",
-        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "x-voyant-unit-id": "@voyant-travel/action-ledger",
         "x-voyant-package-name": "@voyant-travel/action-ledger"
       }
     },
     "/v1/admin/action-ledger/approvals/{id}/decide": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "parameters": [
           {
             "schema": {
@@ -4226,13 +4227,13 @@
         "tags": ["action-ledger"],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin",
-        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "x-voyant-unit-id": "@voyant-travel/action-ledger",
         "x-voyant-package-name": "@voyant-travel/action-ledger"
       }
     },
     "/v1/admin/action-ledger/delegations": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "parameters": [
           {
             "schema": {
@@ -4495,13 +4496,13 @@
         "tags": ["action-ledger"],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin",
-        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "x-voyant-unit-id": "@voyant-travel/action-ledger",
         "x-voyant-package-name": "@voyant-travel/action-ledger"
       }
     },
     "/v1/admin/action-ledger/delegations/{id}": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "parameters": [
           {
             "schema": {
@@ -4606,7 +4607,6 @@
         "tags": ["action-ledger"],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin",
-        "x-voyant-api-id": "@voyant-travel/action-ledger#api.admin",
         "x-voyant-unit-id": "@voyant-travel/action-ledger",
         "x-voyant-package-name": "@voyant-travel/action-ledger"
       }

--- a/packages/action-ledger/package.json
+++ b/packages/action-ledger/package.json
@@ -24,13 +24,14 @@
     "./openapi/admin/health": "./openapi/admin/action-ledger-health.json"
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.typecheck.json",
-    "lint": "biome check src/ tests/",
-    "test": "vitest run --passWithNoTests",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=action_ledger_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && node --import tsx scripts/generate-health-openapi.ts && biome format --write openapi/admin/action-ledger.json openapi/admin/action-ledger-health.json",
+    "lint": "biome check src/ tests/",
     "prepack": "pnpm run build",
-    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=action_ledger_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations"
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",

--- a/packages/action-ledger/scripts/generate-health-openapi.ts
+++ b/packages/action-ledger/scripts/generate-health-openapi.ts
@@ -1,0 +1,89 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createActionLedgerHealthRoutes } from "../src/health-routes.js"
+
+const PREFIX = "/v1/admin/action-ledger"
+const MODULE = "action-ledger"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/action-ledger-health.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+/**
+ * The drift checks are runtime behaviour and never affect the document: the
+ * schema comes from `getActionLedgerHealthRoute`, a static route definition.
+ * These stubs exist only to satisfy the constructor and are never called.
+ */
+const NEVER_RUN = {
+  checkBookingDrift: async () => ({ drifted: [] }),
+  checkFinanceDrift: async () => ({ drifted: [] }),
+  checkProductDrift: async () => ({ drifted: [] }),
+  runCanaryCheck: async () => ({ ok: true }),
+} as never
+
+const live = createActionLedgerHealthRoutes(NEVER_RUN).getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (key.startsWith("x-voyant-") || CARRIED.includes(key)) operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/action-ledger/scripts/generate-openapi.ts
+++ b/packages/action-ledger/scripts/generate-openapi.ts
@@ -1,0 +1,77 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { actionLedgerAdminRoutes } from "../src/routes.js"
+
+const PREFIX = "/v1/admin/action-ledger"
+const MODULE = "action-ledger"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/action-ledger.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+const live = actionLedgerAdminRoutes.getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (key.startsWith("x-voyant-") || CARRIED.includes(key)) operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/action-ledger/src/health-routes.ts
+++ b/packages/action-ledger/src/health-routes.ts
@@ -127,6 +127,24 @@ const getActionLedgerHealthRoute = createRoute({
   responses: healthResponses,
 })
 
+/**
+ * `/health/check` runs the canary and the drift checks; `/health` reports the
+ * projections. Sharing `healthResponses` described both with the projection
+ * wording, which is not what this endpoint reports — the published document had
+ * the accurate prose and the routes did not, so generating it from them would
+ * have replaced a correct description with a generic one.
+ */
+const checkHealthResponses = {
+  200: {
+    description: "The canary and all drift checks passed",
+    content: { "application/json": { schema: actionLedgerHealthResponseSchema } },
+  },
+  503: {
+    description: "The canary or a drift check failed",
+    content: { "application/json": { schema: actionLedgerHealthResponseSchema } },
+  },
+} as const
+
 const checkActionLedgerHealthRoute = createRoute({
   method: "post",
   path: "/health/check",
@@ -136,7 +154,7 @@ const checkActionLedgerHealthRoute = createRoute({
       content: { "application/json": { schema: actionLedgerHealthCheckBodySchema } },
     },
   },
-  responses: healthResponses,
+  responses: checkHealthResponses,
 })
 
 export interface ActionLedgerHealthResponse {

--- a/packages/admin-api-client/src/generated/action-ledger-health.ts
+++ b/packages/admin-api-client/src/generated/action-ledger-health.ts
@@ -12,34 +12,7 @@ export interface paths {
       cookie?: never
     }
     /** Inspect action ledger drift and health */
-    get: {
-      parameters: {
-        query?: {
-          createdAtFrom?: string
-          sampleLimit?: number
-        }
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description The ledger and its domain projections are healthy */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content?: never
-        }
-        /** @description A ledger or domain projection health check failed */
-        503: {
-          headers: {
-            [name: string]: unknown
-          }
-          content?: never
-        }
-      }
-    }
+    get: operations["getAdminActionLedgerHealth"]
     put?: never
     post?: never
     delete?: never
@@ -58,42 +31,7 @@ export interface paths {
     get?: never
     put?: never
     /** Run action ledger drift checks and a write canary */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody: {
-        content: {
-          "application/json": {
-            /** Format: date-time */
-            createdAtFrom?: string
-            sampleLimit?: number
-            organizationId?: string
-            principalId?: string
-            idempotencyKey?: string
-          }
-        }
-      }
-      responses: {
-        /** @description The canary and all drift checks passed */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content?: never
-        }
-        /** @description The canary or a drift check failed */
-        503: {
-          headers: {
-            [name: string]: unknown
-          }
-          content?: never
-        }
-      }
-    }
+    post: operations["postAdminActionLedgerHealthCheck"]
     delete?: never
     options?: never
     head?: never
@@ -111,4 +49,213 @@ export interface components {
   pathItems: never
 }
 export type $defs = Record<string, never>
-export type operations = Record<string, never>
+export interface operations {
+  getAdminActionLedgerHealth: {
+    parameters: {
+      query?: {
+        createdAtFrom?: string
+        sampleLimit?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description The action ledger and domain projections are healthy */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              ok: boolean
+              canary: {
+                ok: boolean
+                actionId: string
+                replayed: boolean
+                observedWrite: boolean
+              } | null
+              bookingDrift: {
+                ok: boolean
+                rows: {
+                  check: string
+                  missingCount: number
+                  sampleIds: string[]
+                }[]
+              }
+              financeDrift: {
+                ok: boolean
+                rows: {
+                  check: string
+                  missingCount: number
+                  sampleIds: string[]
+                }[]
+              }
+              productDrift: {
+                ok: boolean
+                rows: {
+                  check: string
+                  missingCount: number
+                  sampleIds: string[]
+                }[]
+              }
+            }
+          }
+        }
+      }
+      /** @description An action ledger or domain projection health check failed */
+      503: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              ok: boolean
+              canary: {
+                ok: boolean
+                actionId: string
+                replayed: boolean
+                observedWrite: boolean
+              } | null
+              bookingDrift: {
+                ok: boolean
+                rows: {
+                  check: string
+                  missingCount: number
+                  sampleIds: string[]
+                }[]
+              }
+              financeDrift: {
+                ok: boolean
+                rows: {
+                  check: string
+                  missingCount: number
+                  sampleIds: string[]
+                }[]
+              }
+              productDrift: {
+                ok: boolean
+                rows: {
+                  check: string
+                  missingCount: number
+                  sampleIds: string[]
+                }[]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  postAdminActionLedgerHealthCheck: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          /** Format: date-time */
+          createdAtFrom?: string
+          sampleLimit?: number
+          organizationId?: string
+          principalId?: string
+          idempotencyKey?: string
+        }
+      }
+    }
+    responses: {
+      /** @description The canary and all drift checks passed */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              ok: boolean
+              canary: {
+                ok: boolean
+                actionId: string
+                replayed: boolean
+                observedWrite: boolean
+              } | null
+              bookingDrift: {
+                ok: boolean
+                rows: {
+                  check: string
+                  missingCount: number
+                  sampleIds: string[]
+                }[]
+              }
+              financeDrift: {
+                ok: boolean
+                rows: {
+                  check: string
+                  missingCount: number
+                  sampleIds: string[]
+                }[]
+              }
+              productDrift: {
+                ok: boolean
+                rows: {
+                  check: string
+                  missingCount: number
+                  sampleIds: string[]
+                }[]
+              }
+            }
+          }
+        }
+      }
+      /** @description The canary or a drift check failed */
+      503: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              ok: boolean
+              canary: {
+                ok: boolean
+                actionId: string
+                replayed: boolean
+                observedWrite: boolean
+              } | null
+              bookingDrift: {
+                ok: boolean
+                rows: {
+                  check: string
+                  missingCount: number
+                  sampleIds: string[]
+                }[]
+              }
+              financeDrift: {
+                ok: boolean
+                rows: {
+                  check: string
+                  missingCount: number
+                  sampleIds: string[]
+                }[]
+              }
+              productDrift: {
+                ok: boolean
+                rows: {
+                  check: string
+                  missingCount: number
+                  sampleIds: string[]
+                }[]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/admin-api-client/src/generated/custom-fields.ts
+++ b/packages/admin-api-client/src/generated/custom-fields.ts
@@ -12,16 +12,7 @@ export interface paths {
       cookie?: never
     }
     /** List selected target and field-type capabilities */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    get: operations["getAdminCustomFieldsTargets"]
     put?: never
     post?: never
     delete?: never
@@ -38,28 +29,27 @@ export interface paths {
       cookie?: never
     }
     /** List selected-target custom-field definitions */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    get: operations["getAdminCustomFields"]
     put?: never
     /** Create an operator-owned custom-field definition */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
+    post: operations["postAdminCustomFields"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/v1/admin/custom-fields/values": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
     }
+    /** List custom-field values */
+    get: operations["getAdminCustomFieldsValues"]
+    put?: never
+    post?: never
     delete?: never
     options?: never
     head?: never
@@ -74,68 +64,15 @@ export interface paths {
       cookie?: never
     }
     /** Get a custom-field definition */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    get: operations["getAdminCustomFieldsById"]
     put?: never
     post?: never
     /** Delete a custom-field definition */
-    delete: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    delete: operations["deleteAdminCustomFieldsById"]
     options?: never
     head?: never
     /** Update a custom-field definition */
-    patch: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
-    trace?: never
-  }
-  "/v1/admin/custom-fields/values": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** List custom-field values */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
+    patch: operations["patchAdminCustomFieldsById"]
     trace?: never
   }
   "/v1/admin/custom-fields/{id}/value": {
@@ -147,16 +84,7 @@ export interface paths {
     }
     get?: never
     /** Upsert a custom-field value */
-    put: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    put: operations["putAdminCustomFieldsByIdValue"]
     post?: never
     delete?: never
     options?: never
@@ -175,16 +103,7 @@ export interface paths {
     put?: never
     post?: never
     /** Delete a custom-field value */
-    delete: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: never
-    }
+    delete: operations["deleteAdminCustomFieldsValuesById"]
     options?: never
     head?: never
     patch?: never
@@ -201,4 +120,655 @@ export interface components {
   pathItems: never
 }
 export type $defs = Record<string, never>
-export type operations = Record<string, never>
+export interface operations {
+  getAdminCustomFieldsTargets: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Selected custom-field target registry */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              id: string
+              namespace: string
+              label: string
+              fieldTypes: (
+                | "varchar"
+                | "text"
+                | "double"
+                | "monetary"
+                | "date"
+                | "boolean"
+                | "enum"
+                | "set"
+                | "json"
+                | "address"
+                | "phone"
+              )[]
+              capabilities: ("read" | "write" | "search" | "export" | "invoice" | "presentation")[]
+              ownerUnitId: string
+            }[]
+          }
+        }
+      }
+    }
+  }
+  getAdminCustomFields: {
+    parameters: {
+      query?: {
+        entityType?: string
+        ownerKind?: "platform" | "operator" | "app"
+        lifecycleState?: "active" | "inactive" | "deprecated"
+        limit?: number
+        offset?: number | null
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Selected-target custom-field definitions */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              entityType: string
+              key: string
+              label: string
+              /** @enum {string} */
+              fieldType:
+                | "varchar"
+                | "text"
+                | "double"
+                | "monetary"
+                | "date"
+                | "boolean"
+                | "enum"
+                | "set"
+                | "json"
+                | "address"
+                | "phone"
+              /** @default false */
+              isRequired: boolean
+              /** @default false */
+              isSearchable: boolean
+              /** @default true */
+              isExportable: boolean
+              /** @default false */
+              isInvoiceable: boolean
+              options?:
+                | {
+                    label: string
+                    value: string
+                  }[]
+                | null
+              id: string
+              namespace: string
+              /** @enum {string} */
+              ownerKind: "platform" | "operator" | "app"
+              ownerId: string | null
+              /** @enum {string} */
+              lifecycleState: "active" | "inactive" | "deprecated"
+              provenance: {
+                [key: string]: unknown
+              }
+              createdAt: string
+              updatedAt: string
+            }[]
+            total: number
+            limit: number
+            offset: number
+          }
+        }
+      }
+    }
+  }
+  postAdminCustomFields: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          entityType: string
+          key: string
+          label: string
+          /** @enum {string} */
+          fieldType:
+            | "varchar"
+            | "text"
+            | "double"
+            | "monetary"
+            | "date"
+            | "boolean"
+            | "enum"
+            | "set"
+            | "json"
+            | "address"
+            | "phone"
+          /** @default false */
+          isRequired?: boolean
+          /** @default false */
+          isSearchable?: boolean
+          /** @default true */
+          isExportable?: boolean
+          /** @default false */
+          isInvoiceable?: boolean
+          options?:
+            | {
+                label: string
+                value: string
+              }[]
+            | null
+        }
+      }
+    }
+    responses: {
+      /** @description Created custom-field definition */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              entityType: string
+              key: string
+              label: string
+              /** @enum {string} */
+              fieldType:
+                | "varchar"
+                | "text"
+                | "double"
+                | "monetary"
+                | "date"
+                | "boolean"
+                | "enum"
+                | "set"
+                | "json"
+                | "address"
+                | "phone"
+              /** @default false */
+              isRequired: boolean
+              /** @default false */
+              isSearchable: boolean
+              /** @default true */
+              isExportable: boolean
+              /** @default false */
+              isInvoiceable: boolean
+              options?:
+                | {
+                    label: string
+                    value: string
+                  }[]
+                | null
+              id: string
+              namespace: string
+              /** @enum {string} */
+              ownerKind: "platform" | "operator" | "app"
+              ownerId: string | null
+              /** @enum {string} */
+              lifecycleState: "active" | "inactive" | "deprecated"
+              provenance: {
+                [key: string]: unknown
+              }
+              createdAt: string
+              updatedAt: string
+            }
+          }
+        }
+      }
+      /** @description Unsupported target or field type */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+      /** @description Duplicate custom-field key */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  getAdminCustomFieldsValues: {
+    parameters: {
+      query?: {
+        entityType?: string
+        entityId?: string
+        definitionId?: string
+        limit?: number
+        offset?: number | null
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Paginated list of custom-field values */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              id: string
+              definitionId: string
+              entityType: string
+              entityId: string
+              namespace: string
+              key: string
+              textValue: string | null
+              numberValue: number | null
+              dateValue: string | null
+              booleanValue: boolean | null
+              monetaryValueCents: number | null
+              currencyCode: string | null
+              jsonValue:
+                | {
+                    [key: string]: unknown
+                  }
+                | string[]
+                | null
+            }[]
+            total: number
+            limit: number
+            offset: number
+          }
+        }
+      }
+      /** @description Unsupported custom-field target */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  getAdminCustomFieldsById: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Custom-field definition */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              entityType: string
+              key: string
+              label: string
+              /** @enum {string} */
+              fieldType:
+                | "varchar"
+                | "text"
+                | "double"
+                | "monetary"
+                | "date"
+                | "boolean"
+                | "enum"
+                | "set"
+                | "json"
+                | "address"
+                | "phone"
+              /** @default false */
+              isRequired: boolean
+              /** @default false */
+              isSearchable: boolean
+              /** @default true */
+              isExportable: boolean
+              /** @default false */
+              isInvoiceable: boolean
+              options?:
+                | {
+                    label: string
+                    value: string
+                  }[]
+                | null
+              id: string
+              namespace: string
+              /** @enum {string} */
+              ownerKind: "platform" | "operator" | "app"
+              ownerId: string | null
+              /** @enum {string} */
+              lifecycleState: "active" | "inactive" | "deprecated"
+              provenance: {
+                [key: string]: unknown
+              }
+              createdAt: string
+              updatedAt: string
+            }
+          }
+        }
+      }
+      /** @description Custom-field definition not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  deleteAdminCustomFieldsById: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Deleted custom-field definition */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            /** @enum {boolean} */
+            success: true
+          }
+        }
+      }
+      /** @description Definition is controlled by another owner */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+      /** @description Custom-field definition not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  patchAdminCustomFieldsById: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          key?: string
+          label?: string
+          isRequired?: boolean
+          isSearchable?: boolean
+          isExportable?: boolean
+          isInvoiceable?: boolean
+          options?:
+            | {
+                label: string
+                value: string
+              }[]
+            | null
+        }
+      }
+    }
+    responses: {
+      /** @description Updated custom-field definition */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              entityType: string
+              key: string
+              label: string
+              /** @enum {string} */
+              fieldType:
+                | "varchar"
+                | "text"
+                | "double"
+                | "monetary"
+                | "date"
+                | "boolean"
+                | "enum"
+                | "set"
+                | "json"
+                | "address"
+                | "phone"
+              /** @default false */
+              isRequired: boolean
+              /** @default false */
+              isSearchable: boolean
+              /** @default true */
+              isExportable: boolean
+              /** @default false */
+              isInvoiceable: boolean
+              options?:
+                | {
+                    label: string
+                    value: string
+                  }[]
+                | null
+              id: string
+              namespace: string
+              /** @enum {string} */
+              ownerKind: "platform" | "operator" | "app"
+              ownerId: string | null
+              /** @enum {string} */
+              lifecycleState: "active" | "inactive" | "deprecated"
+              provenance: {
+                [key: string]: unknown
+              }
+              createdAt: string
+              updatedAt: string
+            }
+          }
+        }
+      }
+      /** @description Definition is controlled by another owner */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+      /** @description Custom-field definition not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  putAdminCustomFieldsByIdValue: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          entityType: string
+          entityId: string
+          textValue?: string | null
+          numberValue?: number | null
+          /** Format: date */
+          dateValue?: string | null
+          booleanValue?: boolean | null
+          monetaryValueCents?: number | null
+          currencyCode?: string | null
+          jsonValue?:
+            | {
+                [key: string]: unknown
+              }
+            | string[]
+            | null
+        }
+      }
+    }
+    responses: {
+      /** @description The upserted custom-field value */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              id: string
+              definitionId: string
+              entityType: string
+              entityId: string
+              namespace: string
+              key: string
+              textValue: string | null
+              numberValue: number | null
+              dateValue: string | null
+              booleanValue: boolean | null
+              monetaryValueCents: number | null
+              currencyCode: string | null
+              jsonValue:
+                | {
+                    [key: string]: unknown
+                  }
+                | string[]
+                | null
+            }
+          }
+        }
+      }
+      /** @description invalid_request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+      /** @description Custom-field definition or entity not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  deleteAdminCustomFieldsValuesById: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Custom-field value deleted */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            /** @enum {boolean} */
+            success: true
+          }
+        }
+      }
+      /** @description Custom-field value not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/admin-api-client/src/generated/event-catalog.ts
+++ b/packages/admin-api-client/src/generated/event-catalog.ts
@@ -50,7 +50,7 @@ export interface operations {
         content: {
           "application/json": {
             data: {
-              /** @constant */
+              /** @enum {string} */
               schemaVersion: "voyant.event-catalog.v1"
               events: {
                 key: string
@@ -62,11 +62,11 @@ export interface operations {
                 payloadSchema: {
                   [key: string]: unknown
                 }
-                /** @enum {unknown} */
+                /** @enum {string} */
                 visibility: "internal" | "external"
                 audit: {
                   sourceModule: string
-                  /** @enum {unknown} */
+                  /** @enum {string} */
                   category: "domain" | "internal"
                 }
                 redactedFields: string[]

--- a/packages/admin-api-client/src/generated/navigation-preferences.ts
+++ b/packages/admin-api-client/src/generated/navigation-preferences.ts
@@ -11,6 +11,7 @@ export interface paths {
       path?: never
       cookie?: never
     }
+    /** GET /v1/admin/navigation-preferences */
     get: operations["getNavigationPreferences"]
     put?: never
     post?: never
@@ -28,6 +29,7 @@ export interface paths {
       cookie?: never
     }
     get?: never
+    /** PUT /v1/admin/navigation-preferences/organization */
     put: operations["setOrganizationNavigationPreferences"]
     post?: never
     delete?: never
@@ -44,6 +46,7 @@ export interface paths {
       cookie?: never
     }
     get?: never
+    /** PUT /v1/admin/navigation-preferences/me */
     put: operations["setOwnNavigationPreferences"]
     post?: never
     delete?: never

--- a/packages/charters/openapi/public-api/charters.json
+++ b/packages/charters/openapi/public-api/charters.json
@@ -129,6 +129,7 @@
   "paths": {
     "/v1/public/charters": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/charters#api.public",
         "parameters": [
           {
             "schema": {
@@ -239,6 +240,7 @@
     },
     "/v1/public/charters/voyages": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/charters#api.public",
         "parameters": [
           {
             "schema": {
@@ -464,6 +466,7 @@
     },
     "/v1/public/charters/voyages/{key}": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/charters#api.public",
         "parameters": [
           {
             "schema": {
@@ -693,6 +696,7 @@
     },
     "/v1/public/charters/voyages/{key}/quote/per-suite": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/charters#api.public",
         "parameters": [
           {
             "schema": {
@@ -840,6 +844,7 @@
     },
     "/v1/public/charters/voyages/{key}/quote/whole-yacht": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/charters#api.public",
         "parameters": [
           {
             "schema": {
@@ -980,6 +985,7 @@
     },
     "/v1/public/charters/yachts/{key}": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/charters#api.public",
         "parameters": [
           {
             "schema": {
@@ -1065,6 +1071,7 @@
     },
     "/v1/public/charters/products/{key}": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/charters#api.public",
         "parameters": [
           {
             "schema": {

--- a/packages/charters/package.json
+++ b/packages/charters/package.json
@@ -25,13 +25,14 @@
     "./tools": "./src/mcp-runtime.ts"
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.typecheck.json",
-    "lint": "biome check src/",
-    "test": "vitest run",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=charters_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && node --import tsx scripts/generate-public-openapi.ts && biome format --write openapi/admin/charters.json openapi/public-api/charters.json",
+    "lint": "biome check src/",
     "prepack": "pnpm run build",
-    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=charters_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations"
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",

--- a/packages/charters/scripts/generate-openapi.ts
+++ b/packages/charters/scripts/generate-openapi.ts
@@ -1,0 +1,77 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { chartersAdminRoutes } from "../src/routes.js"
+
+const PREFIX = "/v1/admin/charters"
+const MODULE = "charters"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/charters.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+const live = chartersAdminRoutes.getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (key.startsWith("x-voyant-") || CARRIED.includes(key)) operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/charters/scripts/generate-public-openapi.ts
+++ b/packages/charters/scripts/generate-public-openapi.ts
@@ -1,0 +1,77 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { chartersPublicRoutes } from "../src/routes-public.js"
+
+const PREFIX = "/v1/public/charters"
+const MODULE = "charters"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/public-api/charters.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+const live = chartersPublicRoutes.getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (key.startsWith("x-voyant-") || CARRIED.includes(key)) operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/custom-fields/openapi/admin/custom-fields.json
+++ b/packages/custom-fields/openapi/admin/custom-fields.json
@@ -7,25 +7,1445 @@
   },
   "paths": {
     "/v1/admin/custom-fields/targets": {
-      "get": { "summary": "List selected target and field-type capabilities" }
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Selected custom-field target registry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          },
+                          "label": {
+                            "type": "string"
+                          },
+                          "fieldTypes": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "varchar",
+                                "text",
+                                "double",
+                                "monetary",
+                                "date",
+                                "boolean",
+                                "enum",
+                                "set",
+                                "json",
+                                "address",
+                                "phone"
+                              ]
+                            }
+                          },
+                          "capabilities": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "read",
+                                "write",
+                                "search",
+                                "export",
+                                "invoice",
+                                "presentation"
+                              ]
+                            }
+                          },
+                          "ownerUnitId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "namespace",
+                          "label",
+                          "fieldTypes",
+                          "capabilities",
+                          "ownerUnitId"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminCustomFieldsTargets",
+        "summary": "List selected target and field-type capabilities",
+        "tags": ["custom-fields"],
+        "x-voyant-module": "custom-fields",
+        "x-voyant-surface": "admin"
+      }
     },
     "/v1/admin/custom-fields": {
-      "get": { "summary": "List selected-target custom-field definitions" },
-      "post": { "summary": "Create an operator-owned custom-field definition" }
-    },
-    "/v1/admin/custom-fields/{id}": {
-      "get": { "summary": "Get a custom-field definition" },
-      "patch": { "summary": "Update a custom-field definition" },
-      "delete": { "summary": "Delete a custom-field definition" }
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false,
+            "name": "entityType",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["platform", "operator", "app"]
+            },
+            "required": false,
+            "name": "ownerKind",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["active", "inactive", "deprecated"]
+            },
+            "required": false,
+            "name": "lifecycleState",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 100,
+              "default": 25
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": ["integer", "null"],
+              "minimum": 0,
+              "default": 0
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Selected-target custom-field definitions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "entityType": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "key": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "label": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "fieldType": {
+                            "type": "string",
+                            "enum": [
+                              "varchar",
+                              "text",
+                              "double",
+                              "monetary",
+                              "date",
+                              "boolean",
+                              "enum",
+                              "set",
+                              "json",
+                              "address",
+                              "phone"
+                            ]
+                          },
+                          "isRequired": {
+                            "type": "boolean",
+                            "default": false
+                          },
+                          "isSearchable": {
+                            "type": "boolean",
+                            "default": false
+                          },
+                          "isExportable": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "isInvoiceable": {
+                            "type": "boolean",
+                            "default": false
+                          },
+                          "options": {
+                            "type": ["array", "null"],
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["label", "value"]
+                            }
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          },
+                          "ownerKind": {
+                            "type": "string",
+                            "enum": ["platform", "operator", "app"]
+                          },
+                          "ownerId": {
+                            "type": ["string", "null"]
+                          },
+                          "lifecycleState": {
+                            "type": "string",
+                            "enum": ["active", "inactive", "deprecated"]
+                          },
+                          "provenance": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "createdAt": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            ]
+                          },
+                          "updatedAt": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "entityType",
+                          "key",
+                          "label",
+                          "fieldType",
+                          "id",
+                          "namespace",
+                          "ownerKind",
+                          "ownerId",
+                          "lifecycleState",
+                          "provenance",
+                          "createdAt",
+                          "updatedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "type": "number"
+                    },
+                    "limit": {
+                      "type": "number"
+                    },
+                    "offset": {
+                      "type": "number"
+                    }
+                  },
+                  "required": ["data", "total", "limit", "offset"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminCustomFields",
+        "summary": "List selected-target custom-field definitions",
+        "tags": ["custom-fields"],
+        "x-voyant-module": "custom-fields",
+        "x-voyant-surface": "admin"
+      },
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "entityType": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "key": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "label": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "fieldType": {
+                    "type": "string",
+                    "enum": [
+                      "varchar",
+                      "text",
+                      "double",
+                      "monetary",
+                      "date",
+                      "boolean",
+                      "enum",
+                      "set",
+                      "json",
+                      "address",
+                      "phone"
+                    ]
+                  },
+                  "isRequired": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "isSearchable": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "isExportable": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "isInvoiceable": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "options": {
+                    "type": ["array", "null"],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "label": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["label", "value"]
+                    }
+                  }
+                },
+                "required": ["entityType", "key", "label", "fieldType"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created custom-field definition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "entityType": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "key": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "label": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "fieldType": {
+                          "type": "string",
+                          "enum": [
+                            "varchar",
+                            "text",
+                            "double",
+                            "monetary",
+                            "date",
+                            "boolean",
+                            "enum",
+                            "set",
+                            "json",
+                            "address",
+                            "phone"
+                          ]
+                        },
+                        "isRequired": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "isSearchable": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "isExportable": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "isInvoiceable": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "options": {
+                          "type": ["array", "null"],
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["label", "value"]
+                          }
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "ownerKind": {
+                          "type": "string",
+                          "enum": ["platform", "operator", "app"]
+                        },
+                        "ownerId": {
+                          "type": ["string", "null"]
+                        },
+                        "lifecycleState": {
+                          "type": "string",
+                          "enum": ["active", "inactive", "deprecated"]
+                        },
+                        "provenance": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "createdAt": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          ]
+                        },
+                        "updatedAt": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "entityType",
+                        "key",
+                        "label",
+                        "fieldType",
+                        "id",
+                        "namespace",
+                        "ownerKind",
+                        "ownerId",
+                        "lifecycleState",
+                        "provenance",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Unsupported target or field type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate custom-field key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminCustomFields",
+        "summary": "Create an operator-owned custom-field definition",
+        "tags": ["custom-fields"],
+        "x-voyant-module": "custom-fields",
+        "x-voyant-surface": "admin"
+      }
     },
     "/v1/admin/custom-fields/values": {
-      "get": { "summary": "List custom-field values" }
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false,
+            "name": "entityType",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false,
+            "name": "entityId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false,
+            "name": "definitionId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 50
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": ["integer", "null"],
+              "minimum": 0,
+              "default": 0
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of custom-field values",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "definitionId": {
+                            "type": "string"
+                          },
+                          "entityType": {
+                            "type": "string"
+                          },
+                          "entityId": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "textValue": {
+                            "type": ["string", "null"]
+                          },
+                          "numberValue": {
+                            "type": ["number", "null"]
+                          },
+                          "dateValue": {
+                            "type": ["string", "null"]
+                          },
+                          "booleanValue": {
+                            "type": ["boolean", "null"]
+                          },
+                          "monetaryValueCents": {
+                            "type": ["integer", "null"]
+                          },
+                          "currencyCode": {
+                            "type": ["string", "null"]
+                          },
+                          "jsonValue": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "definitionId",
+                          "entityType",
+                          "entityId",
+                          "namespace",
+                          "key",
+                          "textValue",
+                          "numberValue",
+                          "dateValue",
+                          "booleanValue",
+                          "monetaryValueCents",
+                          "currencyCode",
+                          "jsonValue"
+                        ]
+                      }
+                    },
+                    "total": {
+                      "type": "number"
+                    },
+                    "limit": {
+                      "type": "number"
+                    },
+                    "offset": {
+                      "type": "number"
+                    }
+                  },
+                  "required": ["data", "total", "limit", "offset"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Unsupported custom-field target",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminCustomFieldsValues",
+        "summary": "List custom-field values",
+        "tags": ["custom-fields"],
+        "x-voyant-module": "custom-fields",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/custom-fields/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Custom-field definition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "entityType": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "key": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "label": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "fieldType": {
+                          "type": "string",
+                          "enum": [
+                            "varchar",
+                            "text",
+                            "double",
+                            "monetary",
+                            "date",
+                            "boolean",
+                            "enum",
+                            "set",
+                            "json",
+                            "address",
+                            "phone"
+                          ]
+                        },
+                        "isRequired": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "isSearchable": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "isExportable": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "isInvoiceable": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "options": {
+                          "type": ["array", "null"],
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["label", "value"]
+                          }
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "ownerKind": {
+                          "type": "string",
+                          "enum": ["platform", "operator", "app"]
+                        },
+                        "ownerId": {
+                          "type": ["string", "null"]
+                        },
+                        "lifecycleState": {
+                          "type": "string",
+                          "enum": ["active", "inactive", "deprecated"]
+                        },
+                        "provenance": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "createdAt": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          ]
+                        },
+                        "updatedAt": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "entityType",
+                        "key",
+                        "label",
+                        "fieldType",
+                        "id",
+                        "namespace",
+                        "ownerKind",
+                        "ownerId",
+                        "lifecycleState",
+                        "provenance",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Custom-field definition not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminCustomFieldsById",
+        "summary": "Get a custom-field definition",
+        "tags": ["custom-fields"],
+        "x-voyant-module": "custom-fields",
+        "x-voyant-surface": "admin"
+      },
+      "patch": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "label": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "isRequired": {
+                    "type": "boolean"
+                  },
+                  "isSearchable": {
+                    "type": "boolean"
+                  },
+                  "isExportable": {
+                    "type": "boolean"
+                  },
+                  "isInvoiceable": {
+                    "type": "boolean"
+                  },
+                  "options": {
+                    "type": ["array", "null"],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "label": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["label", "value"]
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated custom-field definition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "entityType": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "key": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "label": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "fieldType": {
+                          "type": "string",
+                          "enum": [
+                            "varchar",
+                            "text",
+                            "double",
+                            "monetary",
+                            "date",
+                            "boolean",
+                            "enum",
+                            "set",
+                            "json",
+                            "address",
+                            "phone"
+                          ]
+                        },
+                        "isRequired": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "isSearchable": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "isExportable": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "isInvoiceable": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "options": {
+                          "type": ["array", "null"],
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["label", "value"]
+                          }
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "ownerKind": {
+                          "type": "string",
+                          "enum": ["platform", "operator", "app"]
+                        },
+                        "ownerId": {
+                          "type": ["string", "null"]
+                        },
+                        "lifecycleState": {
+                          "type": "string",
+                          "enum": ["active", "inactive", "deprecated"]
+                        },
+                        "provenance": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "createdAt": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          ]
+                        },
+                        "updatedAt": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "entityType",
+                        "key",
+                        "label",
+                        "fieldType",
+                        "id",
+                        "namespace",
+                        "ownerKind",
+                        "ownerId",
+                        "lifecycleState",
+                        "provenance",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Definition is controlled by another owner",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Custom-field definition not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "patchAdminCustomFieldsById",
+        "summary": "Update a custom-field definition",
+        "tags": ["custom-fields"],
+        "x-voyant-module": "custom-fields",
+        "x-voyant-surface": "admin"
+      },
+      "delete": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted custom-field definition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [true]
+                    }
+                  },
+                  "required": ["success"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Definition is controlled by another owner",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Custom-field definition not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "deleteAdminCustomFieldsById",
+        "summary": "Delete a custom-field definition",
+        "tags": ["custom-fields"],
+        "x-voyant-module": "custom-fields",
+        "x-voyant-surface": "admin"
+      }
     },
     "/v1/admin/custom-fields/{id}/value": {
-      "put": { "summary": "Upsert a custom-field value" }
+      "put": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "entityType": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "entityId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "textValue": {
+                    "type": ["string", "null"]
+                  },
+                  "numberValue": {
+                    "type": ["number", "null"]
+                  },
+                  "dateValue": {
+                    "type": ["string", "null"],
+                    "format": "date"
+                  },
+                  "booleanValue": {
+                    "type": ["boolean", "null"]
+                  },
+                  "monetaryValueCents": {
+                    "type": ["integer", "null"]
+                  },
+                  "currencyCode": {
+                    "type": ["string", "null"]
+                  },
+                  "jsonValue": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "additionalProperties": {}
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": ["entityType", "entityId"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The upserted custom-field value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "definitionId": {
+                          "type": "string"
+                        },
+                        "entityType": {
+                          "type": "string"
+                        },
+                        "entityId": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "textValue": {
+                          "type": ["string", "null"]
+                        },
+                        "numberValue": {
+                          "type": ["number", "null"]
+                        },
+                        "dateValue": {
+                          "type": ["string", "null"]
+                        },
+                        "booleanValue": {
+                          "type": ["boolean", "null"]
+                        },
+                        "monetaryValueCents": {
+                          "type": ["integer", "null"]
+                        },
+                        "currencyCode": {
+                          "type": ["string", "null"]
+                        },
+                        "jsonValue": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "definitionId",
+                        "entityType",
+                        "entityId",
+                        "namespace",
+                        "key",
+                        "textValue",
+                        "numberValue",
+                        "dateValue",
+                        "booleanValue",
+                        "monetaryValueCents",
+                        "currencyCode",
+                        "jsonValue"
+                      ]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Custom-field definition or entity not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "putAdminCustomFieldsByIdValue",
+        "summary": "Upsert a custom-field value",
+        "tags": ["custom-fields"],
+        "x-voyant-module": "custom-fields",
+        "x-voyant-surface": "admin"
+      }
     },
     "/v1/admin/custom-fields/values/{id}": {
-      "delete": { "summary": "Delete a custom-field value" }
+      "delete": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Custom-field value deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [true]
+                    }
+                  },
+                  "required": ["success"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Custom-field value not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "deleteAdminCustomFieldsValuesById",
+        "summary": "Delete a custom-field value",
+        "tags": ["custom-fields"],
+        "x-voyant-module": "custom-fields",
+        "x-voyant-surface": "admin"
+      }
     }
   }
 }

--- a/packages/custom-fields/package.json
+++ b/packages/custom-fields/package.json
@@ -15,12 +15,13 @@
     "./openapi/admin": "./openapi/admin/custom-fields.json"
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.typecheck.json",
-    "lint": "biome check src/",
-    "test": "vitest run",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
-    "prepack": "pnpm --workspace-concurrency=1 --filter @voyant-travel/custom-fields... run build"
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && biome format --write openapi/admin/custom-fields.json",
+    "lint": "biome check src/",
+    "prepack": "pnpm --workspace-concurrency=1 --filter @voyant-travel/custom-fields... run build",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",

--- a/packages/custom-fields/scripts/generate-openapi.ts
+++ b/packages/custom-fields/scripts/generate-openapi.ts
@@ -1,0 +1,77 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createCustomFieldRoutes } from "../src/routes.js"
+
+const PREFIX = "/v1/admin/custom-fields"
+const MODULE = "custom-fields"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/custom-fields.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+const live = createCustomFieldRoutes(new Map()).getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (key.startsWith("x-voyant-") || CARRIED.includes(key)) operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/event-catalog/openapi/admin/event-catalog.json
+++ b/packages/event-catalog/openapi/admin/event-catalog.json
@@ -18,17 +18,65 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["data"],
                   "properties": {
                     "data": {
                       "type": "object",
-                      "required": ["schemaVersion", "events"],
                       "properties": {
-                        "schemaVersion": { "const": "voyant.event-catalog.v1" },
+                        "schemaVersion": {
+                          "type": "string",
+                          "enum": ["voyant.event-catalog.v1"]
+                        },
                         "events": {
                           "type": "array",
                           "items": {
                             "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
+                              },
+                              "unitId": {
+                                "type": "string"
+                              },
+                              "packageName": {
+                                "type": "string"
+                              },
+                              "eventType": {
+                                "type": "string"
+                              },
+                              "version": {
+                                "type": "string"
+                              },
+                              "payloadSchema": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "visibility": {
+                                "type": "string",
+                                "enum": ["internal", "external"]
+                              },
+                              "audit": {
+                                "type": "object",
+                                "properties": {
+                                  "sourceModule": {
+                                    "type": "string"
+                                  },
+                                  "category": {
+                                    "type": "string",
+                                    "enum": ["domain", "internal"]
+                                  }
+                                },
+                                "required": ["sourceModule", "category"]
+                              },
+                              "redactedFields": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
                             "required": [
                               "key",
                               "id",
@@ -40,39 +88,21 @@
                               "visibility",
                               "audit",
                               "redactedFields"
-                            ],
-                            "properties": {
-                              "key": { "type": "string" },
-                              "id": { "type": "string" },
-                              "unitId": { "type": "string" },
-                              "packageName": { "type": "string" },
-                              "eventType": { "type": "string" },
-                              "version": { "type": "string" },
-                              "payloadSchema": { "type": "object", "additionalProperties": true },
-                              "visibility": { "enum": ["internal", "external"] },
-                              "audit": {
-                                "type": "object",
-                                "required": ["sourceModule", "category"],
-                                "properties": {
-                                  "sourceModule": { "type": "string" },
-                                  "category": { "enum": ["domain", "internal"] }
-                                }
-                              },
-                              "redactedFields": {
-                                "type": "array",
-                                "items": { "type": "string" }
-                              }
-                            }
+                            ]
                           }
                         }
-                      }
+                      },
+                      "required": ["schemaVersion", "events"]
                     }
-                  }
+                  },
+                  "required": ["data"]
                 }
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "event-catalog",
+        "x-voyant-surface": "admin"
       }
     }
   }

--- a/packages/event-catalog/package.json
+++ b/packages/event-catalog/package.json
@@ -34,10 +34,11 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
-    "prepack": "pnpm run build",
-    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && biome format --write openapi/admin/event-catalog.json",
     "lint": "biome check src/ tests/",
-    "test": "vitest run"
+    "prepack": "pnpm run build",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",

--- a/packages/event-catalog/scripts/generate-openapi.ts
+++ b/packages/event-catalog/scripts/generate-openapi.ts
@@ -1,0 +1,82 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { VOYANT_EVENT_CATALOG_SCHEMA_VERSION } from "@voyant-travel/core/project"
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+import { createEventCatalogHonoApp } from "../src/routes.js"
+
+const PREFIX = "/v1/admin/event-catalog"
+const MODULE = "event-catalog"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/event-catalog.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+// The catalog argument only fills the response *value*; the route definition
+// that produces the schema is static, so an empty catalog generates the same
+// document a populated one would.
+const live = createEventCatalogHonoApp({
+  schemaVersion: VOYANT_EVENT_CATALOG_SCHEMA_VERSION,
+  events: [],
+}).getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (key.startsWith("x-voyant-") || CARRIED.includes(key)) operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/navigation-preferences/openapi/admin/navigation-preferences.json
+++ b/packages/navigation-preferences/openapi/admin/navigation-preferences.json
@@ -67,7 +67,11 @@
               }
             }
           }
-        }
+        },
+        "summary": "GET /v1/admin/navigation-preferences",
+        "tags": ["navigation-preferences"],
+        "x-voyant-module": "navigation-preferences",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/navigation-preferences/organization": {
@@ -158,7 +162,11 @@
               }
             }
           }
-        }
+        },
+        "summary": "PUT /v1/admin/navigation-preferences/organization",
+        "tags": ["navigation-preferences"],
+        "x-voyant-module": "navigation-preferences",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/navigation-preferences/me": {
@@ -236,7 +244,11 @@
               }
             }
           }
-        }
+        },
+        "summary": "PUT /v1/admin/navigation-preferences/me",
+        "tags": ["navigation-preferences"],
+        "x-voyant-module": "navigation-preferences",
+        "x-voyant-surface": "admin"
       }
     }
   }

--- a/packages/navigation-preferences/package.json
+++ b/packages/navigation-preferences/package.json
@@ -18,11 +18,12 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
-    "prepack": "pnpm run build",
-    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --prefix=timestamp --name=navigation_preferences_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && biome format --write openapi/admin/navigation-preferences.json",
     "lint": "biome check src/ tests/",
+    "prepack": "pnpm run build",
     "test": "vitest run",
-    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --prefix=timestamp --name=navigation_preferences_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations"
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",

--- a/packages/navigation-preferences/scripts/generate-openapi.ts
+++ b/packages/navigation-preferences/scripts/generate-openapi.ts
@@ -1,0 +1,77 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createNavigationPreferencesRoutes } from "../src/routes.js"
+
+const PREFIX = "/v1/admin/navigation-preferences"
+const MODULE = "navigation-preferences"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/navigation-preferences.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+const live = createNavigationPreferencesRoutes().getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (key.startsWith("x-voyant-") || CARRIED.includes(key)) operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/scripts/checks/openapi/generated-specs.json
+++ b/scripts/checks/openapi/generated-specs.json
@@ -20,6 +20,14 @@
       ]
     },
     {
+      "command": "pnpm --filter @voyant-travel/custom-fields generate:openapi",
+      "files": ["packages/custom-fields/openapi/admin/custom-fields.json"]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/event-catalog generate:openapi",
+      "files": ["packages/event-catalog/openapi/admin/event-catalog.json"]
+    },
+    {
       "command": "pnpm --filter @voyant-travel/finance generate:openapi",
       "files": [
         "packages/finance/openapi/admin/finance.json",
@@ -53,6 +61,10 @@
     {
       "command": "pnpm --filter @voyant-travel/mice generate:openapi",
       "files": ["packages/mice/openapi/admin/mice.json"]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/navigation-preferences generate:openapi",
+      "files": ["packages/navigation-preferences/openapi/admin/navigation-preferences.json"]
     },
     {
       "command": "pnpm --filter @voyant-travel/operations generate:openapi",

--- a/scripts/checks/openapi/generated-specs.json
+++ b/scripts/checks/openapi/generated-specs.json
@@ -9,6 +9,13 @@
   ],
   "generators": [
     {
+      "command": "pnpm --filter @voyant-travel/action-ledger generate:openapi",
+      "files": [
+        "packages/action-ledger/openapi/admin/action-ledger.json",
+        "packages/action-ledger/openapi/admin/action-ledger-health.json"
+      ]
+    },
+    {
       "command": "pnpm --filter @voyant-travel/apps generate:openapi",
       "files": ["packages/apps/openapi/admin/apps.json"]
     },
@@ -17,6 +24,13 @@
       "files": [
         "packages/catalog/openapi/admin/catalog-booking.json",
         "packages/catalog/openapi/public-api/catalog-booking.json"
+      ]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/charters generate:openapi",
+      "files": [
+        "packages/charters/openapi/admin/charters.json",
+        "packages/charters/openapi/public-api/charters.json"
       ]
     },
     {


### PR DESCRIPTION
Six documents across five packages, plus one route fix the exercise produced.

| document | paths | outcome |
|---|---|---|
| `charters` admin | 13 | **byte-identical** |
| `action-ledger` | 10 | **byte-identical** |
| `charters` public | 7 | `x-voyant-api-id` added on every operation |
| `custom-fields` | 6 | **9 responses, 9 operationIds, 7 parameter sets absent** from the document |
| `navigation-preferences` | 3 | metadata added; schemas already correct |
| `event-catalog` | 1 | additive, plus two equivalent spellings |
| `action-ledger-health` | 2 | schemas added; **the routes were corrected**, see below |

Four regenerate byte-identical or schema-clean. That is worth stating: the generators are not rewriting documents into their own idiom, so a diff means something when one appears.

## The document was more accurate than the code

`/health` and `/health/check` shared one `healthResponses` object, so the routes described the canary endpoint with the projection wording — *"The action ledger and domain projections are healthy"* — while the hand-written document said what it actually reports: *"The canary and all drift checks passed"*.

Generating from the routes would have replaced correct prose with generic prose. Instead `/health/check` now has its own response definitions carrying the document's wording, so **both** are right. First time in this series the exercise improved runtime code rather than an artifact.

## Two template corrections

**Path convention.** Route modules use both: some mount at `/` with prefix-relative paths, others declare absolute paths. Prefixing unconditionally produced `/v1/admin/navigation-preferences/v1/admin/navigation-preferences` — a diff that reads as a wholesale path rename rather than the mistake it is. The template now normalises.

**Equivalent spellings.** `event-catalog`'s `const: "voyant.event-catalog.v1"` became `{type: "string", enum: [...]}` and `additionalProperties: true` became `{}`. Checked rather than assumed — same constraints, zod-openapi's spelling.

## Verification

- `pnpm verify:architecture` — full chain, exit 0, zero failure markers, tree settled throughout
- `verify:openapi-path-ownership` **658/658**; `verify:openapi-drift` **89 documents**; dialect 82 documents, 0 `nullable`
- action-ledger 244 tests, custom-fields 80, event-catalog 4, navigation-preferences 13
- root `biome check .` clean at error level

Part of #4256 P0.