### PR TITLE
feat(inbox): add two-way email conversations

### DIFF
--- a/.changeset/bright-inbox-conversations.md
+++ b/.changeset/bright-inbox-conversations.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/conversations-contracts": minor
+"@voyant-travel/conversations": minor
+"@voyant-travel/conversations-react": minor
+"@voyant-travel/notifications": patch
+"@voyant-travel/operator-standard": patch
+"@voyant-travel/schema-kit": patch
+---
+
+Add the provider-neutral two-way email Inbox, including durable inbound replay,
+exact email threading, transactional outbound admission, and the minimal
+operator conversation surface.

--- a/apps/operator/package.json
+++ b/apps/operator/package.json
@@ -52,6 +52,8 @@
     "@voyant-travel/commerce": "workspace:^",
     "@voyant-travel/commerce-react": "workspace:^",
     "@voyant-travel/connect-sdk": "0.9.1",
+    "@voyant-travel/conversations": "workspace:^",
+    "@voyant-travel/conversations-react": "workspace:^",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/cruises": "workspace:^",
     "@voyant-travel/cruises-react": "workspace:^",

--- a/packages/conversations-contracts/package.json
+++ b/packages/conversations-contracts/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@voyant-travel/conversations-contracts",
+  "version": "0.1.0",
+  "description": "Provider-neutral inbound message contracts for Voyant Conversations.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": { ".": "./src/index.ts" },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "test": "vitest run",
+    "lint": "biome check src/"
+  },
+  "dependencies": { "zod": "catalog:" },
+  "devDependencies": {
+    "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js", "default": "./dist/index.js" }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyant-travel/voyant.git",
+    "directory": "packages/conversations-contracts"
+  }
+}

