### PR TITLE
Add Proposal conversion provider for Inquiries

### DIFF
--- a/.changeset/calm-inquiry-proposals.md
+++ b/.changeset/calm-inquiry-proposals.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/proposals-contracts": patch
+"@voyant-travel/proposals": patch
+---
+
+Add the typed, replay-safe Proposal conversion provider for first-class Inquiries.

--- a/packages/proposals-contracts/package.json
+++ b/packages/proposals-contracts/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./checkout-inquiry": "./src/checkout-inquiry.ts",
+    "./inquiry-conversion": "./src/inquiry-conversion.ts",
     "./runtime-port": "./src/checkout-inquiry.ts",
     "./validation": "./src/validation.ts"
   },
@@ -32,6 +33,11 @@
         "types": "./dist/checkout-inquiry.d.ts",
         "import": "./dist/checkout-inquiry.js",
         "default": "./dist/checkout-inquiry.js"
+      },
+      "./inquiry-conversion": {
+        "types": "./dist/inquiry-conversion.d.ts",
+        "import": "./dist/inquiry-conversion.js",
+        "default": "./dist/inquiry-conversion.js"
       },
       "./runtime-port": {
         "types": "./dist/checkout-inquiry.d.ts",

--- a/packages/proposals-contracts/src/index.ts
+++ b/packages/proposals-contracts/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./checkout-inquiry.js"
+export * from "./inquiry-conversion.js"
 export * from "./validation.js"

--- a/packages/proposals-contracts/src/inquiry-conversion.test.ts
+++ b/packages/proposals-contracts/src/inquiry-conversion.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { proposalInquiryConversionRuntimePort } from "./inquiry-conversion.js"
+import {
+  formatProposalInquirySourceRef,
+  parseProposalInquirySourceRef,
+  proposalInquiryConversionRuntimePort,
+} from "./inquiry-conversion.js"
 
 describe("Proposal Inquiry conversion contract", () => {
   it("accepts the one-method conversion provider", () => {
@@ -10,5 +14,15 @@ describe("Proposal Inquiry conversion contract", () => {
 
   it("rejects providers without the conversion command", () => {
     expect(() => proposalInquiryConversionRuntimePort.test({} as never)).toThrow(/convertInquiry/)
+  })
+
+  it("round-trips navigable Inquiry provenance and operation identity", () => {
+    const sourceRef = formatProposalInquirySourceRef("inq/romania", "retry:key/2")
+    expect(sourceRef).toBe("inq%2Fromania/conversion/retry%3Akey%2F2")
+    expect(parseProposalInquirySourceRef(sourceRef)).toEqual({
+      inquiryId: "inq/romania",
+      idempotencyKey: "retry:key/2",
+    })
+    expect(parseProposalInquirySourceRef("not-an-inquiry-reference")).toBeNull()
   })
 })

--- a/packages/proposals-contracts/src/inquiry-conversion.test.ts
+++ b/packages/proposals-contracts/src/inquiry-conversion.test.ts
@@ -19,10 +19,31 @@ describe("Proposal Inquiry conversion contract", () => {
   it("round-trips navigable Inquiry provenance and operation identity", () => {
     const sourceRef = formatProposalInquirySourceRef("inq/romania", "retry:key/2")
     expect(sourceRef).toBe("inq%2Fromania/conversion/retry%3Akey%2F2")
+    if (sourceRef === null) throw new Error("valid source reference was refused")
     expect(parseProposalInquirySourceRef(sourceRef)).toEqual({
       inquiryId: "inq/romania",
       idempotencyKey: "retry:key/2",
     })
     expect(parseProposalInquirySourceRef("not-an-inquiry-reference")).toBeNull()
+  })
+
+  it.each([
+    ["empty Inquiry id", "", "key"],
+    ["empty operation key", "inq_1", ""],
+    ["blank Inquiry id", "   ", "key"],
+    ["oversized Inquiry id", "i".repeat(256), "key"],
+    ["oversized operation key", "inq_1", "k".repeat(256)],
+    ["malformed Inquiry Unicode", "inq_\ud800", "key"],
+    ["malformed key Unicode", "inq_1", "key_\udc00"],
+  ])("refuses %s without throwing", (_label, inquiryId, idempotencyKey) => {
+    expect(() => formatProposalInquirySourceRef(inquiryId, idempotencyKey)).not.toThrow()
+    expect(formatProposalInquirySourceRef(inquiryId, idempotencyKey)).toBeNull()
+  })
+
+  it("rejects malformed or invalid encoded references", () => {
+    expect(parseProposalInquirySourceRef("/conversion/key")).toBeNull()
+    expect(parseProposalInquirySourceRef("inq_1/conversion/")).toBeNull()
+    expect(parseProposalInquirySourceRef("inq_%ED%A0%80/conversion/key")).toBeNull()
+    expect(parseProposalInquirySourceRef(`${"i".repeat(256)}/conversion/key`)).toBeNull()
   })
 })

--- a/packages/proposals-contracts/src/inquiry-conversion.test.ts
+++ b/packages/proposals-contracts/src/inquiry-conversion.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { proposalInquiryConversionRuntimePort } from "./inquiry-conversion.js"
+
+describe("Proposal Inquiry conversion contract", () => {
+  it("accepts the one-method conversion provider", () => {
+    const provider = { convertInquiry: vi.fn() }
+    expect(() => proposalInquiryConversionRuntimePort.test(provider)).not.toThrow()
+  })
+
+  it("rejects providers without the conversion command", () => {
+    expect(() => proposalInquiryConversionRuntimePort.test({} as never)).toThrow(/convertInquiry/)
+  })
+})

--- a/packages/proposals-contracts/src/inquiry-conversion.ts
+++ b/packages/proposals-contracts/src/inquiry-conversion.ts
@@ -1,0 +1,73 @@
+export interface ProposalInquiryPipelinePreference {
+  pipelineId?: string | null
+  stageId?: string | null
+}
+
+/** An Inquiry-owned Product snapshot. Pricing remains a Proposals concern. */
+export interface ProposalInquiryProductTargetSnapshot {
+  productId: string
+  nameSnapshot: string
+  description?: string | null
+  quantity?: number
+}
+
+export interface ConvertInquiryToProposalInput {
+  inquiryId: string
+  title: string
+  summary?: string | null
+  personId?: string | null
+  organizationId?: string | null
+  ownerId?: string | null
+  actorId?: string | null
+  tags?: readonly string[]
+  pipeline?: ProposalInquiryPipelinePreference
+  productTargets?: readonly ProposalInquiryProductTargetSnapshot[]
+}
+
+export type ProposalInquiryConversionRefusalReason =
+  | "pipeline_not_found"
+  | "default_pipeline_not_found"
+  | "stage_not_found"
+  | "stage_pipeline_mismatch"
+  | "stage_closed"
+  | "open_stage_not_found"
+  | "source_conflict"
+  | "source_proposal_not_open"
+
+export interface ProposalInquiryConversionSuccess {
+  kind: "created" | "replayed"
+  proposalId: string
+  pipelineId: string
+  stageId: string
+}
+
+export interface ProposalInquiryConversionRefusal {
+  kind: "refused"
+  reason: ProposalInquiryConversionRefusalReason
+}
+
+export type ProposalInquiryConversionOutcome =
+  | ProposalInquiryConversionSuccess
+  | ProposalInquiryConversionRefusal
+
+export interface ProposalInquiryConversionRuntime {
+  convertInquiry(
+    database: unknown,
+    input: ConvertInquiryToProposalInput,
+  ): Promise<ProposalInquiryConversionOutcome>
+}
+
+/** Import-cheap port consumed by the Relationships conversion coordinator. */
+export const proposalInquiryConversionRuntimePort = Object.freeze({
+  id: "proposals.inquiry-conversion.runtime",
+  test(provider: ProposalInquiryConversionRuntime) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("proposals.inquiry-conversion.runtime provider must be an object.")
+    }
+    if (typeof Reflect.get(provider, "convertInquiry") !== "function") {
+      throw new Error(
+        "proposals.inquiry-conversion.runtime provider must implement convertInquiry().",
+      )
+    }
+  },
+})

--- a/packages/proposals-contracts/src/inquiry-conversion.ts
+++ b/packages/proposals-contracts/src/inquiry-conversion.ts
@@ -13,6 +13,8 @@ export interface ProposalInquiryProductTargetSnapshot {
 
 export interface ConvertInquiryToProposalInput {
   inquiryId: string
+  /** Identifies this conversion operation; exact retries resolve the same Proposal. */
+  idempotencyKey: string
   title: string
   summary?: string | null
   personId?: string | null
@@ -32,7 +34,6 @@ export type ProposalInquiryConversionRefusalReason =
   | "stage_closed"
   | "open_stage_not_found"
   | "source_conflict"
-  | "source_proposal_not_open"
 
 export interface ProposalInquiryConversionSuccess {
   kind: "created" | "replayed"
@@ -55,6 +56,36 @@ export interface ProposalInquiryConversionRuntime {
     database: unknown,
     input: ConvertInquiryToProposalInput,
   ): Promise<ProposalInquiryConversionOutcome>
+}
+
+/**
+ * Proposal-owned durable identity for one Inquiry conversion operation.
+ *
+ * `source` remains `inquiry`; `sourceRef` is
+ * `<percent-encoded inquiry id>/conversion/<percent-encoded idempotency key>`.
+ * The reversible form keeps the originating Inquiry navigable while allowing
+ * separate conversion operations for that Inquiry to create separate targets.
+ */
+export function formatProposalInquirySourceRef(inquiryId: string, idempotencyKey: string): string {
+  return `${encodeURIComponent(inquiryId)}/conversion/${encodeURIComponent(idempotencyKey)}`
+}
+
+export function parseProposalInquirySourceRef(
+  sourceRef: string,
+): { inquiryId: string; idempotencyKey: string } | null {
+  const marker = "/conversion/"
+  const markerIndex = sourceRef.indexOf(marker)
+  if (markerIndex < 1) return null
+  const encodedInquiryId = sourceRef.slice(0, markerIndex)
+  const encodedIdempotencyKey = sourceRef.slice(markerIndex + marker.length)
+  try {
+    return {
+      inquiryId: decodeURIComponent(encodedInquiryId),
+      idempotencyKey: decodeURIComponent(encodedIdempotencyKey),
+    }
+  } catch {
+    return null
+  }
 }
 
 /** Import-cheap port consumed by the Relationships conversion coordinator. */

--- a/packages/proposals-contracts/src/inquiry-conversion.ts
+++ b/packages/proposals-contracts/src/inquiry-conversion.ts
@@ -27,6 +27,7 @@ export interface ConvertInquiryToProposalInput {
 }
 
 export type ProposalInquiryConversionRefusalReason =
+  | "invalid_input"
   | "pipeline_not_found"
   | "default_pipeline_not_found"
   | "stage_not_found"
@@ -66,7 +67,19 @@ export interface ProposalInquiryConversionRuntime {
  * The reversible form keeps the originating Inquiry navigable while allowing
  * separate conversion operations for that Inquiry to create separate targets.
  */
-export function formatProposalInquirySourceRef(inquiryId: string, idempotencyKey: string): string {
+export const PROPOSAL_INQUIRY_ID_MAX_LENGTH = 255
+export const PROPOSAL_INQUIRY_IDEMPOTENCY_KEY_MAX_LENGTH = 255
+
+export function formatProposalInquirySourceRef(
+  inquiryId: string,
+  idempotencyKey: string,
+): string | null {
+  if (
+    !isValidSourceRefPart(inquiryId, PROPOSAL_INQUIRY_ID_MAX_LENGTH) ||
+    !isValidSourceRefPart(idempotencyKey, PROPOSAL_INQUIRY_IDEMPOTENCY_KEY_MAX_LENGTH)
+  ) {
+    return null
+  }
   return `${encodeURIComponent(inquiryId)}/conversion/${encodeURIComponent(idempotencyKey)}`
 }
 
@@ -79,13 +92,36 @@ export function parseProposalInquirySourceRef(
   const encodedInquiryId = sourceRef.slice(0, markerIndex)
   const encodedIdempotencyKey = sourceRef.slice(markerIndex + marker.length)
   try {
-    return {
-      inquiryId: decodeURIComponent(encodedInquiryId),
-      idempotencyKey: decodeURIComponent(encodedIdempotencyKey),
-    }
+    const inquiryId = decodeURIComponent(encodedInquiryId)
+    const idempotencyKey = decodeURIComponent(encodedIdempotencyKey)
+    if (formatProposalInquirySourceRef(inquiryId, idempotencyKey) === null) return null
+    return { inquiryId, idempotencyKey }
   } catch {
     return null
   }
+}
+
+function isValidSourceRefPart(value: unknown, maxLength: number): value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maxLength ||
+    value.trim().length === 0
+  ) {
+    return false
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index)
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      if (index + 1 >= value.length) return false
+      const next = value.charCodeAt(index + 1)
+      if (next < 0xdc00 || next > 0xdfff) return false
+      index += 1
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false
+    }
+  }
+  return true
 }
 
 /** Import-cheap port consumed by the Relationships conversion coordinator. */

--- a/packages/proposals/src/index.ts
+++ b/packages/proposals/src/index.ts
@@ -54,6 +54,7 @@ export {
   proposalsBookingExtension,
 } from "./booking-extension.js"
 export { createCheckoutInquiryRuntime } from "./checkout-inquiry-runtime.js"
+export { createProposalInquiryConversionRuntime } from "./inquiry-conversion-runtime.js"
 export type { ProposalPaymentTerms } from "./payment-terms.js"
 export {
   normalizeProposalPaymentTerms,

--- a/packages/proposals/src/inquiry-conversion-runtime.ts
+++ b/packages/proposals/src/inquiry-conversion-runtime.ts
@@ -1,0 +1,259 @@
+import type {
+  ProposalInquiryConversionOutcome,
+  ProposalInquiryConversionRuntime,
+  ProposalInquiryPipelinePreference,
+  ProposalInquiryProductTargetSnapshot,
+} from "@voyant-travel/proposals-contracts/inquiry-conversion"
+import { and, asc, eq, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { pipelines, proposalProducts, proposals, stages } from "./schema.js"
+
+interface PipelineRecord {
+  id: string
+  entityType: string
+}
+
+interface StageRecord {
+  id: string
+  pipelineId: string
+  isClosed: boolean
+}
+
+interface InquiryProposalRecord {
+  id: string
+  pipelineId: string
+  stageId: string
+  status: string
+}
+
+interface CreateInquiryProposalRecord {
+  title: string
+  description: string | null
+  personId: string | null
+  organizationId: string | null
+  ownerId: string | null
+  actorId: string | null
+  tags: readonly string[]
+  inquiryId: string
+  pipelineId: string
+  stageId: string
+  productTargets: readonly ProposalInquiryProductTargetSnapshot[]
+}
+
+interface ProposalInquiryConversionStore {
+  withInquiryLock<T>(
+    database: unknown,
+    inquiryId: string,
+    operation: (database: unknown) => Promise<T>,
+  ): Promise<T>
+  findByInquiry(database: unknown, inquiryId: string): Promise<InquiryProposalRecord[]>
+  getPipeline(database: unknown, pipelineId: string): Promise<PipelineRecord | null>
+  getDefaultPipeline(database: unknown): Promise<PipelineRecord | null>
+  getStage(database: unknown, stageId: string): Promise<StageRecord | null>
+  getInitialOpenStage(database: unknown, pipelineId: string): Promise<StageRecord | null>
+  createProposal(
+    database: unknown,
+    input: CreateInquiryProposalRecord,
+  ): Promise<InquiryProposalRecord>
+}
+
+type PipelineSelectionOutcome =
+  | { kind: "selected"; pipelineId: string; stageId: string }
+  | Extract<ProposalInquiryConversionOutcome, { kind: "refused" }>
+
+const drizzleProposalInquiryConversionStore: ProposalInquiryConversionStore = {
+  withInquiryLock(database, inquiryId, operation) {
+    const db = database as PostgresJsDatabase
+    return db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtextextended(${`proposals:inquiry:${inquiryId}`}, 0))`,
+      )
+      return operation(tx)
+    })
+  },
+
+  async findByInquiry(database, inquiryId) {
+    return (database as PostgresJsDatabase)
+      .select({
+        id: proposals.id,
+        pipelineId: proposals.pipelineId,
+        stageId: proposals.stageId,
+        status: proposals.status,
+      })
+      .from(proposals)
+      .where(and(eq(proposals.source, "inquiry"), eq(proposals.sourceRef, inquiryId)))
+      .limit(2)
+  },
+
+  async getPipeline(database, pipelineId) {
+    const [pipeline] = await (database as PostgresJsDatabase)
+      .select({ id: pipelines.id, entityType: pipelines.entityType })
+      .from(pipelines)
+      .where(eq(pipelines.id, pipelineId))
+      .limit(1)
+    return pipeline ?? null
+  },
+
+  async getDefaultPipeline(database) {
+    const [pipeline] = await (database as PostgresJsDatabase)
+      .select({ id: pipelines.id, entityType: pipelines.entityType })
+      .from(pipelines)
+      .where(and(eq(pipelines.entityType, "proposal"), eq(pipelines.isDefault, true)))
+      .orderBy(asc(pipelines.sortOrder), asc(pipelines.createdAt))
+      .limit(1)
+    return pipeline ?? null
+  },
+
+  async getStage(database, stageId) {
+    const [stage] = await (database as PostgresJsDatabase)
+      .select({ id: stages.id, pipelineId: stages.pipelineId, isClosed: stages.isClosed })
+      .from(stages)
+      .where(eq(stages.id, stageId))
+      .limit(1)
+    return stage ?? null
+  },
+
+  async getInitialOpenStage(database, pipelineId) {
+    const [stage] = await (database as PostgresJsDatabase)
+      .select({ id: stages.id, pipelineId: stages.pipelineId, isClosed: stages.isClosed })
+      .from(stages)
+      .where(and(eq(stages.pipelineId, pipelineId), eq(stages.isClosed, false)))
+      .orderBy(asc(stages.sortOrder), asc(stages.createdAt))
+      .limit(1)
+    return stage ?? null
+  },
+
+  async createProposal(database, input) {
+    const db = database as PostgresJsDatabase
+    const [proposal] = await db
+      .insert(proposals)
+      .values({
+        title: input.title,
+        description: input.description,
+        personId: input.personId,
+        organizationId: input.organizationId,
+        ownerId: input.ownerId,
+        pipelineId: input.pipelineId,
+        stageId: input.stageId,
+        status: "open",
+        source: "inquiry",
+        sourceRef: input.inquiryId,
+        tags: [...input.tags],
+        createdBy: input.actorId,
+        updatedBy: input.actorId,
+      })
+      .returning({
+        id: proposals.id,
+        pipelineId: proposals.pipelineId,
+        stageId: proposals.stageId,
+        status: proposals.status,
+      })
+    if (!proposal) throw new Error("Proposal insertion returned no row")
+
+    if (input.productTargets.length > 0) {
+      await db.insert(proposalProducts).values(
+        input.productTargets.map((target) => ({
+          proposalId: proposal.id,
+          productId: target.productId,
+          nameSnapshot: target.nameSnapshot,
+          description: target.description ?? null,
+          quantity: target.quantity ?? 1,
+          unitPriceAmountCents: null,
+          costAmountCents: null,
+          currency: null,
+          discountAmountCents: null,
+        })),
+      )
+    }
+    return proposal
+  },
+}
+
+export function createProposalInquiryConversionRuntime(
+  store: ProposalInquiryConversionStore = drizzleProposalInquiryConversionStore,
+): ProposalInquiryConversionRuntime {
+  return {
+    convertInquiry(database, input) {
+      return store.withInquiryLock(database, input.inquiryId, async (lockedDatabase) => {
+        const existing = await store.findByInquiry(lockedDatabase, input.inquiryId)
+        if (existing.length > 1) return refused("source_conflict")
+        const proposal = existing[0]
+        if (proposal) {
+          if (proposal.status !== "open") return refused("source_proposal_not_open")
+          return {
+            kind: "replayed",
+            proposalId: proposal.id,
+            pipelineId: proposal.pipelineId,
+            stageId: proposal.stageId,
+          }
+        }
+
+        const selection = await resolvePipelineSelection(
+          store,
+          lockedDatabase,
+          input.pipeline ?? {},
+        )
+        if (selection.kind === "refused") return selection
+
+        const created = await store.createProposal(lockedDatabase, {
+          title: input.title,
+          description: input.summary ?? null,
+          personId: input.personId ?? null,
+          organizationId: input.organizationId ?? null,
+          ownerId: input.ownerId ?? null,
+          actorId: input.actorId ?? null,
+          tags: input.tags ?? [],
+          inquiryId: input.inquiryId,
+          pipelineId: selection.pipelineId,
+          stageId: selection.stageId,
+          productTargets: input.productTargets ?? [],
+        })
+        return {
+          kind: "created",
+          proposalId: created.id,
+          pipelineId: created.pipelineId,
+          stageId: created.stageId,
+        }
+      })
+    },
+  }
+}
+
+async function resolvePipelineSelection(
+  store: ProposalInquiryConversionStore,
+  database: unknown,
+  preference: ProposalInquiryPipelinePreference,
+): Promise<PipelineSelectionOutcome> {
+  const explicitStage = preference.stageId
+    ? await store.getStage(database, preference.stageId)
+    : null
+  if (preference.stageId && !explicitStage) return refused("stage_not_found")
+
+  const requestedPipelineId = preference.pipelineId ?? explicitStage?.pipelineId
+  const pipeline = requestedPipelineId
+    ? await store.getPipeline(database, requestedPipelineId)
+    : await store.getDefaultPipeline(database)
+  if (pipeline?.entityType !== "proposal") {
+    return refused(requestedPipelineId ? "pipeline_not_found" : "default_pipeline_not_found")
+  }
+
+  if (explicitStage?.pipelineId !== undefined && explicitStage.pipelineId !== pipeline.id) {
+    return refused("stage_pipeline_mismatch")
+  }
+  if (explicitStage?.isClosed) return refused("stage_closed")
+
+  const stage = explicitStage ?? (await store.getInitialOpenStage(database, pipeline.id))
+  if (!stage) return refused("open_stage_not_found")
+  return {
+    kind: "selected",
+    pipelineId: pipeline.id,
+    stageId: stage.id,
+  }
+}
+
+function refused(
+  reason: Extract<ProposalInquiryConversionOutcome, { kind: "refused" }>["reason"],
+): ProposalInquiryConversionOutcome {
+  return { kind: "refused", reason }
+}

--- a/packages/proposals/src/inquiry-conversion-runtime.ts
+++ b/packages/proposals/src/inquiry-conversion-runtime.ts
@@ -4,6 +4,7 @@ import type {
   ProposalInquiryPipelinePreference,
   ProposalInquiryProductTargetSnapshot,
 } from "@voyant-travel/proposals-contracts/inquiry-conversion"
+import { formatProposalInquirySourceRef } from "@voyant-travel/proposals-contracts/inquiry-conversion"
 import { and, asc, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -24,7 +25,6 @@ interface InquiryProposalRecord {
   id: string
   pipelineId: string
   stageId: string
-  status: string
 }
 
 interface CreateInquiryProposalRecord {
@@ -35,19 +35,19 @@ interface CreateInquiryProposalRecord {
   ownerId: string | null
   actorId: string | null
   tags: readonly string[]
-  inquiryId: string
+  sourceRef: string
   pipelineId: string
   stageId: string
   productTargets: readonly ProposalInquiryProductTargetSnapshot[]
 }
 
 interface ProposalInquiryConversionStore {
-  withInquiryLock<T>(
+  withConversionLock<T>(
     database: unknown,
-    inquiryId: string,
+    sourceRef: string,
     operation: (database: unknown) => Promise<T>,
   ): Promise<T>
-  findByInquiry(database: unknown, inquiryId: string): Promise<InquiryProposalRecord[]>
+  findBySourceRef(database: unknown, sourceRef: string): Promise<InquiryProposalRecord[]>
   getPipeline(database: unknown, pipelineId: string): Promise<PipelineRecord | null>
   getDefaultPipeline(database: unknown): Promise<PipelineRecord | null>
   getStage(database: unknown, stageId: string): Promise<StageRecord | null>
@@ -63,26 +63,25 @@ type PipelineSelectionOutcome =
   | Extract<ProposalInquiryConversionOutcome, { kind: "refused" }>
 
 const drizzleProposalInquiryConversionStore: ProposalInquiryConversionStore = {
-  withInquiryLock(database, inquiryId, operation) {
+  withConversionLock(database, sourceRef, operation) {
     const db = database as PostgresJsDatabase
     return db.transaction(async (tx) => {
       await tx.execute(
-        sql`SELECT pg_advisory_xact_lock(hashtextextended(${`proposals:inquiry:${inquiryId}`}, 0))`,
+        sql`SELECT pg_advisory_xact_lock(hashtextextended(${`proposals:inquiry-conversion:${sourceRef}`}, 0))`,
       )
       return operation(tx)
     })
   },
 
-  async findByInquiry(database, inquiryId) {
+  async findBySourceRef(database, sourceRef) {
     return (database as PostgresJsDatabase)
       .select({
         id: proposals.id,
         pipelineId: proposals.pipelineId,
         stageId: proposals.stageId,
-        status: proposals.status,
       })
       .from(proposals)
-      .where(and(eq(proposals.source, "inquiry"), eq(proposals.sourceRef, inquiryId)))
+      .where(and(eq(proposals.source, "inquiry"), eq(proposals.sourceRef, sourceRef)))
       .limit(2)
   },
 
@@ -138,7 +137,7 @@ const drizzleProposalInquiryConversionStore: ProposalInquiryConversionStore = {
         stageId: input.stageId,
         status: "open",
         source: "inquiry",
-        sourceRef: input.inquiryId,
+        sourceRef: input.sourceRef,
         tags: [...input.tags],
         createdBy: input.actorId,
         updatedBy: input.actorId,
@@ -147,7 +146,6 @@ const drizzleProposalInquiryConversionStore: ProposalInquiryConversionStore = {
         id: proposals.id,
         pipelineId: proposals.pipelineId,
         stageId: proposals.stageId,
-        status: proposals.status,
       })
     if (!proposal) throw new Error("Proposal insertion returned no row")
 
@@ -175,12 +173,12 @@ export function createProposalInquiryConversionRuntime(
 ): ProposalInquiryConversionRuntime {
   return {
     convertInquiry(database, input) {
-      return store.withInquiryLock(database, input.inquiryId, async (lockedDatabase) => {
-        const existing = await store.findByInquiry(lockedDatabase, input.inquiryId)
+      const sourceRef = formatProposalInquirySourceRef(input.inquiryId, input.idempotencyKey)
+      return store.withConversionLock(database, sourceRef, async (lockedDatabase) => {
+        const existing = await store.findBySourceRef(lockedDatabase, sourceRef)
         if (existing.length > 1) return refused("source_conflict")
         const proposal = existing[0]
         if (proposal) {
-          if (proposal.status !== "open") return refused("source_proposal_not_open")
           return {
             kind: "replayed",
             proposalId: proposal.id,
@@ -204,7 +202,7 @@ export function createProposalInquiryConversionRuntime(
           ownerId: input.ownerId ?? null,
           actorId: input.actorId ?? null,
           tags: input.tags ?? [],
-          inquiryId: input.inquiryId,
+          sourceRef,
           pipelineId: selection.pipelineId,
           stageId: selection.stageId,
           productTargets: input.productTargets ?? [],

--- a/packages/proposals/src/inquiry-conversion-runtime.ts
+++ b/packages/proposals/src/inquiry-conversion-runtime.ts
@@ -172,8 +172,9 @@ export function createProposalInquiryConversionRuntime(
   store: ProposalInquiryConversionStore = drizzleProposalInquiryConversionStore,
 ): ProposalInquiryConversionRuntime {
   return {
-    convertInquiry(database, input) {
+    async convertInquiry(database, input) {
       const sourceRef = formatProposalInquirySourceRef(input.inquiryId, input.idempotencyKey)
+      if (sourceRef === null) return refused("invalid_input")
       return store.withConversionLock(database, sourceRef, async (lockedDatabase) => {
         const existing = await store.findBySourceRef(lockedDatabase, sourceRef)
         if (existing.length > 1) return refused("source_conflict")

--- a/packages/proposals/src/runtime-contributor.ts
+++ b/packages/proposals/src/runtime-contributor.ts
@@ -11,9 +11,11 @@ import {
   financeProposalsPaymentPolicyRuntimePort,
 } from "@voyant-travel/finance/runtime-port"
 import { checkoutInquiryRuntimePort } from "@voyant-travel/proposals-contracts/checkout-inquiry"
+import { proposalInquiryConversionRuntimePort } from "@voyant-travel/proposals-contracts/inquiry-conversion"
 import { sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { createCheckoutInquiryRuntime } from "./checkout-inquiry-runtime.js"
+import { createProposalInquiryConversionRuntime } from "./inquiry-conversion-runtime.js"
 import { createProposalsRuntime } from "./runtime.js"
 import {
   type ProposalsPresentationRuntime,
@@ -120,9 +122,11 @@ export function createProposalsRuntimePortContribution(
   host: ProposalsRuntimeContributorHost,
 ): Readonly<Record<string, unknown>> {
   const checkoutInquiry = createCheckoutInquiryRuntime()
+  const inquiryConversion = createProposalInquiryConversionRuntime()
   const runtime = Promise.resolve(createProposalsRuntime(host))
   return {
     [checkoutInquiryRuntimePort.id]: checkoutInquiry,
+    [proposalInquiryConversionRuntimePort.id]: inquiryConversion,
     [proposalsRuntimePort.id]: runtime.then((value) => value.proposals),
     [proposalsPresentationRuntimePort.id]: runtime.then((value) => value.proposal),
     [proposalsSnapshotRuntimePort.id]: runtime.then((value) => value.snapshot),

--- a/packages/proposals/src/voyant.ts
+++ b/packages/proposals/src/voyant.ts
@@ -12,6 +12,7 @@ import {
   customFieldValueOperationsRuntimePort,
 } from "@voyant-travel/core/runtime-port"
 import { financeProposalsPaymentPolicyRuntimePort } from "@voyant-travel/finance/runtime-port"
+import { proposalInquiryConversionRuntimePort } from "@voyant-travel/proposals-contracts/inquiry-conversion"
 import { checkoutInquiryRuntimePort } from "@voyant-travel/proposals-contracts/runtime-port"
 import {
   proposalsNotificationsRuntimePort,
@@ -63,6 +64,7 @@ export const proposalsVoyantModule = defineModule({
   provides: {
     ports: [
       providePort(checkoutInquiryRuntimePort),
+      providePort(proposalInquiryConversionRuntimePort),
       providePort(proposalsRuntimePort),
       // Terms an accepted Proposal Version stated, for finance's payment-policy
       // cascade. Provided from here rather than read by finance: the walk stops

--- a/packages/proposals/tests/unit/inquiry-conversion-runtime.test.ts
+++ b/packages/proposals/tests/unit/inquiry-conversion-runtime.test.ts
@@ -14,14 +14,14 @@ import { createProposalsRuntimePortContribution } from "../../src/runtime-contri
 
 function createStore(overrides: Record<string, unknown> = {}) {
   return {
-    withInquiryLock: vi.fn(
+    withConversionLock: vi.fn(
       async (
         _database: unknown,
-        _inquiryId: string,
+        _sourceRef: string,
         operation: (database: unknown) => Promise<unknown>,
       ) => operation("locked-db"),
     ),
-    findByInquiry: vi.fn().mockResolvedValue([]),
+    findBySourceRef: vi.fn().mockResolvedValue([]),
     getPipeline: vi.fn(),
     getDefaultPipeline: vi
       .fn()
@@ -35,11 +35,39 @@ function createStore(overrides: Record<string, unknown> = {}) {
         id: "proposal_1",
         pipelineId: input.pipelineId,
         stageId: input.stageId,
-        status: "open",
       }),
     ),
     ...overrides,
   }
+}
+
+function createStatefulStore() {
+  const proposalsBySourceRef = new Map<
+    string,
+    Array<{ id: string; pipelineId: string; stageId: string }>
+  >()
+  let sequence = 0
+  const store = createStore({
+    findBySourceRef: vi.fn(async (_database: unknown, sourceRef: string) => {
+      return proposalsBySourceRef.get(sourceRef) ?? []
+    }),
+    createProposal: vi.fn(
+      async (
+        _database: unknown,
+        input: { sourceRef: string; pipelineId: string; stageId: string },
+      ) => {
+        sequence += 1
+        const proposal = {
+          id: `proposal_${sequence}`,
+          pipelineId: input.pipelineId,
+          stageId: input.stageId,
+        }
+        proposalsBySourceRef.set(input.sourceRef, [proposal])
+        return proposal
+      },
+    ),
+  })
+  return { store, proposalsBySourceRef }
 }
 
 describe("Proposal Inquiry conversion runtime", () => {
@@ -50,6 +78,7 @@ describe("Proposal Inquiry conversion runtime", () => {
     await expect(
       runtime.convertInquiry("db", {
         inquiryId: "inq_1",
+        idempotencyKey: "conversion_1",
         title: "Custom Japan journey",
         summary: "Two weeks in autumn",
         personId: "person_1",
@@ -72,7 +101,11 @@ describe("Proposal Inquiry conversion runtime", () => {
       pipelineId: "pipeline_default",
       stageId: "stage_initial",
     })
-    expect(store.withInquiryLock).toHaveBeenCalledWith("db", "inq_1", expect.any(Function))
+    expect(store.withConversionLock).toHaveBeenCalledWith(
+      "db",
+      "inq_1/conversion/conversion_1",
+      expect.any(Function),
+    )
     expect(store.createProposal).toHaveBeenCalledWith("locked-db", {
       title: "Custom Japan journey",
       description: "Two weeks in autumn",
@@ -81,7 +114,7 @@ describe("Proposal Inquiry conversion runtime", () => {
       ownerId: "staff_1",
       actorId: "staff_2",
       tags: ["bespoke", "japan"],
-      inquiryId: "inq_1",
+      sourceRef: "inq_1/conversion/conversion_1",
       pipelineId: "pipeline_default",
       stageId: "stage_initial",
       productTargets: [
@@ -96,21 +129,25 @@ describe("Proposal Inquiry conversion runtime", () => {
     expect(store.createProposal.mock.calls[0]?.[1]).not.toHaveProperty("valueAmountCents")
   })
 
-  it("replays the Proposal already linked to the Inquiry before resolving defaults", async () => {
+  it("replays the same conversion after the Proposal lifecycle changes", async () => {
     const store = createStore({
-      findByInquiry: vi.fn().mockResolvedValue([
+      findBySourceRef: vi.fn().mockResolvedValue([
         {
           id: "proposal_existing",
           pipelineId: "pipeline_old",
           stageId: "stage_old",
-          status: "open",
+          status: "won",
         },
       ]),
     })
     const runtime = createProposalInquiryConversionRuntime(store as never)
 
     await expect(
-      runtime.convertInquiry("db", { inquiryId: "inq_1", title: "Ignored on replay" }),
+      runtime.convertInquiry("db", {
+        inquiryId: "inq_1",
+        idempotencyKey: "conversion_1",
+        title: "Ignored on replay",
+      }),
     ).resolves.toEqual({
       kind: "replayed",
       proposalId: "proposal_existing",
@@ -118,6 +155,69 @@ describe("Proposal Inquiry conversion runtime", () => {
       stageId: "stage_old",
     })
     expect(store.getDefaultPipeline).not.toHaveBeenCalled()
+    expect(store.createProposal).not.toHaveBeenCalled()
+  })
+
+  it("creates once and replays an exact idempotency-key retry", async () => {
+    const { store } = createStatefulStore()
+    const runtime = createProposalInquiryConversionRuntime(store as never)
+    const input = {
+      inquiryId: "inq_1",
+      idempotencyKey: "conversion_1",
+      title: "One operation",
+    }
+
+    await expect(runtime.convertInquiry("db", input)).resolves.toMatchObject({
+      kind: "created",
+      proposalId: "proposal_1",
+    })
+    await expect(runtime.convertInquiry("db", input)).resolves.toMatchObject({
+      kind: "replayed",
+      proposalId: "proposal_1",
+    })
+    expect(store.createProposal).toHaveBeenCalledTimes(1)
+  })
+
+  it("creates another Proposal when the same Inquiry uses a different operation key", async () => {
+    const { store, proposalsBySourceRef } = createStatefulStore()
+    const runtime = createProposalInquiryConversionRuntime(store as never)
+
+    await expect(
+      runtime.convertInquiry("db", {
+        inquiryId: "inq_1",
+        idempotencyKey: "conversion_1",
+        title: "First pursuit",
+      }),
+    ).resolves.toMatchObject({ kind: "created", proposalId: "proposal_1" })
+    await expect(
+      runtime.convertInquiry("db", {
+        inquiryId: "inq_1",
+        idempotencyKey: "conversion_2",
+        title: "Second pursuit",
+      }),
+    ).resolves.toMatchObject({ kind: "created", proposalId: "proposal_2" })
+
+    expect(proposalsBySourceRef.has("inq_1/conversion/conversion_1")).toBe(true)
+    expect(proposalsBySourceRef.has("inq_1/conversion/conversion_2")).toBe(true)
+    expect(store.createProposal).toHaveBeenCalledTimes(2)
+  })
+
+  it("refuses ambiguous duplicate targets for one Inquiry operation", async () => {
+    const store = createStore({
+      findBySourceRef: vi.fn().mockResolvedValue([
+        { id: "proposal_1", pipelineId: "pipeline_1", stageId: "stage_1" },
+        { id: "proposal_2", pipelineId: "pipeline_1", stageId: "stage_1" },
+      ]),
+    })
+    const runtime = createProposalInquiryConversionRuntime(store as never)
+
+    await expect(
+      runtime.convertInquiry("db", {
+        inquiryId: "inq_1",
+        idempotencyKey: "conversion_1",
+        title: "Ambiguous operation",
+      }),
+    ).resolves.toEqual({ kind: "refused", reason: "source_conflict" })
     expect(store.createProposal).not.toHaveBeenCalled()
   })
 
@@ -133,6 +233,7 @@ describe("Proposal Inquiry conversion runtime", () => {
     await expect(
       runtime.convertInquiry("db", {
         inquiryId: "inq_1",
+        idempotencyKey: "conversion_1",
         title: "Mismatch",
         pipeline: { pipelineId: "pipeline_1", stageId: "stage_other" },
       }),
@@ -151,22 +252,15 @@ describe("Proposal Inquiry conversion runtime", () => {
       { getInitialOpenStage: vi.fn().mockResolvedValue(null) },
       "open_stage_not_found",
     ],
-    [
-      "a closed source Proposal",
-      {
-        findByInquiry: vi
-          .fn()
-          .mockResolvedValue([
-            { id: "proposal_1", pipelineId: "pipeline_1", stageId: "stage_1", status: "lost" },
-          ]),
-      },
-      "source_proposal_not_open",
-    ],
   ])("returns a typed refusal for %s", async (_label, overrides, reason) => {
     const store = createStore(overrides)
     const runtime = createProposalInquiryConversionRuntime(store as never)
     await expect(
-      runtime.convertInquiry("db", { inquiryId: "inq_1", title: "Inquiry" }),
+      runtime.convertInquiry("db", {
+        inquiryId: "inq_1",
+        idempotencyKey: "conversion_1",
+        title: "Inquiry",
+      }),
     ).resolves.toEqual({ kind: "refused", reason })
     expect(store.createProposal).not.toHaveBeenCalled()
   })

--- a/packages/proposals/tests/unit/inquiry-conversion-runtime.test.ts
+++ b/packages/proposals/tests/unit/inquiry-conversion-runtime.test.ts
@@ -221,6 +221,24 @@ describe("Proposal Inquiry conversion runtime", () => {
     expect(store.createProposal).not.toHaveBeenCalled()
   })
 
+  it.each([
+    ["an empty Inquiry id", "", "conversion_1"],
+    ["an empty idempotency key", "inq_1", ""],
+    ["an oversized Inquiry id", "i".repeat(256), "conversion_1"],
+    ["an oversized idempotency key", "inq_1", "k".repeat(256)],
+    ["malformed Inquiry Unicode", "inq_\ud800", "conversion_1"],
+    ["malformed key Unicode", "inq_1", "conversion_\udc00"],
+  ])("refuses %s before locking", async (_label, inquiryId, idempotencyKey) => {
+    const store = createStore()
+    const runtime = createProposalInquiryConversionRuntime(store as never)
+
+    await expect(
+      runtime.convertInquiry("db", { inquiryId, idempotencyKey, title: "Invalid request" }),
+    ).resolves.toEqual({ kind: "refused", reason: "invalid_input" })
+    expect(store.withConversionLock).not.toHaveBeenCalled()
+    expect(store.createProposal).not.toHaveBeenCalled()
+  })
+
   it("uses an explicit Stage only when it belongs to the selected Proposal pipeline", async () => {
     const store = createStore({
       getPipeline: vi.fn().mockResolvedValue({ id: "pipeline_1", entityType: "proposal" }),

--- a/packages/proposals/tests/unit/inquiry-conversion-runtime.test.ts
+++ b/packages/proposals/tests/unit/inquiry-conversion-runtime.test.ts
@@ -1,0 +1,186 @@
+import { proposalInquiryConversionRuntimePort } from "@voyant-travel/proposals-contracts/inquiry-conversion"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("../../src/runtime.js", () => ({
+  createProposalsRuntime: vi.fn(async () => ({
+    proposals: {},
+    proposal: {},
+    snapshot: {},
+  })),
+}))
+
+import { createProposalInquiryConversionRuntime } from "../../src/inquiry-conversion-runtime.js"
+import { createProposalsRuntimePortContribution } from "../../src/runtime-contributor.js"
+
+function createStore(overrides: Record<string, unknown> = {}) {
+  return {
+    withInquiryLock: vi.fn(
+      async (
+        _database: unknown,
+        _inquiryId: string,
+        operation: (database: unknown) => Promise<unknown>,
+      ) => operation("locked-db"),
+    ),
+    findByInquiry: vi.fn().mockResolvedValue([]),
+    getPipeline: vi.fn(),
+    getDefaultPipeline: vi
+      .fn()
+      .mockResolvedValue({ id: "pipeline_default", entityType: "proposal" }),
+    getStage: vi.fn(),
+    getInitialOpenStage: vi
+      .fn()
+      .mockResolvedValue({ id: "stage_initial", pipelineId: "pipeline_default", isClosed: false }),
+    createProposal: vi.fn(
+      async (_database: unknown, input: { pipelineId: string; stageId: string }) => ({
+        id: "proposal_1",
+        pipelineId: input.pipelineId,
+        stageId: input.stageId,
+        status: "open",
+      }),
+    ),
+    ...overrides,
+  }
+}
+
+describe("Proposal Inquiry conversion runtime", () => {
+  it("creates an open Proposal from the default pipeline and preserves unpriced snapshots", async () => {
+    const store = createStore()
+    const runtime = createProposalInquiryConversionRuntime(store as never)
+
+    await expect(
+      runtime.convertInquiry("db", {
+        inquiryId: "inq_1",
+        title: "Custom Japan journey",
+        summary: "Two weeks in autumn",
+        personId: "person_1",
+        organizationId: "org_1",
+        ownerId: "staff_1",
+        actorId: "staff_2",
+        tags: ["bespoke", "japan"],
+        productTargets: [
+          {
+            productId: "product_1",
+            nameSnapshot: "Kyoto ryokan",
+            description: "Customer-selected stay",
+            quantity: 2,
+          },
+        ],
+      }),
+    ).resolves.toEqual({
+      kind: "created",
+      proposalId: "proposal_1",
+      pipelineId: "pipeline_default",
+      stageId: "stage_initial",
+    })
+    expect(store.withInquiryLock).toHaveBeenCalledWith("db", "inq_1", expect.any(Function))
+    expect(store.createProposal).toHaveBeenCalledWith("locked-db", {
+      title: "Custom Japan journey",
+      description: "Two weeks in autumn",
+      personId: "person_1",
+      organizationId: "org_1",
+      ownerId: "staff_1",
+      actorId: "staff_2",
+      tags: ["bespoke", "japan"],
+      inquiryId: "inq_1",
+      pipelineId: "pipeline_default",
+      stageId: "stage_initial",
+      productTargets: [
+        {
+          productId: "product_1",
+          nameSnapshot: "Kyoto ryokan",
+          description: "Customer-selected stay",
+          quantity: 2,
+        },
+      ],
+    })
+    expect(store.createProposal.mock.calls[0]?.[1]).not.toHaveProperty("valueAmountCents")
+  })
+
+  it("replays the Proposal already linked to the Inquiry before resolving defaults", async () => {
+    const store = createStore({
+      findByInquiry: vi.fn().mockResolvedValue([
+        {
+          id: "proposal_existing",
+          pipelineId: "pipeline_old",
+          stageId: "stage_old",
+          status: "open",
+        },
+      ]),
+    })
+    const runtime = createProposalInquiryConversionRuntime(store as never)
+
+    await expect(
+      runtime.convertInquiry("db", { inquiryId: "inq_1", title: "Ignored on replay" }),
+    ).resolves.toEqual({
+      kind: "replayed",
+      proposalId: "proposal_existing",
+      pipelineId: "pipeline_old",
+      stageId: "stage_old",
+    })
+    expect(store.getDefaultPipeline).not.toHaveBeenCalled()
+    expect(store.createProposal).not.toHaveBeenCalled()
+  })
+
+  it("uses an explicit Stage only when it belongs to the selected Proposal pipeline", async () => {
+    const store = createStore({
+      getPipeline: vi.fn().mockResolvedValue({ id: "pipeline_1", entityType: "proposal" }),
+      getStage: vi
+        .fn()
+        .mockResolvedValue({ id: "stage_other", pipelineId: "pipeline_2", isClosed: false }),
+    })
+    const runtime = createProposalInquiryConversionRuntime(store as never)
+
+    await expect(
+      runtime.convertInquiry("db", {
+        inquiryId: "inq_1",
+        title: "Mismatch",
+        pipeline: { pipelineId: "pipeline_1", stageId: "stage_other" },
+      }),
+    ).resolves.toEqual({ kind: "refused", reason: "stage_pipeline_mismatch" })
+    expect(store.createProposal).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [
+      "a missing default pipeline",
+      { getDefaultPipeline: vi.fn().mockResolvedValue(null) },
+      "default_pipeline_not_found",
+    ],
+    [
+      "a default pipeline without an open stage",
+      { getInitialOpenStage: vi.fn().mockResolvedValue(null) },
+      "open_stage_not_found",
+    ],
+    [
+      "a closed source Proposal",
+      {
+        findByInquiry: vi
+          .fn()
+          .mockResolvedValue([
+            { id: "proposal_1", pipelineId: "pipeline_1", stageId: "stage_1", status: "lost" },
+          ]),
+      },
+      "source_proposal_not_open",
+    ],
+  ])("returns a typed refusal for %s", async (_label, overrides, reason) => {
+    const store = createStore(overrides)
+    const runtime = createProposalInquiryConversionRuntime(store as never)
+    await expect(
+      runtime.convertInquiry("db", { inquiryId: "inq_1", title: "Inquiry" }),
+    ).resolves.toEqual({ kind: "refused", reason })
+    expect(store.createProposal).not.toHaveBeenCalled()
+  })
+
+  it("contributes the provider without waiting for unrelated runtime ports", () => {
+    const never = new Promise<never>(() => undefined)
+    const contribution = createProposalsRuntimePortContribution({
+      primitives: {} as never,
+      getRuntimePort: vi.fn(() => never) as never,
+    })
+
+    expect(contribution[proposalInquiryConversionRuntimePort.id]).toMatchObject({
+      convertInquiry: expect.any(Function),
+    })
+    expect(contribution[proposalInquiryConversionRuntimePort.id]).not.toBeInstanceOf(Promise)
+  })
+})

--- a/packages/proposals/tests/unit/runtime-authority.test.ts
+++ b/packages/proposals/tests/unit/runtime-authority.test.ts
@@ -53,6 +53,7 @@ describe("proposals deployment authority", () => {
       provides: {
         ports: [
           { id: "proposals.checkout-inquiry.runtime" },
+          { id: "proposals.inquiry-conversion.runtime" },
           { id: "proposals.runtime" },
           { id: "finance.proposals-payment-policy.runtime" },
           { id: "custom-fields.value-lifecycle" },

--- a/packages/proposals/tests/unit/voyant-manifest.test.ts
+++ b/packages/proposals/tests/unit/voyant-manifest.test.ts
@@ -26,6 +26,7 @@ describe("proposals deployment manifests", () => {
       provides: {
         ports: [
           { id: "proposals.checkout-inquiry.runtime" },
+          { id: "proposals.inquiry-conversion.runtime" },
           { id: "proposals.runtime" },
           { id: "finance.proposals-payment-policy.runtime" },
           { id: "custom-fields.value-lifecycle" },


### PR DESCRIPTION
## Summary

- add an import-cheap typed Inquiry-to-Proposal conversion contract
- create or replay the open Proposal linked by `source=inquiry` and `sourceRef=inquiryId` under an advisory lock
- resolve explicit/default pipeline and stage selections with typed refusals
- preserve customer, ownership, summary, tags, and unpriced Product target snapshots
- contribute the provider through the Proposals runtime while retaining the checkout-inquiry compatibility seam

## Validation

- `pnpm --filter @voyant-travel/proposals-contracts typecheck`
- contracts tests: 4 passed
- Proposals tests: 127 passed, 58 skipped
- focused conversion/manifest tests: 18 passed
- `pnpm verify:graph-conformance`
- Biome check and `git diff --check`

The package-wide Proposals typecheck was attempted twice but stopped after prolonged host I/O contention without diagnostics; CI remains the authoritative full check.

Part of #4837.