--- a/packages/conversations-contracts/src/index.ts
+++ b/packages/conversations-contracts/src/index.ts
@@ -1,0 +1,126 @@
+import { z } from "zod"
+
+export const messageAddressSchema = z.object({
+  address: z.string().email(),
+  name: z.string().trim().min(1).nullable().optional(),
+})
+
+export const inboundAttachmentSchema = z.object({
+  externalId: z.string().min(1),
+  filename: z.string().min(1),
+  contentType: z.string().min(1),
+  size: z.number().int().nonnegative(),
+  privateHandle: z.string().min(1),
+  inlineContentId: z.string().min(1).nullable().optional(),
+})
+
+export const inboundEmailEnvelopeV1Schema = z.object({
+  version: z.literal("1"),
+  sourceId: z.string().min(1),
+  externalEnvelopeId: z.string().min(1),
+  externalMessageId: z.string().min(1),
+  sender: messageAddressSchema,
+  to: z.array(messageAddressSchema).min(1),
+  cc: z.array(messageAddressSchema).default([]),
+  replyTo: z.array(messageAddressSchema).default([]),
+  subject: z.string().nullable(),
+  text: z.string().nullable(),
+  html: z.string().nullable(),
+  attachments: z.array(inboundAttachmentSchema).default([]),
+  threading: z.object({
+    messageId: z.string().min(1).nullable(),
+    inReplyTo: z.string().min(1).nullable(),
+    references: z.array(z.string().min(1)).default([]),
+  }),
+  occurredAt: z.string().datetime({ offset: true }),
+})
+
+export type InboundEmailEnvelopeV1 = z.infer<typeof inboundEmailEnvelopeV1Schema>
+export type InboundAttachment = z.infer<typeof inboundAttachmentSchema>
+
+export interface IngressItemRef {
+  id: string
+}
+
+export interface IngressListPage {
+  items: readonly IngressItemRef[]
+  cursor?: string
+}
+
+/**
+ * Provider-neutral pull boundary. A source retains an item until `ack` returns,
+ * so committing an envelope and crashing before acknowledgement is safe.
+ */
+export interface ConversationIngressSource {
+  readonly id: string
+  list(input: { cursor?: string; limit: number }): Promise<IngressListPage>
+  fetch(ref: IngressItemRef): Promise<InboundEmailEnvelopeV1>
+  ack(ref: IngressItemRef): Promise<void>
+}
+
+export interface ConversationRenderedServiceMessage {
+  channelAccountId: string
+  target: { type: "@voyant-travel/conversations#part"; id: string }
+  purpose: "conversation-reply"
+  idempotencyKey: string
+  to: string
+  subject?: string
+  text?: string
+  sanitizedHtml?: string
+  thread: { threadId: string; replyToDeliveryId?: string }
+  metadata: {
+    replyAlias: string
+    inReplyTo: string | null
+    references: readonly string[]
+  }
+}
+
+export interface ConversationMessageAdmissionResult {
+  deliveryId: string
+  state:
+    | "pending"
+    | "accepted"
+    | "delivered"
+    | "failed"
+    | "bounced"
+    | "complained"
+    | "suppressed"
+    | "cancelled"
+}
+
+/** Notifications implements this consumer contract on the caller's transaction. */
+export interface ConversationsRenderedMessageAdmission {
+  admitRenderedServiceMessage(
+    db: unknown,
+    message: ConversationRenderedServiceMessage,
+    context?: { bindings?: unknown },
+  ): Promise<ConversationMessageAdmissionResult>
+}
+
+/** Stable, order-independent JSON used to detect replay payload drift. */
+export function canonicalEnvelopePayload(envelope: InboundEmailEnvelopeV1): string {
+  return canonicalJson(inboundEmailEnvelopeV1Schema.parse(envelope))
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
+      .join(",")}}`
+  }
+  return JSON.stringify(value)
+}
+
+/** Canonical comparison form for RFC message identifiers. */
+export function canonicalMessageId(value: string): string {
+  const trimmed = value.trim()
+  return trimmed.startsWith("<") && trimmed.endsWith(">")
+    ? trimmed.slice(1, -1).trim().toLowerCase()
+    : trimmed.toLowerCase()
+}
+
+export function normalizeEmailAddress(value: string): string {
+  return value.trim().toLowerCase()
+}

--- a/packages/conversations-contracts/tests/contracts.test.ts
+++ b/packages/conversations-contracts/tests/contracts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import {
+  canonicalEnvelopePayload,
+  canonicalMessageId,
+  inboundEmailEnvelopeV1Schema,
+} from "../src/index.js"
+
+const envelope = {
+  version: "1" as const,
+  sourceId: "fixture-source",
+  externalEnvelopeId: "envelope-1",
+  externalMessageId: "external-1",
+  sender: { address: "customer@example.test" },
+  to: [{ address: "inbox@example.test" }],
+  cc: [],
+  replyTo: [],
+  subject: "A question",
+  text: "Hello",
+  html: null,
+  attachments: [],
+  threading: { messageId: "<message-1@example.test>", inReplyTo: null, references: [] },
+  occurredAt: "2026-08-17T10:00:00.000Z",
+}
+
+describe("provider-neutral inbound email envelope", () => {
+  it("accepts the versioned transport-free shape", () => {
+    expect(inboundEmailEnvelopeV1Schema.parse(envelope)).toEqual(envelope)
+  })
+
+  it("canonicalizes object key order and message identifiers", () => {
+    expect(canonicalEnvelopePayload(envelope)).toBe(canonicalEnvelopePayload({ ...envelope }))
+    expect(canonicalMessageId(" <Message-1@Example.Test> ")).toBe("message-1@example.test")
+  })
+})

--- a/packages/conversations-contracts/tsconfig.build.json
+++ b/packages/conversations-contracts/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}

--- a/packages/conversations-contracts/tsconfig.json
+++ b/packages/conversations-contracts/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@voyant-travel/voyant-typescript-config/base.json",
+  "compilerOptions": { "composite": false, "module": "ESNext", "moduleResolution": "Bundler" },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/conversations-contracts/tsconfig.typecheck.json
+++ b/packages/conversations-contracts/tsconfig.typecheck.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": { "noEmit": true }
+}

--- a/packages/conversations-react/package.json
+++ b/packages/conversations-react/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@voyant-travel/conversations-react",
+  "version": "0.1.0",
+  "description": "Minimal React Inbox for Voyant Conversations.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": { ".": "./src/index.ts", "./admin": "./src/admin/index.tsx" },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "test": "vitest run --passWithNoTests",
+    "lint": "biome check src/"
+  },
+  "peerDependencies": {
+    "@voyant-travel/admin": "workspace:^",
+    "@voyant-travel/react": "workspace:^",
+    "react": "^19.0.0"
+  },
+  "dependencies": { "lucide-react": "^1.23.0" },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@voyant-travel/admin": "workspace:^",
+    "@voyant-travel/react": "workspace:^",
+    "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "react": "^19.2.7",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js", "default": "./dist/index.js" },
+      "./admin": { "types": "./dist/admin/index.d.ts", "import": "./dist/admin/index.js", "default": "./dist/admin/index.js" }
+    },
+    "main": "./dist/index.js", "types": "./dist/index.d.ts"
+  },
+  "repository": { "type": "git", "url": "https://github.com/voyant-travel/voyant.git", "directory": "packages/conversations-react" },
+  "private": true
+}

--- a/packages/conversations-react/src/admin/conversation-page.tsx
+++ b/packages/conversations-react/src/admin/conversation-page.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import type { AdminRoutePageProps } from "@voyant-travel/admin"
+import { useVoyantReactContext } from "@voyant-travel/react"
+import { type FormEvent, useEffect, useState } from "react"
+import { conversationsApi } from "../api.js"
+import type { InboxConversationDetail } from "../types.js"
+
+export default function ConversationPage({ params }: AdminRoutePageProps) {
+  const id = params.id ?? ""
+  const { baseUrl, fetcher } = useVoyantReactContext()
+  const [detail, setDetail] = useState<InboxConversationDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  useEffect(() => {
+    conversationsApi
+      .get(fetcher, baseUrl, id)
+      .then(setDetail)
+      .catch((cause) => setError(String(cause)))
+    conversationsApi.markRead(fetcher, baseUrl, id).catch(() => undefined)
+  }, [baseUrl, fetcher, id])
+  async function reply(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = new FormData(event.currentTarget)
+    try {
+      const part = await conversationsApi.reply(fetcher, baseUrl, id, {
+        channelAccountId: String(form.get("channelAccountId")),
+        text: String(form.get("text")),
+        idempotencyKey: crypto.randomUUID(),
+      })
+      setDetail((current) => (current ? { ...current, parts: [...current.parts, part] } : current))
+      event.currentTarget.reset()
+    } catch (cause) {
+      setError(String(cause))
+    }
+  }
+  if (!detail) return <main className="p-6">{error ?? "Loading conversation…"}</main>
+  return (
+    <main className="space-y-6 p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">{detail.conversation.subject ?? "No subject"}</h1>
+        <p className="text-sm text-muted-foreground">{detail.conversation.customerAddress}</p>
+      </header>
+      <ol className="space-y-3">
+        {detail.parts.map((part) => (
+          <li
+            key={part.id}
+            className={`max-w-2xl rounded-md border p-4 ${part.direction === "outbound" ? "ml-auto bg-muted/40" : ""}`}
+          >
+            <div className="mb-2 flex justify-between text-xs text-muted-foreground">
+              <span>{part.senderAddress}</span>
+              <span>{part.deliveryStatus}</span>
+            </div>
+            <p className="whitespace-pre-wrap">{part.textBody ?? "(HTML message)"}</p>
+          </li>
+        ))}
+      </ol>
+      <form className="grid max-w-2xl gap-3" onSubmit={reply}>
+        <input
+          required
+          name="channelAccountId"
+          placeholder="Channel account ID"
+          className="rounded border p-2"
+        />
+        <textarea
+          required
+          name="text"
+          placeholder="Reply"
+          className="min-h-28 rounded border p-2"
+        />
+        <button
+          className="justify-self-start rounded bg-primary px-4 py-2 text-primary-foreground"
+          type="submit"
+        >
+          Send reply
+        </button>
+        {error ? <p role="alert">{error}</p> : null}
+      </form>
+    </main>
+  )
+}

--- a/packages/conversations-react/src/admin/inbox-page.tsx
+++ b/packages/conversations-react/src/admin/inbox-page.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import { useAdminHref } from "@voyant-travel/admin"
+import { useVoyantReactContext } from "@voyant-travel/react"
+import { type FormEvent, useEffect, useState } from "react"
+import { conversationsApi } from "../api.js"
+import type { InboxConversation } from "../types.js"
+
+export function InboxPage() {
+  const { baseUrl, fetcher } = useVoyantReactContext()
+  const [items, setItems] = useState<InboxConversation[]>([])
+  const [error, setError] = useState<string | null>(null)
+  useEffect(() => {
+    conversationsApi
+      .list(fetcher, baseUrl)
+      .then(setItems)
+      .catch((cause) => setError(String(cause)))
+  }, [baseUrl, fetcher])
+  return (
+    <main className="space-y-6 p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Inbox</h1>
+        <p className="text-sm text-muted-foreground">Customer email conversations</p>
+      </header>
+      {error ? <p role="alert">{error}</p> : null}
+      <section className="divide-y rounded-md border" aria-label="Conversations">
+        {items.map((item) => (
+          <ConversationRow key={item.id} item={item} />
+        ))}
+        {items.length === 0 && !error ? (
+          <p className="p-6 text-sm text-muted-foreground">No conversations yet.</p>
+        ) : null}
+      </section>
+      <StartConversation onStarted={(item) => setItems((current) => [item, ...current])} />
+    </main>
+  )
+}
+
+function ConversationRow({ item }: { item: InboxConversation }) {
+  const resolveHref = useAdminHref()
+  const href = resolveHref("conversation.detail", { id: item.id })
+  return (
+    <a className="block p-4 hover:bg-muted/50" href={href}>
+      <div className="flex justify-between gap-4">
+        <strong>{item.subject ?? item.suggestedSubject ?? "No subject"}</strong>
+        <time className="text-xs">{new Date(item.lastPartAt).toLocaleString()}</time>
+      </div>
+      <div className="flex justify-between text-sm text-muted-foreground">
+        <span>{item.customerAddress}</span>
+        <span>{item.unreadCount > 0 ? `${item.unreadCount} unread` : item.status}</span>
+      </div>
+    </a>
+  )
+}
+
+function StartConversation({ onStarted }: { onStarted(item: InboxConversation): void }) {
+  const { baseUrl, fetcher } = useVoyantReactContext()
+  const [open, setOpen] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = new FormData(event.currentTarget)
+    try {
+      const detail = await conversationsApi.start(fetcher, baseUrl, {
+        personRef: String(form.get("personRef")),
+        contactPointRef: String(form.get("contactPointRef")),
+        channelAccountId: String(form.get("channelAccountId")),
+        fromAddress: String(form.get("fromAddress")),
+        subject: String(form.get("subject")) || null,
+        text: String(form.get("text")),
+        idempotencyKey: crypto.randomUUID(),
+      })
+      onStarted(detail.conversation)
+      setOpen(false)
+    } catch (cause) {
+      setError(String(cause))
+    }
+  }
+  if (!open)
+    return (
+      <button type="button" className="rounded-md border px-3 py-2" onClick={() => setOpen(true)}>
+        Start conversation
+      </button>
+    )
+  return (
+    <form className="grid max-w-xl gap-3 rounded-md border p-4" onSubmit={submit}>
+      <h2 className="font-medium">New email conversation</h2>
+      <input
+        required
+        name="personRef"
+        placeholder="Person reference"
+        className="rounded border p-2"
+      />
+      <input
+        required
+        name="contactPointRef"
+        placeholder="Email contact point reference"
+        className="rounded border p-2"
+      />
+      <input
+        required
+        name="channelAccountId"
+        placeholder="Channel account ID"
+        className="rounded border p-2"
+      />
+      <input
+        required
+        name="fromAddress"
+        type="email"
+        placeholder="Sending address"
+        className="rounded border p-2"
+      />
+      <input name="subject" placeholder="Subject" className="rounded border p-2" />
+      <textarea
+        required
+        name="text"
+        placeholder="Message"
+        className="min-h-24 rounded border p-2"
+      />
+      {error ? <p role="alert">{error}</p> : null}
+      <div className="flex gap-2">
+        <button className="rounded bg-primary px-3 py-2 text-primary-foreground" type="submit">
+          Send
+        </button>
+        <button type="button" onClick={() => setOpen(false)}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/packages/conversations-react/src/admin/index.tsx
+++ b/packages/conversations-react/src/admin/index.tsx
@@ -1,0 +1,52 @@
+import {
+  type AdminExtension,
+  adminRoutePageModule,
+  defineAdminExtension,
+  type SelectedAdminExtensionFactoryContext,
+} from "@voyant-travel/admin"
+import { Inbox } from "lucide-react"
+
+declare module "@voyant-travel/admin" {
+  interface AdminDestinations {
+    "conversation.list": Record<string, never>
+    "conversation.detail": { id: string }
+  }
+}
+
+export function createConversationsAdminExtension(
+  options: { basePath?: string; label?: string } = {},
+): AdminExtension {
+  const basePath = options.basePath ?? "/inbox"
+  const label = options.label ?? "Inbox"
+  return defineAdminExtension({
+    id: "conversations",
+    destinations: {
+      "conversation.list": () => basePath,
+      "conversation.detail": ({ id }: { id: string }) => `${basePath}/${encodeURIComponent(id)}`,
+    },
+    navigation: [
+      { order: -45, items: [{ id: "inbox", title: label, url: basePath, icon: Inbox }] },
+    ],
+    routes: [
+      {
+        id: "conversations-inbox",
+        path: basePath,
+        title: label,
+        page: () =>
+          import("./inbox-page.js").then((module) => adminRoutePageModule(module.InboxPage)),
+      },
+      {
+        id: "conversations-detail",
+        path: `${basePath}/$id`,
+        title: "Conversation",
+        page: () => import("./conversation-page.js"),
+      },
+    ],
+  })
+}
+
+export function createSelectedConversationsAdminExtension(
+  { navMessages }: SelectedAdminExtensionFactoryContext = { navMessages: {} },
+): AdminExtension {
+  return createConversationsAdminExtension({ label: navMessages.inbox ?? "Inbox" })
+}

--- a/packages/conversations-react/src/api.ts
+++ b/packages/conversations-react/src/api.ts
@@ -1,0 +1,64 @@
+import type { VoyantFetcher } from "@voyant-travel/react"
+import type { InboxConversation, InboxConversationDetail, InboxPart } from "./types.js"
+
+async function request<T>(fetcher: VoyantFetcher, url: string, init?: RequestInit): Promise<T> {
+  const response = await fetcher(url, init)
+  const payload = (await response.json()) as { data?: T; error?: string }
+  if (!response.ok || payload.data === undefined)
+    throw new Error(payload.error ?? `Request failed (${response.status})`)
+  return payload.data
+}
+
+export const conversationsApi = {
+  list(fetcher: VoyantFetcher, baseUrl: string) {
+    return request<InboxConversation[]>(fetcher, `${baseUrl}/v1/admin/conversations`)
+  },
+  get(fetcher: VoyantFetcher, baseUrl: string, id: string) {
+    return request<InboxConversationDetail>(
+      fetcher,
+      `${baseUrl}/v1/admin/conversations/${encodeURIComponent(id)}`,
+    )
+  },
+  markRead(fetcher: VoyantFetcher, baseUrl: string, id: string) {
+    return request<InboxConversation>(
+      fetcher,
+      `${baseUrl}/v1/admin/conversations/${encodeURIComponent(id)}/read`,
+      { method: "POST" },
+    )
+  },
+  reply(
+    fetcher: VoyantFetcher,
+    baseUrl: string,
+    id: string,
+    input: { channelAccountId: string; text: string; idempotencyKey: string },
+  ) {
+    return request<InboxPart>(
+      fetcher,
+      `${baseUrl}/v1/admin/conversations/${encodeURIComponent(id)}/replies`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(input),
+      },
+    )
+  },
+  start(
+    fetcher: VoyantFetcher,
+    baseUrl: string,
+    input: {
+      personRef: string
+      contactPointRef: string
+      channelAccountId: string
+      fromAddress: string
+      subject: string | null
+      text: string
+      idempotencyKey: string
+    },
+  ) {
+    return request<InboxConversationDetail>(fetcher, `${baseUrl}/v1/admin/conversations`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(input),
+    })
+  },
+}

--- a/packages/conversations-react/src/index.ts
+++ b/packages/conversations-react/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./types.js"

--- a/packages/conversations-react/src/types.ts
+++ b/packages/conversations-react/src/types.ts
@@ -1,0 +1,25 @@
+export interface InboxConversation {
+  id: string
+  status: "open" | "closed" | "snoozed"
+  subject: string | null
+  suggestedSubject: string | null
+  customerAddress: string
+  personRef: string | null
+  unreadCount: number
+  lastPartAt: string
+}
+
+export interface InboxPart {
+  id: string
+  direction: "inbound" | "outbound"
+  senderAddress: string
+  textBody: string | null
+  htmlBody: string | null
+  deliveryStatus: string
+  occurredAt: string
+}
+
+export interface InboxConversationDetail {
+  conversation: InboxConversation
+  parts: InboxPart[]
+}

--- a/packages/conversations-react/tsconfig.build.json
+++ b/packages/conversations-react/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}

--- a/packages/conversations-react/tsconfig.json
+++ b/packages/conversations-react/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@voyant-travel/voyant-typescript-config/base.json",
+  "compilerOptions": { "composite": false, "module": "ESNext", "moduleResolution": "Bundler", "jsx": "react-jsx" },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/conversations-react/tsconfig.typecheck.json
+++ b/packages/conversations-react/tsconfig.typecheck.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": { "noEmit": true }
+}

--- a/packages/conversations/drizzle.migrations.config.ts
+++ b/packages/conversations/drizzle.migrations.config.ts
@@ -1,0 +1,11 @@
+/**
+ * This package owns and ships its migration history for source-free runtimes.
+ * Regenerate with `pnpm -C packages/conversations db:generate`.
+ */
+import { defineConfig } from "drizzle-kit"
+
+export default defineConfig({
+  schema: "./src/schema.ts",
+  out: "./migrations",
+  dialect: "postgresql",
+})

--- a/packages/conversations/migrations/0000_conversations_baseline.sql
+++ b/packages/conversations/migrations/0000_conversations_baseline.sql
@@ -1,0 +1,109 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."conversation_ingress_status" AS ENUM('committed', 'drifted');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."conversation_part_delivery_status" AS ENUM('received', 'pending', 'accepted', 'delivered', 'failed', 'bounced', 'complained', 'suppressed', 'cancelled');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."conversation_part_direction" AS ENUM('inbound', 'outbound');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."conversation_participant_role" AS ENUM('customer', 'staff');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."conversation_status" AS ENUM('open', 'closed', 'snoozed');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE TABLE "conversation_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"conversation_id" text NOT NULL,
+	"type" text NOT NULL,
+	"payload" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"occurred_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "conversation_ingress_operations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"source_id" text NOT NULL,
+	"external_envelope_id" text NOT NULL,
+	"external_message_id" text NOT NULL,
+	"payload_fingerprint" text NOT NULL,
+	"conversation_part_id" text,
+	"status" "conversation_ingress_status" DEFAULT 'committed' NOT NULL,
+	"error" text,
+	"committed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "conversation_participants" (
+	"id" text PRIMARY KEY NOT NULL,
+	"conversation_id" text NOT NULL,
+	"role" "conversation_participant_role" NOT NULL,
+	"address" text NOT NULL,
+	"person_ref" text,
+	"contact_point_ref" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "conversation_parts" (
+	"id" text PRIMARY KEY NOT NULL,
+	"conversation_id" text NOT NULL,
+	"direction" "conversation_part_direction" NOT NULL,
+	"sender_address" text NOT NULL,
+	"recipient_addresses" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"subject" text,
+	"text_body" text,
+	"html_body" text,
+	"attachments" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"external_source_id" text,
+	"external_message_id" text,
+	"message_id" text,
+	"in_reply_to" text,
+	"references" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"payload_fingerprint" text NOT NULL,
+	"notification_delivery_id" text,
+	"idempotency_key" text,
+	"delivery_status" "conversation_part_delivery_status" NOT NULL,
+	"occurred_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "conversations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"channel" text DEFAULT 'email' NOT NULL,
+	"status" "conversation_status" DEFAULT 'open' NOT NULL,
+	"subject" text,
+	"suggested_subject" text,
+	"reply_alias" text NOT NULL,
+	"customer_address" text NOT NULL,
+	"person_ref" text,
+	"contact_point_ref" text,
+	"start_idempotency_key" text,
+	"start_payload_fingerprint" text,
+	"unread_count" integer DEFAULT 0 NOT NULL,
+	"snoozed_until" timestamp with time zone,
+	"last_part_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "conversation_events" ADD CONSTRAINT "conversation_events_conversation_id_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversation_ingress_operations" ADD CONSTRAINT "conversation_ingress_operations_conversation_part_id_conversation_parts_id_fk" FOREIGN KEY ("conversation_part_id") REFERENCES "public"."conversation_parts"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversation_participants" ADD CONSTRAINT "conversation_participants_conversation_id_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversation_parts" ADD CONSTRAINT "conversation_parts_conversation_id_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_conversation_events_conversation" ON "conversation_events" USING btree ("conversation_id","occurred_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_conversation_ingress_envelope" ON "conversation_ingress_operations" USING btree ("source_id","external_envelope_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_conversation_ingress_message" ON "conversation_ingress_operations" USING btree ("source_id","external_message_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_conversation_participant_address" ON "conversation_participants" USING btree ("conversation_id","role","address");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_conversation_parts_external_message" ON "conversation_parts" USING btree ("external_source_id","external_message_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_conversation_parts_message_id" ON "conversation_parts" USING btree ("message_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_conversation_parts_idempotency" ON "conversation_parts" USING btree ("idempotency_key");--> statement-breakpoint
+CREATE INDEX "idx_conversation_parts_conversation_occurred" ON "conversation_parts" USING btree ("conversation_id","occurred_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_conversations_reply_alias" ON "conversations" USING btree ("reply_alias");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_conversations_start_idempotency" ON "conversations" USING btree ("start_idempotency_key");--> statement-breakpoint
+CREATE INDEX "idx_conversations_last_part" ON "conversations" USING btree ("last_part_at");--> statement-breakpoint
+CREATE INDEX "idx_conversations_person" ON "conversations" USING btree ("person_ref");

--- a/packages/conversations/migrations/meta/0000_snapshot.json
+++ b/packages/conversations/migrations/meta/0000_snapshot.json
@@ -1,0 +1,783 @@
+{
+  "id": "61de828a-af3c-4bc2-a683-34d076ecd42a",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.conversation_events": {
+      "name": "conversation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_conversation_events_conversation": {
+          "name": "idx_conversation_events_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_events_conversation_id_conversations_id_fk": {
+          "name": "conversation_events_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_events",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_ingress_operations": {
+      "name": "conversation_ingress_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_envelope_id": {
+          "name": "external_envelope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint": {
+          "name": "payload_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_part_id": {
+          "name": "conversation_part_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "conversation_ingress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'committed'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_ingress_envelope": {
+          "name": "uidx_conversation_ingress_envelope",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_envelope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_ingress_message": {
+          "name": "uidx_conversation_ingress_message",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_ingress_operations_conversation_part_id_conversation_parts_id_fk": {
+          "name": "conversation_ingress_operations_conversation_part_id_conversation_parts_id_fk",
+          "tableFrom": "conversation_ingress_operations",
+          "tableTo": "conversation_parts",
+          "columnsFrom": [
+            "conversation_part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "conversation_participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_ref": {
+          "name": "person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_point_ref": {
+          "name": "contact_point_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_participant_address": {
+          "name": "uidx_conversation_participant_address",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_parts": {
+      "name": "conversation_parts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "conversation_part_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_address": {
+          "name": "sender_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_addresses": {
+          "name": "recipient_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "payload_fingerprint": {
+          "name": "payload_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_delivery_id": {
+          "name": "notification_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_status": {
+          "name": "delivery_status",
+          "type": "conversation_part_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_parts_external_message": {
+          "name": "uidx_conversation_parts_external_message",
+          "columns": [
+            {
+              "expression": "external_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_parts_message_id": {
+          "name": "uidx_conversation_parts_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_parts_idempotency": {
+          "name": "uidx_conversation_parts_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversation_parts_conversation_occurred": {
+          "name": "idx_conversation_parts_conversation_occurred",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_parts_conversation_id_conversations_id_fk": {
+          "name": "conversation_parts_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_parts",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "status": {
+          "name": "status",
+          "type": "conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_subject": {
+          "name": "suggested_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_alias": {
+          "name": "reply_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_address": {
+          "name": "customer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_ref": {
+          "name": "person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_point_ref": {
+          "name": "contact_point_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_idempotency_key": {
+          "name": "start_idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_payload_fingerprint": {
+          "name": "start_payload_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_part_at": {
+          "name": "last_part_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversations_reply_alias": {
+          "name": "uidx_conversations_reply_alias",
+          "columns": [
+            {
+              "expression": "reply_alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversations_start_idempotency": {
+          "name": "uidx_conversations_start_idempotency",
+          "columns": [
+            {
+              "expression": "start_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_last_part": {
+          "name": "idx_conversations_last_part",
+          "columns": [
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_person": {
+          "name": "idx_conversations_person",
+          "columns": [
+            {
+              "expression": "person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.conversation_ingress_status": {
+      "name": "conversation_ingress_status",
+      "schema": "public",
+      "values": [
+        "committed",
+        "drifted"
+      ]
+    },
+    "public.conversation_part_delivery_status": {
+      "name": "conversation_part_delivery_status",
+      "schema": "public",
+      "values": [
+        "received",
+        "pending",
+        "accepted",
+        "delivered",
+        "failed",
+        "bounced",
+        "complained",
+        "suppressed",
+        "cancelled"
+      ]
+    },
+    "public.conversation_part_direction": {
+      "name": "conversation_part_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.conversation_participant_role": {
+      "name": "conversation_participant_role",
+      "schema": "public",
+      "values": [
+        "customer",
+        "staff"
+      ]
+    },
+    "public.conversation_status": {
+      "name": "conversation_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed",
+        "snoozed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/conversations/migrations/meta/_journal.json
+++ b/packages/conversations/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1787003479671,
+      "tag": "0000_conversations_baseline",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/conversations/openapi/admin/conversations.json
+++ b/packages/conversations/openapi/admin/conversations.json
@@ -1,0 +1,1041 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Voyant Conversations Admin API",
+    "version": "0.1.0",
+    "description": "Provider-neutral operator Inbox routes."
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "paths": {
+    "/v1/admin/conversations": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["open", "closed", "snoozed"]
+            },
+            "required": false,
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 100
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Inbox conversations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "channel": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": ["open", "closed", "snoozed"]
+                          },
+                          "subject": {
+                            "type": ["string", "null"]
+                          },
+                          "suggestedSubject": {
+                            "type": ["string", "null"]
+                          },
+                          "replyAlias": {
+                            "type": "string"
+                          },
+                          "customerAddress": {
+                            "type": "string"
+                          },
+                          "personRef": {
+                            "type": ["string", "null"]
+                          },
+                          "contactPointRef": {
+                            "type": ["string", "null"]
+                          },
+                          "unreadCount": {
+                            "type": "integer"
+                          },
+                          "snoozedUntil": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "lastPartAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "channel",
+                          "status",
+                          "subject",
+                          "suggestedSubject",
+                          "replyAlias",
+                          "customerAddress",
+                          "personRef",
+                          "contactPointRef",
+                          "unreadCount",
+                          "snoozedUntil",
+                          "lastPartAt",
+                          "createdAt",
+                          "updatedAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "personRef": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "contactPointRef": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "channelAccountId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "fromAddress": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "subject": {
+                    "type": ["string", "null"]
+                  },
+                  "text": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "idempotencyKey": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "personRef",
+                  "contactPointRef",
+                  "channelAccountId",
+                  "fromAddress",
+                  "subject",
+                  "text",
+                  "idempotencyKey"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Started conversation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "conversation": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "channel": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": ["open", "closed", "snoozed"]
+                            },
+                            "subject": {
+                              "type": ["string", "null"]
+                            },
+                            "suggestedSubject": {
+                              "type": ["string", "null"]
+                            },
+                            "replyAlias": {
+                              "type": "string"
+                            },
+                            "customerAddress": {
+                              "type": "string"
+                            },
+                            "personRef": {
+                              "type": ["string", "null"]
+                            },
+                            "contactPointRef": {
+                              "type": ["string", "null"]
+                            },
+                            "unreadCount": {
+                              "type": "integer"
+                            },
+                            "snoozedUntil": {
+                              "type": ["string", "null"],
+                              "format": "date-time"
+                            },
+                            "lastPartAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "createdAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "updatedAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "channel",
+                            "status",
+                            "subject",
+                            "suggestedSubject",
+                            "replyAlias",
+                            "customerAddress",
+                            "personRef",
+                            "contactPointRef",
+                            "unreadCount",
+                            "snoozedUntil",
+                            "lastPartAt",
+                            "createdAt",
+                            "updatedAt"
+                          ]
+                        },
+                        "parts": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "conversationId": {
+                                "type": "string"
+                              },
+                              "direction": {
+                                "type": "string",
+                                "enum": ["inbound", "outbound"]
+                              },
+                              "senderAddress": {
+                                "type": "string"
+                              },
+                              "recipientAddresses": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "subject": {
+                                "type": ["string", "null"]
+                              },
+                              "textBody": {
+                                "type": ["string", "null"]
+                              },
+                              "htmlBody": {
+                                "type": ["string", "null"]
+                              },
+                              "attachments": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "additionalProperties": {}
+                                }
+                              },
+                              "externalMessageId": {
+                                "type": ["string", "null"]
+                              },
+                              "messageId": {
+                                "type": ["string", "null"]
+                              },
+                              "inReplyTo": {
+                                "type": ["string", "null"]
+                              },
+                              "references": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "deliveryStatus": {
+                                "type": "string",
+                                "enum": [
+                                  "received",
+                                  "pending",
+                                  "accepted",
+                                  "delivered",
+                                  "failed",
+                                  "bounced",
+                                  "complained",
+                                  "suppressed",
+                                  "cancelled"
+                                ]
+                              },
+                              "occurredAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "conversationId",
+                              "direction",
+                              "senderAddress",
+                              "recipientAddresses",
+                              "subject",
+                              "textBody",
+                              "htmlBody",
+                              "attachments",
+                              "externalMessageId",
+                              "messageId",
+                              "inReplyTo",
+                              "references",
+                              "deliveryStatus",
+                              "occurredAt",
+                              "createdAt"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["conversation", "parts"]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Person contact point not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Required runtime, admission, or idempotency conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/conversations/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Conversation thread",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "conversation": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "channel": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": ["open", "closed", "snoozed"]
+                            },
+                            "subject": {
+                              "type": ["string", "null"]
+                            },
+                            "suggestedSubject": {
+                              "type": ["string", "null"]
+                            },
+                            "replyAlias": {
+                              "type": "string"
+                            },
+                            "customerAddress": {
+                              "type": "string"
+                            },
+                            "personRef": {
+                              "type": ["string", "null"]
+                            },
+                            "contactPointRef": {
+                              "type": ["string", "null"]
+                            },
+                            "unreadCount": {
+                              "type": "integer"
+                            },
+                            "snoozedUntil": {
+                              "type": ["string", "null"],
+                              "format": "date-time"
+                            },
+                            "lastPartAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "createdAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "updatedAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "channel",
+                            "status",
+                            "subject",
+                            "suggestedSubject",
+                            "replyAlias",
+                            "customerAddress",
+                            "personRef",
+                            "contactPointRef",
+                            "unreadCount",
+                            "snoozedUntil",
+                            "lastPartAt",
+                            "createdAt",
+                            "updatedAt"
+                          ]
+                        },
+                        "parts": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "conversationId": {
+                                "type": "string"
+                              },
+                              "direction": {
+                                "type": "string",
+                                "enum": ["inbound", "outbound"]
+                              },
+                              "senderAddress": {
+                                "type": "string"
+                              },
+                              "recipientAddresses": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "subject": {
+                                "type": ["string", "null"]
+                              },
+                              "textBody": {
+                                "type": ["string", "null"]
+                              },
+                              "htmlBody": {
+                                "type": ["string", "null"]
+                              },
+                              "attachments": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "additionalProperties": {}
+                                }
+                              },
+                              "externalMessageId": {
+                                "type": ["string", "null"]
+                              },
+                              "messageId": {
+                                "type": ["string", "null"]
+                              },
+                              "inReplyTo": {
+                                "type": ["string", "null"]
+                              },
+                              "references": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "deliveryStatus": {
+                                "type": "string",
+                                "enum": [
+                                  "received",
+                                  "pending",
+                                  "accepted",
+                                  "delivered",
+                                  "failed",
+                                  "bounced",
+                                  "complained",
+                                  "suppressed",
+                                  "cancelled"
+                                ]
+                              },
+                              "occurredAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "conversationId",
+                              "direction",
+                              "senderAddress",
+                              "recipientAddresses",
+                              "subject",
+                              "textBody",
+                              "htmlBody",
+                              "attachments",
+                              "externalMessageId",
+                              "messageId",
+                              "inReplyTo",
+                              "references",
+                              "deliveryStatus",
+                              "occurredAt",
+                              "createdAt"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["conversation", "parts"]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Conversation not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": ["open", "closed", "snoozed"]
+                  },
+                  "snoozedUntil": {
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                  }
+                },
+                "required": ["status"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated conversation state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "channel": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": ["open", "closed", "snoozed"]
+                        },
+                        "subject": {
+                          "type": ["string", "null"]
+                        },
+                        "suggestedSubject": {
+                          "type": ["string", "null"]
+                        },
+                        "replyAlias": {
+                          "type": "string"
+                        },
+                        "customerAddress": {
+                          "type": "string"
+                        },
+                        "personRef": {
+                          "type": ["string", "null"]
+                        },
+                        "contactPointRef": {
+                          "type": ["string", "null"]
+                        },
+                        "unreadCount": {
+                          "type": "integer"
+                        },
+                        "snoozedUntil": {
+                          "type": ["string", "null"],
+                          "format": "date-time"
+                        },
+                        "lastPartAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "channel",
+                        "status",
+                        "subject",
+                        "suggestedSubject",
+                        "replyAlias",
+                        "customerAddress",
+                        "personRef",
+                        "contactPointRef",
+                        "unreadCount",
+                        "snoozedUntil",
+                        "lastPartAt",
+                        "createdAt",
+                        "updatedAt"
+                      ]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Conversation not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/conversations/{id}/replies": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "channelAccountId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "text": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "html": {
+                    "type": ["string", "null"]
+                  },
+                  "idempotencyKey": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": ["channelAccountId", "text", "idempotencyKey"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Atomically admitted reply",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "conversationId": {
+                          "type": "string"
+                        },
+                        "direction": {
+                          "type": "string",
+                          "enum": ["inbound", "outbound"]
+                        },
+                        "senderAddress": {
+                          "type": "string"
+                        },
+                        "recipientAddresses": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "subject": {
+                          "type": ["string", "null"]
+                        },
+                        "textBody": {
+                          "type": ["string", "null"]
+                        },
+                        "htmlBody": {
+                          "type": ["string", "null"]
+                        },
+                        "attachments": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "externalMessageId": {
+                          "type": ["string", "null"]
+                        },
+                        "messageId": {
+                          "type": ["string", "null"]
+                        },
+                        "inReplyTo": {
+                          "type": ["string", "null"]
+                        },
+                        "references": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "deliveryStatus": {
+                          "type": "string",
+                          "enum": [
+                            "received",
+                            "pending",
+                            "accepted",
+                            "delivered",
+                            "failed",
+                            "bounced",
+                            "complained",
+                            "suppressed",
+                            "cancelled"
+                          ]
+                        },
+                        "occurredAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "conversationId",
+                        "direction",
+                        "senderAddress",
+                        "recipientAddresses",
+                        "subject",
+                        "textBody",
+                        "htmlBody",
+                        "attachments",
+                        "externalMessageId",
+                        "messageId",
+                        "inReplyTo",
+                        "references",
+                        "deliveryStatus",
+                        "occurredAt",
+                        "createdAt"
+                      ]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Conversation not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Delivery admission or idempotency conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/conversations/{id}/read": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Acknowledged Inbox conversation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "channel": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": ["open", "closed", "snoozed"]
+                        },
+                        "subject": {
+                          "type": ["string", "null"]
+                        },
+                        "suggestedSubject": {
+                          "type": ["string", "null"]
+                        },
+                        "replyAlias": {
+                          "type": "string"
+                        },
+                        "customerAddress": {
+                          "type": "string"
+                        },
+                        "personRef": {
+                          "type": ["string", "null"]
+                        },
+                        "contactPointRef": {
+                          "type": ["string", "null"]
+                        },
+                        "unreadCount": {
+                          "type": "integer"
+                        },
+                        "snoozedUntil": {
+                          "type": ["string", "null"],
+                          "format": "date-time"
+                        },
+                        "lastPartAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "channel",
+                        "status",
+                        "subject",
+                        "suggestedSubject",
+                        "replyAlias",
+                        "customerAddress",
+                        "personRef",
+                        "contactPointRef",
+                        "unreadCount",
+                        "snoozedUntil",
+                        "lastPartAt",
+                        "createdAt",
+                        "updatedAt"
+                      ]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Conversation not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/conversations/package.json
+++ b/packages/conversations/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@voyant-travel/conversations",
+  "version": "0.1.0",
+  "description": "Provider-neutral operator conversations and Inbox module.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schema": "./src/schema.ts",
+    "./runtime-port": "./src/runtime-port.ts",
+    "./runtime-contributor": "./src/runtime-contributor.ts",
+    "./ingress-job": "./src/ingress-job.ts",
+    "./voyant": "./src/voyant.ts",
+    "./openapi/admin": "./openapi/admin/conversations.json"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "test": "vitest run",
+    "lint": "biome check src/",
+    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=conversations_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
+    "openapi:generate": "tsx scripts/generate-openapi.ts && biome format --write openapi/admin/conversations.json"
+  },
+  "dependencies": {
+    "@hono/zod-openapi": "catalog:",
+    "@voyant-travel/conversations-contracts": "workspace:^",
+    "@voyant-travel/core": "workspace:^",
+    "@voyant-travel/db": "workspace:^",
+    "@voyant-travel/hono": "workspace:^",
+    "drizzle-orm": "catalog:",
+    "hono": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "drizzle-kit": "^0.31.10",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "files": ["dist", "openapi", "migrations/*.sql", "migrations/meta/*.json"],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js", "default": "./dist/index.js" },
+      "./schema": { "types": "./dist/schema.d.ts", "import": "./dist/schema.js", "default": "./dist/schema.js" },
+      "./runtime-port": { "types": "./dist/runtime-port.d.ts", "import": "./dist/runtime-port.js", "default": "./dist/runtime-port.js" },
+      "./runtime-contributor": { "types": "./dist/runtime-contributor.d.ts", "import": "./dist/runtime-contributor.js", "default": "./dist/runtime-contributor.js" },
+      "./ingress-job": { "types": "./dist/ingress-job.d.ts", "import": "./dist/ingress-job.js", "default": "./dist/ingress-job.js" },
+      "./voyant": { "types": "./dist/voyant.d.ts", "import": "./dist/voyant.js", "default": "./dist/voyant.js" },
+      "./openapi/admin": "./openapi/admin/conversations.json"
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyant-travel/voyant.git",
+    "directory": "packages/conversations"
+  },
+  "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "manifest": "./voyant",
+    "runtime": { "entry": "./runtime-contributor", "export": "createConversationsRuntimePortContribution" },
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": ["node"],
+      "modes": ["local", "managed-cloud", "self-hosted"]
+    },
+    "schema": "./schema",
+    "requiresSchemas": ["@voyant-travel/db"]
+  },
+  "private": true
+}

--- a/packages/conversations/scripts/generate-openapi.ts
+++ b/packages/conversations/scripts/generate-openapi.ts
@@ -1,0 +1,13 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { createConversationsRoutes } from "../src/routes.js"
+
+const artifactPath = resolve(import.meta.dirname, "../openapi/admin/conversations.json")
+const committed = JSON.parse(readFileSync(artifactPath, "utf8"))
+const app = createConversationsRoutes({
+  resolveDb: () => {
+    throw new Error("OpenAPI replay does not execute handlers")
+  },
+})
+const live = app.getOpenAPI31Document({ info: committed.info, servers: committed.servers })
+writeFileSync(artifactPath, `${JSON.stringify({ ...committed, paths: live.paths }, null, 2)}\n`)

--- a/packages/conversations/src/index.ts
+++ b/packages/conversations/src/index.ts
@@ -1,0 +1,46 @@
+import type { Module } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
+import type { ApiModule } from "@voyant-travel/hono/module"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import {
+  conversationsDatabaseRuntimePort,
+  conversationsPersonDirectoryPort,
+  conversationsRenderedMessageAdmissionPort,
+} from "./runtime-port.js"
+import { conversationsModule } from "./schema.js"
+
+export * from "./runtime-port.js"
+export * from "./schema.js"
+export * from "./service.js"
+export * from "./threading.js"
+
+export function createConversationsApiModule(
+  options: import("./routes.js").ConversationsRoutesOptions,
+): ApiModule {
+  const module: Module = conversationsModule
+  return {
+    module,
+    lazyRoutes: {
+      paths: ["/v1/admin/conversations", "/v1/admin/conversations/*"],
+      load: () =>
+        import("./routes.js").then(({ createConversationsRoutes }) =>
+          createConversationsRoutes(options),
+        ),
+    },
+  }
+}
+
+export const createConversationsVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ getPort, hasPort }) => {
+    const database = await getPort(conversationsDatabaseRuntimePort)
+    return createConversationsApiModule({
+      resolveDb: (bindings) => database.resolveDb(bindings) as PostgresJsDatabase,
+      admission: hasPort(conversationsRenderedMessageAdmissionPort)
+        ? await getPort(conversationsRenderedMessageAdmissionPort)
+        : undefined,
+      personDirectory: hasPort(conversationsPersonDirectoryPort)
+        ? await getPort(conversationsPersonDirectoryPort)
+        : undefined,
+    })
+  },
+)

--- a/packages/conversations/src/ingress-job.ts
+++ b/packages/conversations/src/ingress-job.ts
@@ -1,0 +1,58 @@
+import { inboundEmailEnvelopeV1Schema } from "@voyant-travel/conversations-contracts"
+import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import {
+  conversationIngressSourcePort,
+  conversationsDatabaseRuntimePort,
+  conversationsPersonDirectoryPort,
+} from "./runtime-port.js"
+import { ingestEnvelope } from "./service.js"
+
+export interface IngressJobSummary {
+  fetched: number
+  committed: number
+  duplicates: number
+  acknowledged: number
+}
+
+export async function processConversationIngress(input: {
+  db: PostgresJsDatabase
+  sources: readonly import("@voyant-travel/conversations-contracts").ConversationIngressSource[]
+  personDirectory?: import("./runtime-port.js").ConversationsPersonDirectory
+  limit?: number
+  /** Test seam for the commit boundary; production always uses `ingestEnvelope`. */
+  ingest?: typeof ingestEnvelope
+}): Promise<IngressJobSummary> {
+  const summary: IngressJobSummary = { fetched: 0, committed: 0, duplicates: 0, acknowledged: 0 }
+  for (const source of input.sources) {
+    const page = await source.list({ limit: Math.min(input.limit ?? 50, 100) })
+    for (const ref of page.items) {
+      const envelope = inboundEmailEnvelopeV1Schema.parse(await source.fetch(ref))
+      summary.fetched += 1
+      const result = await (input.ingest ?? ingestEnvelope)(input.db, envelope, {
+        personDirectory: input.personDirectory,
+      })
+      if (result.duplicate) summary.duplicates += 1
+      else summary.committed += 1
+      // Intentionally after commit. If the process dies here, replay returns duplicate and acks safely.
+      await source.ack(ref)
+      summary.acknowledged += 1
+    }
+  }
+  return summary
+}
+
+export async function runConversationIngressJob(
+  context: VoyantGraphRuntimeFactoryContext,
+): Promise<void> {
+  const database = await context.getPort(conversationsDatabaseRuntimePort)
+  const sources = await context.getPorts(conversationIngressSourcePort)
+  const personDirectory = context.hasPort(conversationsPersonDirectoryPort)
+    ? await context.getPort(conversationsPersonDirectoryPort)
+    : undefined
+  await processConversationIngress({
+    db: database.resolveDb() as PostgresJsDatabase,
+    sources,
+    personDirectory,
+  })
+}

--- a/packages/conversations/src/routes.ts
+++ b/packages/conversations/src/routes.ts
@@ -1,0 +1,290 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import { openApiValidationHook } from "@voyant-travel/hono"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type {
+  ConversationsPersonDirectory,
+  ConversationsRenderedMessageAdmission,
+} from "./runtime-port.js"
+import type { Conversation, ConversationPart } from "./schema.js"
+import {
+  ConversationConflictError,
+  ConversationIngressDriftError,
+  ConversationNotFoundError,
+  getConversation,
+  listConversations,
+  markConversationRead,
+  replyToConversation,
+  startConversation,
+  updateConversationState,
+} from "./service.js"
+
+export interface ConversationsRoutesOptions {
+  resolveDb(bindings: unknown): PostgresJsDatabase
+  admission?: ConversationsRenderedMessageAdmission
+  personDirectory?: ConversationsPersonDirectory
+}
+
+const timestamp = z.string().datetime()
+const conversationSchema = z.object({
+  id: z.string(),
+  channel: z.string(),
+  status: z.enum(["open", "closed", "snoozed"]),
+  subject: z.string().nullable(),
+  suggestedSubject: z.string().nullable(),
+  replyAlias: z.string(),
+  customerAddress: z.string(),
+  personRef: z.string().nullable(),
+  contactPointRef: z.string().nullable(),
+  unreadCount: z.number().int(),
+  snoozedUntil: timestamp.nullable(),
+  lastPartAt: timestamp,
+  createdAt: timestamp,
+  updatedAt: timestamp,
+})
+const partSchema = z.object({
+  id: z.string(),
+  conversationId: z.string(),
+  direction: z.enum(["inbound", "outbound"]),
+  senderAddress: z.string(),
+  recipientAddresses: z.array(z.string()),
+  subject: z.string().nullable(),
+  textBody: z.string().nullable(),
+  htmlBody: z.string().nullable(),
+  attachments: z.array(z.record(z.string(), z.unknown())),
+  externalMessageId: z.string().nullable(),
+  messageId: z.string().nullable(),
+  inReplyTo: z.string().nullable(),
+  references: z.array(z.string()),
+  deliveryStatus: z.enum([
+    "received",
+    "pending",
+    "accepted",
+    "delivered",
+    "failed",
+    "bounced",
+    "complained",
+    "suppressed",
+    "cancelled",
+  ]),
+  occurredAt: timestamp,
+  createdAt: timestamp,
+})
+const errorSchema = z.object({ error: z.string() })
+const data = <T extends z.ZodTypeAny>(schema: T) => z.object({ data: schema })
+const json = <T extends z.ZodTypeAny>(schema: T, description: string) => ({
+  description,
+  content: { "application/json": { schema } },
+})
+const body = <T extends z.ZodTypeAny>(schema: T) => ({
+  required: true,
+  content: { "application/json": { schema } },
+})
+
+const listRoute = createRoute({
+  method: "get",
+  path: "/v1/admin/conversations",
+  request: {
+    query: z.object({
+      status: z.enum(["open", "closed", "snoozed"]).optional(),
+      limit: z.coerce.number().int().positive().max(100).optional(),
+    }),
+  },
+  responses: { 200: json(data(z.array(conversationSchema)), "Inbox conversations") },
+})
+const detailRoute = createRoute({
+  method: "get",
+  path: "/v1/admin/conversations/{id}",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: json(
+      data(z.object({ conversation: conversationSchema, parts: z.array(partSchema) })),
+      "Conversation thread",
+    ),
+    404: json(errorSchema, "Conversation not found"),
+  },
+})
+const replyInput = z.object({
+  channelAccountId: z.string().min(1),
+  text: z.string().trim().min(1),
+  html: z.string().nullable().optional(),
+  idempotencyKey: z.string().min(1),
+})
+const replyRoute = createRoute({
+  method: "post",
+  path: "/v1/admin/conversations/{id}/replies",
+  request: { params: z.object({ id: z.string() }), body: body(replyInput) },
+  responses: {
+    201: json(data(partSchema), "Atomically admitted reply"),
+    404: json(errorSchema, "Conversation not found"),
+    409: json(errorSchema, "Delivery admission or idempotency conflict"),
+  },
+})
+const startInput = z.object({
+  personRef: z.string().min(1),
+  contactPointRef: z.string().min(1),
+  channelAccountId: z.string().min(1),
+  fromAddress: z.string().email(),
+  subject: z.string().nullable(),
+  text: z.string().trim().min(1),
+  idempotencyKey: z.string().min(1),
+})
+const startRoute = createRoute({
+  method: "post",
+  path: "/v1/admin/conversations",
+  request: { body: body(startInput) },
+  responses: {
+    201: json(
+      data(z.object({ conversation: conversationSchema, parts: z.array(partSchema) })),
+      "Started conversation",
+    ),
+    404: json(errorSchema, "Person contact point not found"),
+    409: json(errorSchema, "Required runtime, admission, or idempotency conflict"),
+  },
+})
+const stateInput = z.object({
+  status: z.enum(["open", "closed", "snoozed"]),
+  snoozedUntil: timestamp.nullable().optional(),
+})
+const stateRoute = createRoute({
+  method: "patch",
+  path: "/v1/admin/conversations/{id}",
+  request: { params: z.object({ id: z.string() }), body: body(stateInput) },
+  responses: {
+    200: json(data(conversationSchema), "Updated conversation state"),
+    404: json(errorSchema, "Conversation not found"),
+  },
+})
+const readRoute = createRoute({
+  method: "post",
+  path: "/v1/admin/conversations/{id}/read",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: json(data(conversationSchema), "Acknowledged Inbox conversation"),
+    404: json(errorSchema, "Conversation not found"),
+  },
+})
+
+// biome-ignore lint/suspicious/noExplicitAny: Date-bearing rows serialize to the declared ISO timestamp wire shape.
+const response = (value: unknown): any => value
+
+function toConversationDto(row: Conversation) {
+  const { startIdempotencyKey: _key, startPayloadFingerprint: _fingerprint, ...dto } = row
+  return dto
+}
+
+function toPartDto(row: ConversationPart) {
+  const {
+    externalSourceId: _source,
+    payloadFingerprint: _fingerprint,
+    idempotencyKey: _idempotencyKey,
+    notificationDeliveryId: _deliveryId,
+    ...dto
+  } = row
+  return dto
+}
+
+function toDetailDto(detail: Awaited<ReturnType<typeof getConversation>>) {
+  if (!detail) return null
+  return {
+    conversation: toConversationDto(detail.conversation),
+    parts: detail.parts.map(toPartDto),
+  }
+}
+
+function serviceError(error: unknown): { status: 404 | 409; error: string } | null {
+  if (error instanceof ConversationNotFoundError) return { status: 404, error: error.code }
+  if (
+    error instanceof ConversationConflictError ||
+    error instanceof ConversationIngressDriftError
+  ) {
+    return { status: 409, error: error.code }
+  }
+  return null
+}
+
+export function createConversationsRoutes(options: ConversationsRoutesOptions) {
+  const app = new OpenAPIHono({ defaultHook: openApiValidationHook })
+  app.openapi(listRoute, async (c) =>
+    c.json(
+      response({
+        data: (await listConversations(options.resolveDb(c.env), c.req.valid("query"))).map(
+          toConversationDto,
+        ),
+      }),
+      200,
+    ),
+  )
+  app.openapi(detailRoute, async (c) => {
+    const detail = await getConversation(options.resolveDb(c.env), c.req.valid("param").id)
+    return detail
+      ? c.json(response({ data: toDetailDto(detail) }), 200)
+      : c.json({ error: "conversation_not_found" }, 404)
+  })
+  app.openapi(replyRoute, async (c) => {
+    if (!options.admission) return c.json({ error: "message_admission_unavailable" }, 409)
+    try {
+      const part = await replyToConversation(options.resolveDb(c.env), options.admission, {
+        conversationId: c.req.valid("param").id,
+        ...c.req.valid("json"),
+        runtimeBindings: c.env,
+      })
+      return c.json(response({ data: toPartDto(part) }), 201)
+    } catch (error) {
+      const mapped = serviceError(error)
+      if (!mapped) throw error
+      return c.json({ error: mapped.error }, mapped.status)
+    }
+  })
+  app.openapi(startRoute, async (c) => {
+    if (!options.admission || !options.personDirectory)
+      return c.json({ error: "conversation_runtime_unavailable" }, 409)
+    try {
+      const detail = await startConversation(
+        options.resolveDb(c.env),
+        options.admission,
+        options.personDirectory,
+        { ...c.req.valid("json"), runtimeBindings: c.env },
+      )
+      return c.json(response({ data: toDetailDto(detail) }), 201)
+    } catch (error) {
+      const mapped = serviceError(error)
+      if (!mapped) throw error
+      return c.json({ error: mapped.error }, mapped.status)
+    }
+  })
+  app.openapi(stateRoute, async (c) => {
+    try {
+      return c.json(
+        response({
+          data: toConversationDto(
+            await updateConversationState(
+              options.resolveDb(c.env),
+              c.req.valid("param").id,
+              c.req.valid("json"),
+            ),
+          ),
+        }),
+        200,
+      )
+    } catch (error) {
+      if (!(error instanceof ConversationNotFoundError)) throw error
+      return c.json({ error: error.code }, 404)
+    }
+  })
+  app.openapi(readRoute, async (c) => {
+    try {
+      return c.json(
+        response({
+          data: toConversationDto(
+            await markConversationRead(options.resolveDb(c.env), c.req.valid("param").id),
+          ),
+        }),
+        200,
+      )
+    } catch (error) {
+      if (!(error instanceof ConversationNotFoundError)) throw error
+      return c.json({ error: error.code }, 404)
+    }
+  })
+  return app
+}

--- a/packages/conversations/src/runtime-contributor.ts
+++ b/packages/conversations/src/runtime-contributor.ts
@@ -1,0 +1,14 @@
+import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import { conversationsDatabaseRuntimePort } from "./runtime-port.js"
+
+/** Supply the package-owned database runtime from standard host primitives. */
+export function createConversationsRuntimePortContribution(host: {
+  primitives: VoyantRuntimeHostPrimitives
+}): Readonly<Record<string, unknown>> {
+  return {
+    [conversationsDatabaseRuntimePort.id]: {
+      resolveDb: (bindings?: unknown) =>
+        host.primitives.database.resolve(bindings as Record<string, unknown> | undefined),
+    },
+  }
+}

--- a/packages/conversations/src/runtime-port.ts
+++ b/packages/conversations/src/runtime-port.ts
@@ -1,0 +1,86 @@
+import type {
+  ConversationIngressSource,
+  ConversationsRenderedMessageAdmission,
+} from "@voyant-travel/conversations-contracts"
+import { definePort } from "@voyant-travel/core/project"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+
+export interface ConversationsDatabaseRuntime {
+  resolveDb(bindings?: unknown): AnyDrizzleDb
+}
+
+export type {
+  ConversationMessageAdmissionResult,
+  ConversationRenderedServiceMessage,
+  ConversationsRenderedMessageAdmission,
+} from "@voyant-travel/conversations-contracts"
+
+export type PersonEmailResolution =
+  | { kind: "none" }
+  | { kind: "ambiguous" }
+  | { kind: "unique"; personRef: string; contactPointRef: string; address: string }
+
+/** Read-only People boundary. It deliberately has no create or merge operation. */
+export interface ConversationsPersonDirectory {
+  resolveEmail(db: unknown, address: string): Promise<PersonEmailResolution>
+  resolvePersonContactPoint(
+    db: unknown,
+    input: { personRef: string; contactPointRef: string },
+  ): Promise<{ address: string } | null>
+}
+
+export const conversationsDatabaseRuntimePort = definePort<ConversationsDatabaseRuntime>({
+  id: "conversations.database",
+  test(provider) {
+    if (!provider || typeof provider !== "object" || typeof provider.resolveDb !== "function") {
+      throw new Error("conversations.database provider must implement resolveDb().")
+    }
+  },
+})
+export const conversationIngressSourcePort = definePort<ConversationIngressSource>({
+  id: "conversations.ingress-source",
+  test(provider) {
+    if (
+      !provider ||
+      typeof provider !== "object" ||
+      typeof provider.id !== "string" ||
+      typeof provider.list !== "function" ||
+      typeof provider.fetch !== "function" ||
+      typeof provider.ack !== "function"
+    ) {
+      throw new Error(
+        "conversations.ingress-source provider must implement list(), fetch(), and ack().",
+      )
+    }
+  },
+})
+export const conversationsRenderedMessageAdmissionPort =
+  definePort<ConversationsRenderedMessageAdmission>({
+    id: "conversations.rendered-message-admission",
+    test(provider) {
+      if (
+        !provider ||
+        typeof provider !== "object" ||
+        typeof provider.admitRenderedServiceMessage !== "function"
+      ) {
+        throw new Error(
+          "conversations.rendered-message-admission provider must implement admitRenderedServiceMessage().",
+        )
+      }
+    },
+  })
+export const conversationsPersonDirectoryPort = definePort<ConversationsPersonDirectory>({
+  id: "conversations.person-directory",
+  test(provider) {
+    if (
+      !provider ||
+      typeof provider !== "object" ||
+      typeof provider.resolveEmail !== "function" ||
+      typeof provider.resolvePersonContactPoint !== "function"
+    ) {
+      throw new Error(
+        "conversations.person-directory provider must implement read-only resolution methods.",
+      )
+    }
+  },
+})

--- a/packages/conversations/src/schema.ts
+++ b/packages/conversations/src/schema.ts
@@ -1,0 +1,173 @@
+import type { Module } from "@voyant-travel/core"
+import { typeId, typeIdRef } from "@voyant-travel/db/lib/typeid-column"
+import {
+  index,
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+} from "drizzle-orm/pg-core"
+
+export const conversationStatusEnum = pgEnum("conversation_status", ["open", "closed", "snoozed"])
+export const conversationPartDirectionEnum = pgEnum("conversation_part_direction", [
+  "inbound",
+  "outbound",
+])
+export const conversationPartDeliveryStatusEnum = pgEnum("conversation_part_delivery_status", [
+  "received",
+  "pending",
+  "accepted",
+  "delivered",
+  "failed",
+  "bounced",
+  "complained",
+  "suppressed",
+  "cancelled",
+])
+export const conversationParticipantRoleEnum = pgEnum("conversation_participant_role", [
+  "customer",
+  "staff",
+])
+export const conversationIngressStatusEnum = pgEnum("conversation_ingress_status", [
+  "committed",
+  "drifted",
+])
+
+export const conversations = pgTable(
+  "conversations",
+  {
+    id: typeId("conversations"),
+    channel: text("channel").notNull().default("email"),
+    status: conversationStatusEnum("status").notNull().default("open"),
+    subject: text("subject"),
+    suggestedSubject: text("suggested_subject"),
+    replyAlias: text("reply_alias").notNull(),
+    customerAddress: text("customer_address").notNull(),
+    personRef: text("person_ref"),
+    contactPointRef: text("contact_point_ref"),
+    startIdempotencyKey: text("start_idempotency_key"),
+    startPayloadFingerprint: text("start_payload_fingerprint"),
+    unreadCount: integer("unread_count").notNull().default(0),
+    snoozedUntil: timestamp("snoozed_until", { withTimezone: true }),
+    lastPartAt: timestamp("last_part_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uidx_conversations_reply_alias").on(table.replyAlias),
+    uniqueIndex("uidx_conversations_start_idempotency").on(table.startIdempotencyKey),
+    index("idx_conversations_last_part").on(table.lastPartAt),
+    index("idx_conversations_person").on(table.personRef),
+  ],
+)
+
+export const conversationParticipants = pgTable(
+  "conversation_participants",
+  {
+    id: typeId("conversation_participants"),
+    conversationId: typeIdRef("conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    role: conversationParticipantRoleEnum("role").notNull(),
+    address: text("address").notNull(),
+    personRef: text("person_ref"),
+    contactPointRef: text("contact_point_ref"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uidx_conversation_participant_address").on(
+      table.conversationId,
+      table.role,
+      table.address,
+    ),
+  ],
+)
+
+export const conversationParts = pgTable(
+  "conversation_parts",
+  {
+    id: typeId("conversation_parts"),
+    conversationId: typeIdRef("conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    direction: conversationPartDirectionEnum("direction").notNull(),
+    senderAddress: text("sender_address").notNull(),
+    recipientAddresses: jsonb("recipient_addresses").$type<string[]>().notNull().default([]),
+    subject: text("subject"),
+    textBody: text("text_body"),
+    htmlBody: text("html_body"),
+    attachments: jsonb("attachments")
+      .$type<readonly Record<string, unknown>[]>()
+      .notNull()
+      .default([]),
+    externalSourceId: text("external_source_id"),
+    externalMessageId: text("external_message_id"),
+    messageId: text("message_id"),
+    inReplyTo: text("in_reply_to"),
+    references: jsonb("references").$type<string[]>().notNull().default([]),
+    payloadFingerprint: text("payload_fingerprint").notNull(),
+    notificationDeliveryId: text("notification_delivery_id"),
+    idempotencyKey: text("idempotency_key"),
+    deliveryStatus: conversationPartDeliveryStatusEnum("delivery_status").notNull(),
+    occurredAt: timestamp("occurred_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uidx_conversation_parts_external_message").on(
+      table.externalSourceId,
+      table.externalMessageId,
+    ),
+    uniqueIndex("uidx_conversation_parts_message_id").on(table.messageId),
+    uniqueIndex("uidx_conversation_parts_idempotency").on(table.idempotencyKey),
+    index("idx_conversation_parts_conversation_occurred").on(
+      table.conversationId,
+      table.occurredAt,
+    ),
+  ],
+)
+
+export const conversationEvents = pgTable(
+  "conversation_events",
+  {
+    id: typeId("conversation_events"),
+    conversationId: typeIdRef("conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    type: text("type").notNull(),
+    payload: jsonb("payload").$type<Record<string, unknown>>().notNull().default({}),
+    occurredAt: timestamp("occurred_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_conversation_events_conversation").on(table.conversationId, table.occurredAt),
+  ],
+)
+
+export const conversationIngressOperations = pgTable(
+  "conversation_ingress_operations",
+  {
+    id: typeId("conversation_ingress_operations"),
+    sourceId: text("source_id").notNull(),
+    externalEnvelopeId: text("external_envelope_id").notNull(),
+    externalMessageId: text("external_message_id").notNull(),
+    payloadFingerprint: text("payload_fingerprint").notNull(),
+    conversationPartId: typeIdRef("conversation_part_id").references(() => conversationParts.id, {
+      onDelete: "restrict",
+    }),
+    status: conversationIngressStatusEnum("status").notNull().default("committed"),
+    error: text("error"),
+    committedAt: timestamp("committed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uidx_conversation_ingress_envelope").on(table.sourceId, table.externalEnvelopeId),
+    uniqueIndex("uidx_conversation_ingress_message").on(table.sourceId, table.externalMessageId),
+  ],
+)
+
+export type Conversation = typeof conversations.$inferSelect
+export type ConversationPart = typeof conversationParts.$inferSelect
+
+export const conversationsModule: Module = { name: "conversations", requiresTransactionalDb: true }

--- a/packages/conversations/src/service.ts
+++ b/packages/conversations/src/service.ts
@@ -1,0 +1,538 @@
+import {
+  canonicalEnvelopePayload,
+  canonicalMessageId,
+  type InboundEmailEnvelopeV1,
+  normalizeEmailAddress,
+} from "@voyant-travel/conversations-contracts"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { and, desc, eq, inArray, or, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type {
+  ConversationRenderedServiceMessage,
+  ConversationsPersonDirectory,
+  ConversationsRenderedMessageAdmission,
+} from "./runtime-port.js"
+import {
+  type Conversation,
+  type ConversationPart,
+  conversationEvents,
+  conversationIngressOperations,
+  conversationParticipants,
+  conversationParts,
+  conversations,
+} from "./schema.js"
+import { createReplyAlias, inboundThreadIds, selectExactConversation } from "./threading.js"
+
+export class ConversationIngressDriftError extends Error {
+  readonly code = "ingress_payload_drift"
+}
+
+export class ConversationNotFoundError extends Error {
+  readonly code = "conversation_not_found"
+}
+
+export class ConversationConflictError extends Error {
+  readonly code = "conversation_conflict"
+}
+
+export interface ConversationDetail {
+  conversation: Conversation
+  parts: ConversationPart[]
+}
+
+/** Fingerprint every delivery-affecting field while excluding the generated Part id. */
+export function conversationReplyFingerprint(message: ConversationRenderedServiceMessage): string {
+  return JSON.stringify({ ...message, target: { ...message.target, id: "" } })
+}
+
+export async function listConversations(
+  db: PostgresJsDatabase,
+  query: { limit?: number; status?: "open" | "closed" | "snoozed" } = {},
+): Promise<Conversation[]> {
+  return db
+    .select()
+    .from(conversations)
+    .where(query.status ? eq(conversations.status, query.status) : undefined)
+    .orderBy(desc(conversations.lastPartAt))
+    .limit(Math.min(query.limit ?? 50, 100))
+}
+
+export async function getConversation(
+  db: PostgresJsDatabase,
+  id: string,
+): Promise<ConversationDetail | null> {
+  const [conversation] = await db
+    .select()
+    .from(conversations)
+    .where(eq(conversations.id, id))
+    .limit(1)
+  if (!conversation) return null
+  const parts = await db
+    .select()
+    .from(conversationParts)
+    .where(eq(conversationParts.conversationId, id))
+    .orderBy(conversationParts.occurredAt)
+  return { conversation, parts }
+}
+
+/** Idempotently commit one provider-neutral envelope. Acknowledgement happens outside this transaction. */
+export async function ingestEnvelope(
+  db: PostgresJsDatabase,
+  envelope: InboundEmailEnvelopeV1,
+  options: { personDirectory?: ConversationsPersonDirectory } = {},
+): Promise<{ conversationId: string; partId: string; duplicate: boolean }> {
+  const fingerprint = canonicalEnvelopePayload(envelope)
+  const result = await db.transaction(async (tx) => {
+    const operationId = newId("conversation_ingress_operations")
+    const [claimed] = await tx
+      .insert(conversationIngressOperations)
+      .values({
+        id: operationId,
+        sourceId: envelope.sourceId,
+        externalEnvelopeId: envelope.externalEnvelopeId,
+        externalMessageId: envelope.externalMessageId,
+        payloadFingerprint: fingerprint,
+        status: "committed",
+      })
+      .onConflictDoNothing()
+      .returning({ id: conversationIngressOperations.id })
+    if (!claimed) {
+      const identities = await findIngressIdentities(tx as PostgresJsDatabase, envelope)
+      if (identities.length === 0) {
+        throw new ConversationConflictError(
+          "Inbound identity claim was lost without a replay record",
+        )
+      }
+      if (identities.some((identity) => identity.payloadFingerprint !== fingerprint)) {
+        await tx
+          .update(conversationIngressOperations)
+          .set({
+            status: "drifted",
+            error: "A replay reused an identity with different content",
+          })
+          .where(
+            inArray(
+              conversationIngressOperations.id,
+              identities.map(({ id }) => id),
+            ),
+          )
+        return { kind: "drift" as const }
+      }
+      const existing = identities[0]!
+      if (!existing.conversationPartId) {
+        throw new ConversationConflictError("Committed ingress is missing its part")
+      }
+      const [part] = await tx
+        .select({ conversationId: conversationParts.conversationId })
+        .from(conversationParts)
+        .where(eq(conversationParts.id, existing.conversationPartId))
+        .limit(1)
+      if (!part) throw new ConversationConflictError("Committed ingress references a missing part")
+      return {
+        kind: "result" as const,
+        value: {
+          conversationId: part.conversationId,
+          partId: existing.conversationPartId,
+          duplicate: true,
+        },
+      }
+    }
+
+    const aliasMatches = await exactAliasMatches(tx as PostgresJsDatabase, envelope)
+    const headerMatches = await exactHeaderMatches(tx as PostgresJsDatabase, envelope)
+    let conversationId = selectExactConversation({ aliasMatches, headerMatches })
+    const occurredAt = new Date(envelope.occurredAt)
+    const senderAddress = normalizeEmailAddress(envelope.sender.address)
+    let resolution: Awaited<ReturnType<ConversationsPersonDirectory["resolveEmail"]>> = {
+      kind: "none",
+    }
+    if (options.personDirectory)
+      resolution = await options.personDirectory.resolveEmail(tx, senderAddress)
+
+    if (!conversationId) {
+      conversationId = newId("conversations")
+      const receivingAddress = envelope.to[0]?.address
+      if (!receivingAddress) throw new Error("Inbound email has no receiving address")
+      const person = resolution.kind === "unique" ? resolution : null
+      await tx.insert(conversations).values({
+        id: conversationId,
+        subject: envelope.subject,
+        suggestedSubject: envelope.subject,
+        replyAlias: createReplyAlias(conversationId, receivingAddress),
+        customerAddress: senderAddress,
+        personRef: person?.personRef ?? null,
+        contactPointRef: person?.contactPointRef ?? null,
+        unreadCount: 1,
+        lastPartAt: occurredAt,
+      })
+      await tx.insert(conversationParticipants).values({
+        conversationId,
+        role: "customer",
+        address: senderAddress,
+        personRef: person?.personRef ?? null,
+        contactPointRef: person?.contactPointRef ?? null,
+      })
+    } else {
+      await tx
+        .update(conversations)
+        .set({
+          status: "open",
+          snoozedUntil: null,
+          lastPartAt: occurredAt,
+          unreadCount: sql`${conversations.unreadCount} + 1`,
+          updatedAt: new Date(),
+        })
+        .where(eq(conversations.id, conversationId))
+    }
+
+    const partId = newId("conversation_parts")
+    const messageId = envelope.threading.messageId
+      ? canonicalMessageId(envelope.threading.messageId)
+      : null
+    await tx.insert(conversationParts).values({
+      id: partId,
+      conversationId,
+      direction: "inbound",
+      senderAddress,
+      recipientAddresses: [...envelope.to, ...envelope.cc].map(({ address }) =>
+        normalizeEmailAddress(address),
+      ),
+      subject: envelope.subject,
+      textBody: envelope.text,
+      htmlBody: envelope.html,
+      attachments: envelope.attachments,
+      externalSourceId: envelope.sourceId,
+      externalMessageId: envelope.externalMessageId,
+      messageId,
+      inReplyTo: envelope.threading.inReplyTo
+        ? canonicalMessageId(envelope.threading.inReplyTo)
+        : null,
+      references: envelope.threading.references.map(canonicalMessageId),
+      payloadFingerprint: fingerprint,
+      deliveryStatus: "received",
+      occurredAt,
+    })
+    await tx
+      .update(conversationIngressOperations)
+      .set({
+        conversationPartId: partId,
+        status: "committed",
+        committedAt: new Date(),
+      })
+      .where(eq(conversationIngressOperations.id, operationId))
+    await tx.insert(conversationEvents).values({
+      conversationId,
+      type: "part.received",
+      payload: { partId, sourceId: envelope.sourceId },
+      occurredAt,
+    })
+    return { kind: "result" as const, value: { conversationId, partId, duplicate: false } }
+  })
+  if (result.kind === "drift") {
+    throw new ConversationIngressDriftError("Inbound identity was replayed with different content")
+  }
+  return result.value
+}
+
+async function findIngressIdentities(db: PostgresJsDatabase, envelope: InboundEmailEnvelopeV1) {
+  return db
+    .select()
+    .from(conversationIngressOperations)
+    .where(
+      or(
+        and(
+          eq(conversationIngressOperations.sourceId, envelope.sourceId),
+          eq(conversationIngressOperations.externalEnvelopeId, envelope.externalEnvelopeId),
+        ),
+        and(
+          eq(conversationIngressOperations.sourceId, envelope.sourceId),
+          eq(conversationIngressOperations.externalMessageId, envelope.externalMessageId),
+        ),
+      ),
+    )
+}
+
+async function exactAliasMatches(
+  db: PostgresJsDatabase,
+  envelope: InboundEmailEnvelopeV1,
+): Promise<string[]> {
+  const recipients = [...envelope.to, ...envelope.cc].map(({ address }) =>
+    normalizeEmailAddress(address),
+  )
+  if (recipients.length === 0) return []
+  const rows = await db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(inArray(conversations.replyAlias, recipients))
+  return rows.map(({ id }) => id)
+}
+
+async function exactHeaderMatches(
+  db: PostgresJsDatabase,
+  envelope: InboundEmailEnvelopeV1,
+): Promise<string[]> {
+  const identifiers = inboundThreadIds(envelope.threading)
+  if (identifiers.length === 0) return []
+  const rows = await db
+    .select({ conversationId: conversationParts.conversationId })
+    .from(conversationParts)
+    .where(inArray(conversationParts.messageId, identifiers))
+  return rows.map(({ conversationId }) => conversationId)
+}
+
+export async function replyToConversation(
+  db: PostgresJsDatabase,
+  admission: ConversationsRenderedMessageAdmission,
+  input: {
+    conversationId: string
+    channelAccountId: string
+    text: string | null
+    html?: string | null
+    idempotencyKey: string
+    runtimeBindings?: unknown
+  },
+): Promise<ConversationPart> {
+  return db.transaction(async (transaction) => {
+    const tx = transaction as PostgresJsDatabase
+    const [conversation] = await tx
+      .select()
+      .from(conversations)
+      .where(eq(conversations.id, input.conversationId))
+      .limit(1)
+    if (!conversation) throw new ConversationNotFoundError("Conversation not found")
+    return admitReplyWithinTransaction(tx, admission, conversation, input)
+  })
+}
+
+export async function startConversation(
+  db: PostgresJsDatabase,
+  admission: ConversationsRenderedMessageAdmission,
+  directory: ConversationsPersonDirectory,
+  input: {
+    personRef: string
+    contactPointRef: string
+    channelAccountId: string
+    fromAddress: string
+    subject: string | null
+    text: string
+    idempotencyKey: string
+    runtimeBindings?: unknown
+  },
+): Promise<ConversationDetail> {
+  const contact = await directory.resolvePersonContactPoint(db, input)
+  if (!contact) throw new ConversationNotFoundError("Known Person contact point not found")
+  const customerAddress = normalizeEmailAddress(contact.address)
+  const startFingerprint = JSON.stringify({
+    personRef: input.personRef,
+    contactPointRef: input.contactPointRef,
+    channelAccountId: input.channelAccountId,
+    fromAddress: normalizeEmailAddress(input.fromAddress),
+    customerAddress,
+    subject: input.subject,
+    text: input.text,
+  })
+  const conversationId = await db.transaction(async (transaction) => {
+    const tx = transaction as PostgresJsDatabase
+    const id = newId("conversations")
+    const now = new Date()
+    const [created] = await tx
+      .insert(conversations)
+      .values({
+        id,
+        subject: input.subject,
+        suggestedSubject: null,
+        replyAlias: createReplyAlias(id, input.fromAddress),
+        customerAddress,
+        personRef: input.personRef,
+        contactPointRef: input.contactPointRef,
+        startIdempotencyKey: input.idempotencyKey,
+        startPayloadFingerprint: startFingerprint,
+        lastPartAt: now,
+      })
+      .onConflictDoNothing({ target: conversations.startIdempotencyKey })
+      .returning()
+    if (!created) {
+      const [existing] = await tx
+        .select()
+        .from(conversations)
+        .where(eq(conversations.startIdempotencyKey, input.idempotencyKey))
+        .limit(1)
+      if (!existing) throw new ConversationConflictError("Conversation start claim was lost")
+      if (existing.startPayloadFingerprint !== startFingerprint) {
+        throw new ConversationConflictError(
+          "Start idempotency key was reused with different content",
+        )
+      }
+      return existing.id
+    }
+    await tx.insert(conversationParticipants).values({
+      conversationId: id,
+      role: "customer",
+      address: customerAddress,
+      personRef: input.personRef,
+      contactPointRef: input.contactPointRef,
+    })
+    await admitReplyWithinTransaction(tx, admission, created, {
+      conversationId: id,
+      channelAccountId: input.channelAccountId,
+      text: input.text,
+      idempotencyKey: input.idempotencyKey,
+      runtimeBindings: input.runtimeBindings,
+    })
+    return id
+  })
+  const detail = await getConversation(db, conversationId)
+  if (!detail) throw new Error("Started conversation disappeared")
+  return detail
+}
+
+async function admitReplyWithinTransaction(
+  tx: PostgresJsDatabase,
+  admission: ConversationsRenderedMessageAdmission,
+  conversation: Conversation,
+  input: {
+    conversationId: string
+    channelAccountId: string
+    text: string | null
+    html?: string | null
+    idempotencyKey: string
+    runtimeBindings?: unknown
+  },
+): Promise<ConversationPart> {
+  const [lastPart] = await tx
+    .select()
+    .from(conversationParts)
+    .where(eq(conversationParts.conversationId, conversation.id))
+    .orderBy(desc(conversationParts.occurredAt))
+    .limit(1)
+  const [lastOutbound] = await tx
+    .select()
+    .from(conversationParts)
+    .where(
+      and(
+        eq(conversationParts.conversationId, conversation.id),
+        eq(conversationParts.direction, "outbound"),
+      ),
+    )
+    .orderBy(desc(conversationParts.occurredAt))
+    .limit(1)
+  const references = lastPart?.messageId ? [...lastPart.references, lastPart.messageId] : []
+  const message = {
+    channelAccountId: input.channelAccountId,
+    target: { type: "@voyant-travel/conversations#part" as const, id: "" },
+    purpose: "conversation-reply" as const,
+    idempotencyKey: input.idempotencyKey,
+    to: conversation.customerAddress,
+    ...(conversation.subject ? { subject: conversation.subject } : {}),
+    ...(input.text ? { text: input.text } : {}),
+    ...(input.html ? { sanitizedHtml: input.html } : {}),
+    thread: {
+      threadId: conversation.id,
+      ...(lastOutbound?.notificationDeliveryId
+        ? { replyToDeliveryId: lastOutbound.notificationDeliveryId }
+        : {}),
+    },
+    metadata: {
+      replyAlias: conversation.replyAlias,
+      inReplyTo: lastPart?.messageId ?? null,
+      references,
+    },
+  }
+  const fingerprint = conversationReplyFingerprint(message)
+  const partId = newId("conversation_parts")
+  message.target.id = partId
+  const now = new Date()
+  const [inserted] = await tx
+    .insert(conversationParts)
+    .values({
+      id: partId,
+      conversationId: conversation.id,
+      direction: "outbound",
+      senderAddress: conversation.replyAlias,
+      recipientAddresses: [conversation.customerAddress],
+      subject: conversation.subject,
+      textBody: input.text,
+      htmlBody: input.html ?? null,
+      payloadFingerprint: fingerprint,
+      idempotencyKey: input.idempotencyKey,
+      deliveryStatus: "pending",
+      occurredAt: now,
+      inReplyTo: lastPart?.messageId ?? null,
+      references,
+    })
+    .onConflictDoNothing({ target: conversationParts.idempotencyKey })
+    .returning()
+  if (!inserted) {
+    const [existing] = await tx
+      .select()
+      .from(conversationParts)
+      .where(eq(conversationParts.idempotencyKey, input.idempotencyKey))
+      .limit(1)
+    if (!existing) throw new ConversationConflictError("Reply idempotency claim was lost")
+    if (existing.payloadFingerprint !== fingerprint) {
+      throw new ConversationConflictError("Reply idempotency key was reused with different content")
+    }
+    return existing
+  }
+  let admitted: Awaited<
+    ReturnType<ConversationsRenderedMessageAdmission["admitRenderedServiceMessage"]>
+  >
+  try {
+    admitted = await admission.admitRenderedServiceMessage(tx, message, {
+      bindings: input.runtimeBindings,
+    })
+  } catch {
+    throw new ConversationConflictError("Rendered message admission was rejected")
+  }
+  const [part] = await tx
+    .update(conversationParts)
+    .set({
+      notificationDeliveryId: admitted.deliveryId,
+      deliveryStatus: admitted.state,
+    })
+    .where(eq(conversationParts.id, partId))
+    .returning()
+  await tx
+    .update(conversations)
+    .set({ lastPartAt: now, updatedAt: now })
+    .where(eq(conversations.id, conversation.id))
+  await tx.insert(conversationEvents).values({
+    conversationId: conversation.id,
+    type: "reply.admitted",
+    payload: { partId, deliveryId: admitted.deliveryId },
+  })
+  if (!part) throw new Error("Reply part disappeared during admission")
+  return part
+}
+
+export async function updateConversationState(
+  db: PostgresJsDatabase,
+  id: string,
+  input: { status: "open" | "closed" | "snoozed"; snoozedUntil?: string | null },
+): Promise<Conversation> {
+  const [row] = await db
+    .update(conversations)
+    .set({
+      status: input.status,
+      snoozedUntil:
+        input.status === "snoozed" && input.snoozedUntil ? new Date(input.snoozedUntil) : null,
+      updatedAt: new Date(),
+    })
+    .where(eq(conversations.id, id))
+    .returning()
+  if (!row) throw new ConversationNotFoundError("Conversation not found")
+  return row
+}
+
+export async function markConversationRead(
+  db: PostgresJsDatabase,
+  id: string,
+): Promise<Conversation> {
+  const [row] = await db
+    .update(conversations)
+    .set({ unreadCount: 0, updatedAt: new Date() })
+    .where(eq(conversations.id, id))
+    .returning()
+  if (!row) throw new ConversationNotFoundError("Conversation not found")
+  return row
+}

--- a/packages/conversations/src/threading.ts
+++ b/packages/conversations/src/threading.ts
@@ -1,0 +1,37 @@
+import { canonicalMessageId, normalizeEmailAddress } from "@voyant-travel/conversations-contracts"
+
+export class ConversationThreadConflictError extends Error {
+  readonly code = "ambiguous_thread"
+}
+
+/** Subject is intentionally absent: only exact aliases and threading identifiers participate. */
+export function selectExactConversation(input: {
+  aliasMatches: readonly string[]
+  headerMatches: readonly string[]
+}): string | null {
+  const matches = new Set([...input.aliasMatches, ...input.headerMatches])
+  if (matches.size > 1)
+    throw new ConversationThreadConflictError("Exact thread identities disagree")
+  return matches.values().next().value ?? null
+}
+
+export function inboundThreadIds(input: {
+  inReplyTo: string | null
+  references: readonly string[]
+}): string[] {
+  return [
+    ...new Set(
+      [input.inReplyTo, ...input.references]
+        .filter((value): value is string => !!value)
+        .map(canonicalMessageId),
+    ),
+  ]
+}
+
+export function createReplyAlias(conversationId: string, receivingAddress: string): string {
+  const normalized = normalizeEmailAddress(receivingAddress)
+  const separator = normalized.lastIndexOf("@")
+  if (separator <= 0)
+    throw new Error("Cannot derive a reply alias from an invalid receiving address")
+  return `${normalized.slice(0, separator)}+${conversationId}@${normalized.slice(separator + 1)}`
+}

--- a/packages/conversations/src/voyant.ts
+++ b/packages/conversations/src/voyant.ts
@@ -1,0 +1,105 @@
+import { defineModule, requirePort } from "@voyant-travel/core/project"
+import {
+  conversationIngressSourcePort,
+  conversationsDatabaseRuntimePort,
+  conversationsPersonDirectoryPort,
+  conversationsRenderedMessageAdmissionPort,
+} from "./runtime-port.js"
+
+const apiRuntime = {
+  entry: "@voyant-travel/conversations",
+  export: "createConversationsVoyantRuntime",
+} as const
+const adminRuntime = {
+  entry: "@voyant-travel/conversations-react/admin",
+  export: "createSelectedConversationsAdminExtension",
+} as const
+
+export const conversationsVoyantModule = defineModule({
+  id: "@voyant-travel/conversations",
+  packageName: "@voyant-travel/conversations",
+  localId: "conversations",
+  runtimePorts: [
+    requirePort(conversationsDatabaseRuntimePort),
+    requirePort(conversationIngressSourcePort, { optional: true, cardinality: "many" }),
+    requirePort(conversationsRenderedMessageAdmissionPort, { optional: true }),
+    requirePort(conversationsPersonDirectoryPort, { optional: true }),
+  ],
+  api: [
+    {
+      id: "@voyant-travel/conversations#api.admin",
+      surface: "admin",
+      mount: "conversations",
+      resource: "conversations",
+      transactional: true,
+      openapi: { document: "conversations" },
+      runtime: apiRuntime,
+    },
+  ],
+  schema: [
+    { id: "@voyant-travel/conversations#schema", source: "@voyant-travel/conversations/schema" },
+  ],
+  migrations: [{ id: "@voyant-travel/conversations#migrations", source: "./migrations" }],
+  jobs: [
+    {
+      id: "conversations.ingress",
+      schedule: { cron: "* * * * *", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          eager: { cron: "* * * * *", overlap: "skip" },
+          economical: { cron: "*/5 * * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
+        },
+      },
+      wakeup: true,
+      runtime: {
+        entry: "@voyant-travel/conversations/ingress-job",
+        export: "runConversationIngressJob",
+      },
+    },
+  ],
+  access: {
+    resources: [
+      {
+        id: "@voyant-travel/conversations#access.conversations",
+        resource: "conversations",
+        label: "Inbox",
+        description: "Read and reply to customer conversations.",
+        actions: [
+          {
+            action: "read",
+            label: "View conversations",
+            description: "View Inbox conversations and messages.",
+          },
+          {
+            action: "write",
+            label: "Manage conversations",
+            description: "Reply, start, close, and snooze conversations.",
+          },
+        ],
+      },
+    ],
+  },
+  admin: {
+    compositionOrder: 35,
+    runtime: adminRuntime,
+    routes: [
+      {
+        id: "@voyant-travel/conversations#admin.route.inbox",
+        path: "/inbox",
+        runtime: adminRuntime,
+      },
+    ],
+  },
+  lifecycle: { uninstall: { default: "retain-data", purge: "not-supported" } },
+  meta: {
+    ownership: "package",
+    agentTools: {
+      posture: "not-applicable",
+      rationale: "The first Inbox slice is staff-operated through admin routes.",
+    },
+  },
+})
+
+export default conversationsVoyantModule

--- a/packages/conversations/tests/integration/ingress-job.test.ts
+++ b/packages/conversations/tests/integration/ingress-job.test.ts
@@ -1,0 +1,68 @@
+import type { InboundEmailEnvelopeV1 } from "@voyant-travel/conversations-contracts"
+import { describe, expect, it, vi } from "vitest"
+import { processConversationIngress } from "../../src/ingress-job.js"
+
+const envelope: InboundEmailEnvelopeV1 = {
+  version: "1",
+  sourceId: "source",
+  externalEnvelopeId: "env-1",
+  externalMessageId: "message-1",
+  sender: { address: "customer@example.test" },
+  to: [{ address: "inbox@example.test" }],
+  cc: [],
+  replyTo: [],
+  subject: "Hello",
+  text: "Question",
+  html: null,
+  attachments: [],
+  threading: { messageId: "<message-1@example.test>", inReplyTo: null, references: [] },
+  occurredAt: "2026-08-17T10:00:00.000Z",
+}
+
+describe("durable ingress list/fetch/ack", () => {
+  it("leaves an item unacknowledged when interruption happens after commit and acknowledges duplicate replay", async () => {
+    let duplicate = false
+    const ack = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("process interrupted"))
+      .mockResolvedValue(undefined)
+    const source = {
+      id: "source",
+      list: vi.fn(async () => ({ items: [{ id: "env-1" }] })),
+      fetch: vi.fn(async () => envelope),
+      ack,
+    }
+    const ingest = vi.fn(async () => {
+      const isDuplicate = duplicate
+      duplicate = true
+      return {
+        conversationId: "conv_1",
+        partId: "part_1",
+        duplicate: isDuplicate,
+      }
+    })
+    await expect(
+      processConversationIngress({ db: {} as never, sources: [source], ingest }),
+    ).rejects.toThrow("interrupted")
+    await expect(
+      processConversationIngress({ db: {} as never, sources: [source], ingest }),
+    ).resolves.toEqual({ fetched: 1, committed: 0, duplicates: 1, acknowledged: 1 })
+    expect(ingest).toHaveBeenCalledTimes(2)
+    expect(ack).toHaveBeenCalledTimes(2)
+  })
+
+  it("validates a fetched envelope before commit or acknowledgement", async () => {
+    const source = {
+      id: "source",
+      list: vi.fn(async () => ({ items: [{ id: "invalid" }] })),
+      fetch: vi.fn(async () => ({ ...envelope, sender: { address: "not-an-email" } }) as never),
+      ack: vi.fn(async () => undefined),
+    }
+    const ingest = vi.fn()
+    await expect(
+      processConversationIngress({ db: {} as never, sources: [source], ingest }),
+    ).rejects.toThrow()
+    expect(ingest).not.toHaveBeenCalled()
+    expect(source.ack).not.toHaveBeenCalled()
+  })
+})

--- a/packages/conversations/tests/unit/runtime-port.test.ts
+++ b/packages/conversations/tests/unit/runtime-port.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import {
+  conversationsPersonDirectoryPort,
+  conversationsRenderedMessageAdmissionPort,
+} from "../../src/runtime-port.js"
+
+describe("Conversations-owned consumer ports", () => {
+  it("keeps People resolution read-only", () => {
+    const provider = {
+      resolveEmail: async () => ({ kind: "none" as const }),
+      resolvePersonContactPoint: async () => null,
+    }
+    expect(() => conversationsPersonDirectoryPort.test?.(provider)).not.toThrow()
+    expect(provider).not.toHaveProperty("create")
+    expect(provider).not.toHaveProperty("merge")
+  })
+
+  it("requires transactional rendered-message admission", () => {
+    expect(() =>
+      conversationsRenderedMessageAdmissionPort.test?.({
+        admitRenderedServiceMessage: async () => ({
+          deliveryId: "delivery_1",
+          state: "pending" as const,
+        }),
+      }),
+    ).not.toThrow()
+    expect(() => conversationsRenderedMessageAdmissionPort.test?.({} as never)).toThrow(
+      "admitRenderedServiceMessage",
+    )
+  })
+})

--- a/packages/conversations/tests/unit/threading.test.ts
+++ b/packages/conversations/tests/unit/threading.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import { conversationReplyFingerprint } from "../../src/service.js"
+import { createReplyAlias, inboundThreadIds, selectExactConversation } from "../../src/threading.js"
+
+describe("exact email threading", () => {
+  it("selects an exact alias or standard header identity", () => {
+    expect(selectExactConversation({ aliasMatches: ["conv_1"], headerMatches: [] })).toBe("conv_1")
+    expect(selectExactConversation({ aliasMatches: [], headerMatches: ["conv_1"] })).toBe("conv_1")
+    expect(selectExactConversation({ aliasMatches: ["conv_1"], headerMatches: ["conv_1"] })).toBe(
+      "conv_1",
+    )
+  })
+
+  it("fails closed when exact identities disagree", () => {
+    expect(() =>
+      selectExactConversation({ aliasMatches: ["conv_1"], headerMatches: ["conv_2"] }),
+    ).toThrow("disagree")
+  })
+
+  it("has no subject input and therefore cannot thread by normalized subject", () => {
+    expect(selectExactConversation({ aliasMatches: [], headerMatches: [] })).toBeNull()
+  })
+
+  it("canonicalizes In-Reply-To and References and creates opaque aliases", () => {
+    expect(
+      inboundThreadIds({
+        inReplyTo: "<First@Example.Test>",
+        references: ["first@example.test", "<Second@Example.Test>"],
+      }),
+    ).toEqual(["first@example.test", "second@example.test"])
+    expect(createReplyAlias("conv_opaque", "Inbox@Example.Test")).toBe(
+      "inbox+conv_opaque@example.test",
+    )
+  })
+})
+
+describe("reply idempotency fingerprint", () => {
+  const message = {
+    channelAccountId: "account_1",
+    target: { type: "@voyant-travel/conversations#part" as const, id: "part_generated" },
+    purpose: "conversation-reply" as const,
+    idempotencyKey: "reply_1",
+    to: "customer@example.test",
+    subject: "Subject",
+    text: "Body",
+    thread: { threadId: "conversation_1", replyToDeliveryId: "delivery_1" },
+    metadata: {
+      replyAlias: "reply+opaque@example.test",
+      inReplyTo: "message_1",
+      references: ["message_1"],
+    },
+  }
+
+  it("covers the channel account and every delivery-affecting input but not generated Part id", () => {
+    const fingerprint = conversationReplyFingerprint(message)
+    expect(
+      conversationReplyFingerprint({ ...message, target: { ...message.target, id: "part_retry" } }),
+    ).toBe(fingerprint)
+    expect(conversationReplyFingerprint({ ...message, channelAccountId: "account_2" })).not.toBe(
+      fingerprint,
+    )
+    expect(conversationReplyFingerprint({ ...message, to: "other@example.test" })).not.toBe(
+      fingerprint,
+    )
+    expect(conversationReplyFingerprint({ ...message, text: "Changed" })).not.toBe(fingerprint)
+    expect(
+      conversationReplyFingerprint({
+        ...message,
+        metadata: { ...message.metadata, replyAlias: "other@example.test" },
+      }),
+    ).not.toBe(fingerprint)
+    expect(
+      conversationReplyFingerprint({ ...message, thread: { threadId: "conversation_1" } }),
+    ).not.toBe(fingerprint)
+  })
+})

--- a/packages/conversations/tsconfig.build.json
+++ b/packages/conversations/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}

--- a/packages/conversations/tsconfig.json
+++ b/packages/conversations/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@voyant-travel/voyant-typescript-config/base.json",
+  "compilerOptions": { "composite": false, "module": "ESNext", "moduleResolution": "Bundler" },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/conversations/tsconfig.typecheck.json
+++ b/packages/conversations/tsconfig.typecheck.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": { "noEmit": true }
+}

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -39,6 +39,8 @@
     "@voyant-travel/action-ledger": "workspace:^",
     "@voyant-travel/bookings": "workspace:^",
     "@voyant-travel/core": "workspace:^",
+    "@voyant-travel/conversations": "workspace:^",
+    "@voyant-travel/conversations-contracts": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/finance": "workspace:^",
     "@voyant-travel/hono": "workspace:^",

--- a/packages/notifications/src/conversations-runtime.ts
+++ b/packages/notifications/src/conversations-runtime.ts
@@ -1,0 +1,30 @@
+import type { ConversationsRenderedMessageAdmission } from "@voyant-travel/conversations-contracts"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { NotificationsRuntimeProvider } from "./runtime-port.js"
+import { admitRenderedServiceMessage } from "./service-channel-accounts.js"
+import type { RenderedServiceMessage } from "./types.js"
+
+/**
+ * Notifications-owned adapter for the Conversations consumer port.
+ *
+ * The supplied transaction is passed to Notifications' normal admission
+ * service, so the Conversation Part and durable Notification delivery commit
+ * or roll back together without Conversations reaching into Notification
+ * tables.
+ */
+export function createConversationsRenderedMessageAdmission(
+  runtime: NotificationsRuntimeProvider,
+): ConversationsRenderedMessageAdmission {
+  return {
+    async admitRenderedServiceMessage(db, message, context) {
+      const bindings = (context?.bindings ?? {}) as Record<string, unknown>
+      const delivery = await admitRenderedServiceMessage(
+        db as PostgresJsDatabase,
+        runtime.resolveProviders(bindings),
+        message satisfies RenderedServiceMessage,
+      )
+      return { deliveryId: delivery.id, state: delivery.status }
+    },
+  }
+}

--- a/packages/notifications/src/runtime-contributor.ts
+++ b/packages/notifications/src/runtime-contributor.ts
@@ -5,6 +5,7 @@ import {
   financeNotificationsRuntimePort,
 } from "@voyant-travel/finance/runtime-port"
 import { customerVerificationRuntimePort } from "@voyant-travel/identity/runtime-port"
+import { conversationsRenderedMessageAdmissionPort } from "@voyant-travel/conversations/runtime-port"
 import type { CustomerVerificationRoutesOptions } from "@voyant-travel/identity/verification"
 import {
   type ProposalsNotificationsRuntime,
@@ -12,6 +13,7 @@ import {
 } from "@voyant-travel/proposals/runtime-port"
 import { relationshipsPersonNotificationsRuntimePort } from "@voyant-travel/relationships/runtime-port"
 import { toCustomerVerificationNotificationProviders } from "./customer-verification-runtime.js"
+import { createConversationsRenderedMessageAdmission } from "./conversations-runtime.js"
 import {
   type DurableNotificationProviderRuntime,
   durableNotificationProviderPort,
@@ -45,6 +47,8 @@ export function createNotificationsRuntimePortContribution(
   } satisfies CustomerVerificationRoutesOptions
   const contribution: Record<string, unknown> = {
     [notificationsRuntimePort.id]: runtime,
+    [conversationsRenderedMessageAdmissionPort.id]:
+      createConversationsRenderedMessageAdmission(runtime),
     [notificationsReminderJobRuntimePort.id]: runtime.resolveReminderJobRuntime(undefined),
     [customerVerificationRuntimePort.id]: verification,
     [financeNotificationsRuntimePort.id]: createFinanceNotificationsRuntime(

--- a/packages/notifications/src/voyant.ts
+++ b/packages/notifications/src/voyant.ts
@@ -10,6 +10,7 @@ import {
 } from "@voyant-travel/core/project"
 import { financeNotificationsRuntimePort } from "@voyant-travel/finance/runtime-port"
 import { customerVerificationRuntimePort } from "@voyant-travel/identity/runtime-port"
+import { conversationsRenderedMessageAdmissionPort } from "@voyant-travel/conversations/runtime-port"
 import { proposalsNotificationsRuntimePort } from "@voyant-travel/proposals/runtime-port"
 import { relationshipsPersonNotificationsRuntimePort } from "@voyant-travel/relationships/runtime-port"
 import { durableNotificationProviderPort } from "./durable-provider-port.js"
@@ -35,6 +36,7 @@ export const notificationsVoyantModule = defineModule({
     capabilities: ["notifications.delivery"],
     ports: [
       providePort(customerVerificationRuntimePort),
+      providePort(conversationsRenderedMessageAdmissionPort),
       providePort(financeNotificationsRuntimePort),
       providePort(notificationsRuntimePort),
       providePort(notificationsReminderJobRuntimePort),

--- a/packages/notifications/tests/unit/conversations-runtime.test.ts
+++ b/packages/notifications/tests/unit/conversations-runtime.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createConversationsRenderedMessageAdmission } from "../../src/conversations-runtime.js"
+import type { NotificationsRuntimeProvider } from "../../src/runtime-port.js"
+
+describe("Conversations rendered-message admission", () => {
+  it("exposes the exact Conversations consumer method", () => {
+    const runtime = {
+      resolveProviders: vi.fn(() => []),
+    } as unknown as NotificationsRuntimeProvider
+    const provider = createConversationsRenderedMessageAdmission(runtime)
+    expect(typeof provider.admitRenderedServiceMessage).toBe("function")
+  })
+})

--- a/packages/operator-standard/package.json
+++ b/packages/operator-standard/package.json
@@ -40,6 +40,8 @@
     "@voyant-travel/charters": "workspace:*",
     "@voyant-travel/commerce": "workspace:*",
     "@voyant-travel/commerce-react": "workspace:*",
+    "@voyant-travel/conversations": "workspace:*",
+    "@voyant-travel/conversations-react": "workspace:*",
     "@voyant-travel/core": "workspace:*",
     "@voyant-travel/cruises": "workspace:*",
     "@voyant-travel/cruises-react": "workspace:*",

--- a/packages/operator-standard/src/index.ts
+++ b/packages/operator-standard/src/index.ts
@@ -211,6 +211,7 @@ export const STANDARD_OPERATOR_DISTRIBUTION_POLICY: {
     { resolve: "@voyant-travel/legal" },
     { resolve: "@voyant-travel/public-document-delivery" },
     { resolve: "@voyant-travel/notifications" },
+    { resolve: "@voyant-travel/conversations" },
     { resolve: "@voyant-travel/storage" },
     { resolve: "@voyant-travel/media" },
     { resolve: "@voyant-travel/public-api" },

--- a/packages/operator-standard/src/standard-styles.css
+++ b/packages/operator-standard/src/standard-styles.css
@@ -6,12 +6,12 @@
 @source "../../admin-app/dist/**/*.{js,mjs}";
 @source "../../auth-react/dist/**/*.{js,mjs}";
 @source "../../ui/dist/**/*.{js,mjs}";
-@source "../../{operations,bookings,catalog,commerce,custom-fields,relationships,finance,flights,legal,inventory,distribution,mice,reporting}-react/dist/**/*.{js,mjs}";
+@source "../../{operations,bookings,catalog,commerce,conversations,custom-fields,relationships,finance,flights,legal,inventory,distribution,mice,reporting}-react/dist/**/*.{js,mjs}";
 @source "../../admin/src/**/*.{ts,tsx}";
 @source "../../admin-app/src/**/*.{ts,tsx}";
 @source "../../auth-react/src/**/*.{ts,tsx}";
 @source "../../ui/src/**/*.{ts,tsx}";
-@source "../../{operations,bookings,catalog,commerce,custom-fields,relationships,finance,flights,legal,inventory,distribution,mice,reporting}-react/src/**/*.{ts,tsx}";
+@source "../../{operations,bookings,catalog,commerce,conversations,custom-fields,relationships,finance,flights,legal,inventory,distribution,mice,reporting}-react/src/**/*.{ts,tsx}";
 
 @import "@voyant-travel/ui/styles.css";
 @import "@voyant-travel/admin/styles.css";

--- a/packages/schema-kit/src/typeid/typeid-prefixes.ts
+++ b/packages/schema-kit/src/typeid/typeid-prefixes.ts
@@ -41,6 +41,11 @@ export const PREFIXES = {
   // --- VOYANT MODULES ---
   communication_log: "clog",
   customer_signals: "csig",
+  conversations: "conv",
+  conversation_participants: "cvpt",
+  conversation_parts: "cvpa",
+  conversation_events: "cvev",
+  conversation_ingress_operations: "cvio",
   notification_templates: "ntpl",
   notification_deliveries: "ntdl",
   notification_channel_accounts: "ncha",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,6 +361,12 @@ importers:
       '@voyant-travel/connect-sdk':
         specifier: 0.9.1
         version: 0.9.1
+      '@voyant-travel/conversations':
+        specifier: workspace:^
+        version: link:../../packages/conversations
+      '@voyant-travel/conversations-react':
+        specifier: workspace:^
+        version: link:../../packages/conversations-react
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../../packages/core
@@ -2153,6 +2159,93 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
+
+  packages/conversations:
+    dependencies:
+      '@hono/zod-openapi':
+        specifier: 'catalog:'
+        version: 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/conversations-contracts':
+        specifier: workspace:^
+        version: link:../conversations-contracts
+      '@voyant-travel/core':
+        specifier: workspace:^
+        version: link:../core
+      '@voyant-travel/db':
+        specifier: workspace:^
+        version: link:../db
+      '@voyant-travel/hono':
+        specifier: workspace:^
+        version: link:../hono
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      hono:
+        specifier: 4.12.25
+        version: 4.12.25
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@voyant-travel/voyant-typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+
+  packages/conversations-contracts:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@voyant-travel/voyant-typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+
+  packages/conversations-react:
+    dependencies:
+      lucide-react:
+        specifier: ^1.23.0
+        version: 1.23.0(react@19.2.7)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@voyant-travel/admin':
+        specifier: workspace:^
+        version: link:../admin
+      '@voyant-travel/react':
+        specifier: workspace:^
+        version: link:../react
+      '@voyant-travel/voyant-typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -4188,6 +4281,12 @@ importers:
       '@voyant-travel/bookings':
         specifier: workspace:^
         version: link:../bookings
+      '@voyant-travel/conversations':
+        specifier: workspace:^
+        version: link:../conversations
+      '@voyant-travel/conversations-contracts':
+        specifier: workspace:^
+        version: link:../conversations-contracts
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../core
@@ -4677,6 +4776,12 @@ importers:
       '@voyant-travel/connect-sdk':
         specifier: 0.9.1
         version: 0.9.1
+      '@voyant-travel/conversations':
+        specifier: workspace:*
+        version: link:../conversations
+      '@voyant-travel/conversations-react':
+        specifier: workspace:*
+        version: link:../conversations-react
       '@voyant-travel/core':
         specifier: workspace:*
         version: link:../core

--- a/scripts/checks/graph/graph-conformance.json
+++ b/scripts/checks/graph/graph-conformance.json
@@ -17,6 +17,16 @@
     "allow": {}
   },
   "packages": {
+    "@voyant-travel/conversations": {
+      "requiresSchemas": ["@voyant-travel/db"],
+      "portIds": [
+        "conversations.database",
+        "conversations.ingress-source",
+        "conversations.rendered-message-admission",
+        "conversations.person-directory"
+      ],
+      "runtimeExport": "createConversationsRuntimePortContribution"
+    },
     "@voyant-travel/flights": {
       "requiresSchemas": ["@voyant-travel/finance"],
       "requiredCapabilities": ["finance.payment-sessions"],

--- a/scripts/checks/manifests/public-surface.json
+++ b/scripts/checks/manifests/public-surface.json
@@ -14,6 +14,7 @@
   "extensionSurface": [
     "@voyant-travel/admin-extension-sdk",
     "@voyant-travel/app-manifest",
+    "@voyant-travel/conversations-contracts",
     "@voyant-travel/custom-fields-contracts",
     "@voyant-travel/graph-contracts",
     "@voyant-travel/public-api-contracts",

--- a/scripts/checks/openapi/generated-specs.json
+++ b/scripts/checks/openapi/generated-specs.json
@@ -9,6 +9,10 @@
   ],
   "generators": [
     {
+      "command": "pnpm --filter @voyant-travel/conversations openapi:generate",
+      "files": ["packages/conversations/openapi/admin/conversations.json"]
+    },
+    {
       "command": "pnpm --filter @voyant-travel/catalog generate:openapi",
       "files": [
         "packages/catalog/openapi/admin/catalog-booking.json",


### PR DESCRIPTION
## What changed

- add provider-neutral inbound email envelope and fetch/ack contracts
- add the Conversations module, schema, migration history, exact threading, replay/drift handling, and transactional outbound replies
- add admin Inbox list, thread, start, reply, lifecycle, and read routes plus a minimal operator UI
- connect replies to Notifications rendered-message admission on the same database transaction
- register the module, runtime ports, operator surface, OpenAPI, graph rules, TypeIDs, and changesets

## Why

This is the first complete two-way Inbox vertical slice. Agencies can receive customer email, view exact threads, start a conversation for a known Person contact point, and reply from the same workspace without exposing deployment adapter details.

## Safety and architecture

- exact reply alias and message identifiers are authoritative; subjects never merge threads
- inbound list/fetch/ack replay is idempotent and payload drift fails closed
- start and reply admission are atomic and idempotent
- Person resolution is read-only and never auto-creates or merges records
- adapter payloads and proprietary provider details do not enter the OSS contracts

## Validation

- conversations-contracts typecheck and tests
- conversations typecheck, tests, and lint
- conversations-react typecheck and lint
- Notifications bridge unit test
- graph conformance and typecheck coverage
- generated migration snapshot and exact OpenAPI drift
- provider-brand scan across the new OSS surfaces

Closes #4826