### PR TITLE
feat(inbox): secure message content and attachments

### DIFF
--- a/.changeset/secure-inbox-content.md
+++ b/.changeset/secure-inbox-content.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/conversations-contracts": minor
+"@voyant-travel/conversations": minor
+"@voyant-travel/conversations-react": minor
+"@voyant-travel/notifications": minor
+"@voyant-travel/schema-kit": minor
+"@voyant-travel/admin-api-client": minor
+---
+
+Add sanitized Inbox content, private attachment lifecycle and scanning, streamed or short-lived private downloads, retention/redaction, and retry-time delivery revalidation.

--- a/packages/admin-api-client/src/generated/conversations.ts
+++ b/packages/admin-api-client/src/generated/conversations.ts
@@ -187,8 +187,31 @@ export interface paths {
                   subject: string | null
                   textBody: string | null
                   htmlBody: string | null
+                  /** @enum {string} */
+                  contentStatus: "safe" | "quarantined" | "redacted"
+                  legacyAttachmentCount: number
+                  /** @enum {string} */
+                  classification:
+                    | "message"
+                    | "automatic_reply"
+                    | "delivery_status"
+                    | "complaint"
+                    | "suspicious"
+                  replyable: boolean
                   attachments: {
-                    [key: string]: unknown
+                    id: string
+                    filename: string
+                    contentType: string
+                    sizeBytes: number
+                    /** @enum {string} */
+                    disposition: "attachment" | "inline"
+                    inlineContentId: string | null
+                    /** @enum {string} */
+                    scanStatus: "pending" | "clean" | "blocked" | "failed"
+                    /** @enum {string} */
+                    availability: "active" | "quarantined" | "redaction_pending" | "redacted"
+                    /** Format: date-time */
+                    createdAt: string
                   }[]
                   externalMessageId: string | null
                   messageId: string | null
@@ -236,8 +259,31 @@ export interface paths {
                         subject: string | null
                         textBody: string | null
                         htmlBody: string | null
+                        /** @enum {string} */
+                        contentStatus: "safe" | "quarantined" | "redacted"
+                        legacyAttachmentCount: number
+                        /** @enum {string} */
+                        classification:
+                          | "message"
+                          | "automatic_reply"
+                          | "delivery_status"
+                          | "complaint"
+                          | "suspicious"
+                        replyable: boolean
                         attachments: {
-                          [key: string]: unknown
+                          id: string
+                          filename: string
+                          contentType: string
+                          sizeBytes: number
+                          /** @enum {string} */
+                          disposition: "attachment" | "inline"
+                          inlineContentId: string | null
+                          /** @enum {string} */
+                          scanStatus: "pending" | "clean" | "blocked" | "failed"
+                          /** @enum {string} */
+                          availability: "active" | "quarantined" | "redaction_pending" | "redacted"
+                          /** Format: date-time */
+                          createdAt: string
                         }[]
                         externalMessageId: string | null
                         messageId: string | null
@@ -426,8 +472,31 @@ export interface paths {
                   subject: string | null
                   textBody: string | null
                   htmlBody: string | null
+                  /** @enum {string} */
+                  contentStatus: "safe" | "quarantined" | "redacted"
+                  legacyAttachmentCount: number
+                  /** @enum {string} */
+                  classification:
+                    | "message"
+                    | "automatic_reply"
+                    | "delivery_status"
+                    | "complaint"
+                    | "suspicious"
+                  replyable: boolean
                   attachments: {
-                    [key: string]: unknown
+                    id: string
+                    filename: string
+                    contentType: string
+                    sizeBytes: number
+                    /** @enum {string} */
+                    disposition: "attachment" | "inline"
+                    inlineContentId: string | null
+                    /** @enum {string} */
+                    scanStatus: "pending" | "clean" | "blocked" | "failed"
+                    /** @enum {string} */
+                    availability: "active" | "quarantined" | "redaction_pending" | "redacted"
+                    /** Format: date-time */
+                    createdAt: string
                   }[]
                   externalMessageId: string | null
                   messageId: string | null
@@ -475,8 +544,31 @@ export interface paths {
                         subject: string | null
                         textBody: string | null
                         htmlBody: string | null
+                        /** @enum {string} */
+                        contentStatus: "safe" | "quarantined" | "redacted"
+                        legacyAttachmentCount: number
+                        /** @enum {string} */
+                        classification:
+                          | "message"
+                          | "automatic_reply"
+                          | "delivery_status"
+                          | "complaint"
+                          | "suspicious"
+                        replyable: boolean
                         attachments: {
-                          [key: string]: unknown
+                          id: string
+                          filename: string
+                          contentType: string
+                          sizeBytes: number
+                          /** @enum {string} */
+                          disposition: "attachment" | "inline"
+                          inlineContentId: string | null
+                          /** @enum {string} */
+                          scanStatus: "pending" | "clean" | "blocked" | "failed"
+                          /** @enum {string} */
+                          availability: "active" | "quarantined" | "redaction_pending" | "redacted"
+                          /** Format: date-time */
+                          createdAt: string
                         }[]
                         externalMessageId: string | null
                         messageId: string | null
@@ -743,8 +835,10 @@ export interface paths {
         content: {
           "application/json": {
             channelAccountId: string
-            text: string
+            text: string | null
             html?: string | null
+            /** @default [] */
+            attachmentIds?: string[]
             idempotencyKey: string
           }
         }
@@ -768,8 +862,31 @@ export interface paths {
                 subject: string | null
                 textBody: string | null
                 htmlBody: string | null
+                /** @enum {string} */
+                contentStatus: "safe" | "quarantined" | "redacted"
+                legacyAttachmentCount: number
+                /** @enum {string} */
+                classification:
+                  | "message"
+                  | "automatic_reply"
+                  | "delivery_status"
+                  | "complaint"
+                  | "suspicious"
+                replyable: boolean
                 attachments: {
-                  [key: string]: unknown
+                  id: string
+                  filename: string
+                  contentType: string
+                  sizeBytes: number
+                  /** @enum {string} */
+                  disposition: "attachment" | "inline"
+                  inlineContentId: string | null
+                  /** @enum {string} */
+                  scanStatus: "pending" | "clean" | "blocked" | "failed"
+                  /** @enum {string} */
+                  availability: "active" | "quarantined" | "redaction_pending" | "redacted"
+                  /** Format: date-time */
+                  createdAt: string
                 }[]
                 externalMessageId: string | null
                 messageId: string | null
@@ -1574,6 +1691,467 @@ export interface paths {
     }
     put?: never
     post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/v1/admin/conversations/{id}/attachments/tickets": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post: {
+      parameters: {
+        query?: never
+        header?: never
+        path: {
+          id: string
+        }
+        cookie?: never
+      }
+      requestBody: {
+        content: {
+          "application/json": {
+            filename: string
+            contentType: string
+            sizeBytes: number
+          }
+        }
+      }
+      responses: {
+        /** @description Short-lived private upload ticket */
+        201: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              data: {
+                token: string
+                /** @enum {string} */
+                method: "PUT" | "POST"
+                /** Format: uri */
+                url: string
+                headers?: {
+                  [key: string]: string
+                }
+                /** Format: date-time */
+                expiresAt: string
+              }
+            }
+          }
+        }
+        /** @description Invalid conversation operation */
+        400: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Authenticated staff required */
+        401: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Inbox membership required */
+        403: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Conversation not found */
+        404: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Private attachment upload unavailable */
+        409: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Attachment rejected by policy */
+        422: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+      }
+    }
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/v1/admin/conversations/{id}/attachments/finalize": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post: {
+      parameters: {
+        query?: never
+        header?: never
+        path: {
+          id: string
+        }
+        cookie?: never
+      }
+      requestBody: {
+        content: {
+          "application/json": {
+            filename: string
+            contentType: string
+            sizeBytes: number
+            token: string
+          }
+        }
+      }
+      responses: {
+        /** @description Attachment finalized and scanned */
+        201: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              data: {
+                id: string
+                filename: string
+                contentType: string
+                sizeBytes: number
+                /** @enum {string} */
+                disposition: "attachment" | "inline"
+                inlineContentId: string | null
+                /** @enum {string} */
+                scanStatus: "pending" | "clean" | "blocked" | "failed"
+                /** @enum {string} */
+                availability: "active" | "quarantined" | "redaction_pending" | "redacted"
+                /** Format: date-time */
+                createdAt: string
+              }
+            }
+          }
+        }
+        /** @description Invalid conversation operation */
+        400: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Authenticated staff required */
+        401: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Inbox membership required */
+        403: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Conversation not found */
+        404: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Upload unavailable or drifted */
+        409: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Attachment rejected by policy */
+        422: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+      }
+    }
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/v1/admin/conversations/{id}/attachments/{attachmentId}/download": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get: {
+      parameters: {
+        query?: never
+        header?: never
+        path: {
+          id: string
+          attachmentId: string
+        }
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Private attachment stream */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/octet-stream": string
+          }
+        }
+        /** @description Short-lived private download redirect */
+        302: {
+          headers: {
+            [name: string]: unknown
+          }
+          content?: never
+        }
+        /** @description Invalid conversation operation */
+        400: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Authenticated staff required */
+        401: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Inbox membership required */
+        403: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Clean attachment not found */
+        404: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Private attachment runtime unavailable */
+        409: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+      }
+    }
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/v1/admin/conversations/{id}/attachments/{attachmentId}/redact": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post: {
+      parameters: {
+        query?: never
+        header?: never
+        path: {
+          id: string
+          attachmentId: string
+        }
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Attachment queued for redaction */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              data: {
+                id: string
+                filename: string
+                contentType: string
+                sizeBytes: number
+                /** @enum {string} */
+                disposition: "attachment" | "inline"
+                inlineContentId: string | null
+                /** @enum {string} */
+                scanStatus: "pending" | "clean" | "blocked" | "failed"
+                /** @enum {string} */
+                availability: "active" | "quarantined" | "redaction_pending" | "redacted"
+                /** Format: date-time */
+                createdAt: string
+              }
+            }
+          }
+        }
+        /** @description Invalid conversation operation */
+        400: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Authenticated staff required */
+        401: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Inbox membership required */
+        403: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Attachment not found */
+        404: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Revision or idempotency conflict */
+        409: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+      }
+    }
     delete?: never
     options?: never
     head?: never

--- a/packages/conversations-contracts/src/index.ts
+++ b/packages/conversations-contracts/src/index.ts
@@ -27,6 +27,9 @@ export const inboundEmailEnvelopeV1Schema = z.object({
   text: z.string().nullable(),
   html: z.string().nullable(),
   attachments: z.array(inboundAttachmentSchema).default([]),
+  classification: z
+    .enum(["message", "automatic_reply", "delivery_status", "complaint", "suspicious"])
+    .default("message"),
   threading: z.object({
     messageId: z.string().min(1).nullable(),
     inReplyTo: z.string().min(1).nullable(),
@@ -67,6 +70,13 @@ export interface ConversationRenderedServiceMessage {
   subject?: string
   text?: string
   sanitizedHtml?: string
+  attachments?: ReadonlyArray<{
+    privateHandle: string
+    filename: string
+    contentType: string
+    disposition: "attachment" | "inline"
+    contentId?: string
+  }>
   thread: { threadId: string; replyToDeliveryId?: string }
   metadata: {
     replyAlias: string
@@ -95,6 +105,24 @@ export interface ConversationsRenderedMessageAdmission {
     message: ConversationRenderedServiceMessage,
     context?: { bindings?: unknown },
   ): Promise<ConversationMessageAdmissionResult>
+}
+
+export interface ConversationPrivateAttachmentDeliveryResolver {
+  resolveForDelivery(input: {
+    targetId: string
+    privateHandle: string
+    filename: string
+    contentType?: string
+    disposition?: "attachment" | "inline"
+    contentId?: string
+  }): Promise<{
+    filename: string
+    contentType: string
+    disposition: "attachment" | "inline"
+    contentId?: string
+    contentBase64?: string
+    path?: string
+  }>
 }
 
 /** Stable, order-independent JSON used to detect replay payload drift. */

--- a/packages/conversations-contracts/tests/contracts.test.ts
+++ b/packages/conversations-contracts/tests/contracts.test.ts
@@ -18,6 +18,7 @@ const envelope = {
   text: "Hello",
   html: null,
   attachments: [],
+  classification: "message" as const,
   threading: { messageId: "<message-1@example.test>", inReplyTo: null, references: [] },
   occurredAt: "2026-08-17T10:00:00.000Z",
 }

--- a/packages/conversations-react/src/admin/conversation-page.tsx
+++ b/packages/conversations-react/src/admin/conversation-page.tsx
@@ -6,6 +6,7 @@ import { useVoyantReactContext } from "@voyant-travel/react"
 import { DateTimePicker } from "@voyant-travel/ui/components/date-time-picker"
 import { type FormEvent, useEffect } from "react"
 import { conversationsApi } from "../api.js"
+import type { InboxPart } from "../types.js"
 
 export default function ConversationPage({ params }: AdminRoutePageProps) {
   const id = params.id ?? ""
@@ -163,9 +164,42 @@ export default function ConversationPage({ params }: AdminRoutePageProps) {
               >
                 <div className="mb-2 flex justify-between text-xs text-muted-foreground">
                   <span>{item.part.senderAddress}</span>
-                  <span>{item.part.deliveryStatus}</span>
+                  <span>
+                    {item.part.classification === "message"
+                      ? item.part.deliveryStatus
+                      : item.part.classification}
+                  </span>
                 </div>
-                <p className="whitespace-pre-wrap">{item.part.textBody ?? "(HTML message)"}</p>
+                {item.part.contentStatus === "redacted" ? (
+                  <p className="italic text-muted-foreground">Content redacted</p>
+                ) : item.part.textBody ? (
+                  <p className="whitespace-pre-wrap">{item.part.textBody}</p>
+                ) : item.part.htmlBody ? (
+                  <SafeConversationHtml html={item.part.htmlBody} />
+                ) : (
+                  <p className="italic text-muted-foreground">No message body</p>
+                )}
+                {item.part.attachments.length > 0 ? (
+                  <ul className="mt-3 space-y-1 border-t pt-3">
+                    {item.part.attachments.map((attachment) => (
+                      <li key={attachment.id} className="text-sm">
+                        {attachment.scanStatus === "clean" &&
+                        attachment.availability === "active" ? (
+                          <a
+                            className="underline"
+                            href={`${baseUrl}/v1/admin/conversations/${encodeURIComponent(id)}/attachments/${encodeURIComponent(attachment.id)}/download`}
+                          >
+                            {attachment.filename}
+                          </a>
+                        ) : (
+                          <span className="text-muted-foreground">
+                            {attachment.filename} ({attachmentStatusLabel(attachment)})
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
               </li>
             )
           if (item.kind === "note")
@@ -187,26 +221,32 @@ export default function ConversationPage({ params }: AdminRoutePageProps) {
           )
         })}
       </ol>
-      <form className="grid max-w-2xl gap-3" onSubmit={submitReply}>
-        <input
-          required
-          name="channelAccountId"
-          placeholder="Channel account ID"
-          className="rounded border p-2"
-        />
-        <textarea
-          required
-          name="text"
-          placeholder="Reply"
-          className="min-h-28 rounded border p-2"
-        />
-        <button
-          className="justify-self-start rounded bg-primary px-4 py-2 text-primary-foreground"
-          type="submit"
-        >
-          Send reply
-        </button>
-      </form>
+      {detail.data.parts.at(-1)?.replyable === false ? (
+        <p className="text-sm text-muted-foreground">
+          This system-generated item is quarantined and cannot be replied to.
+        </p>
+      ) : (
+        <form className="grid max-w-2xl gap-3" onSubmit={submitReply}>
+          <input
+            required
+            name="channelAccountId"
+            placeholder="Channel account ID"
+            className="rounded border p-2"
+          />
+          <textarea
+            required
+            name="text"
+            placeholder="Reply"
+            className="min-h-28 rounded border p-2"
+          />
+          <button
+            className="justify-self-start rounded bg-primary px-4 py-2 text-primary-foreground"
+            type="submit"
+          >
+            Send reply
+          </button>
+        </form>
+      )}
       <form className="grid max-w-2xl gap-3" onSubmit={submitNote}>
         <textarea
           required
@@ -230,4 +270,23 @@ export default function ConversationPage({ params }: AdminRoutePageProps) {
       ) : null}
     </main>
   )
+}
+
+/** HTML reaches this component only after the Conversations server sanitizer. */
+function SafeConversationHtml({ html }: { html: string }) {
+  return (
+    <div
+      className="prose prose-sm max-w-none break-words"
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: server-owned sanitizer is the only persistence boundary.
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}
+
+function attachmentStatusLabel(attachment: InboxPart["attachments"][number]) {
+  if (attachment.availability === "redacted") return "redacted"
+  if (attachment.availability === "redaction_pending") return "redaction pending"
+  if (attachment.scanStatus === "pending") return "scanning"
+  if (attachment.scanStatus === "blocked") return "blocked"
+  return "unavailable"
 }

--- a/packages/conversations-react/src/api.ts
+++ b/packages/conversations-react/src/api.ts
@@ -85,7 +85,13 @@ export const conversationsApi = {
     fetcher: VoyantFetcher,
     baseUrl: string,
     id: string,
-    input: { channelAccountId: string; text: string; idempotencyKey: string },
+    input: {
+      channelAccountId: string
+      text: string
+      html?: string | null
+      attachmentIds?: string[]
+      idempotencyKey: string
+    },
   ) {
     return request<InboxPart>(
       fetcher,

--- a/packages/conversations-react/src/types.ts
+++ b/packages/conversations-react/src/types.ts
@@ -20,6 +20,11 @@ export interface InboxPart {
   senderAddress: string
   textBody: string | null
   htmlBody: string | null
+  contentStatus: "safe" | "quarantined" | "redacted"
+  legacyAttachmentCount: number
+  classification: "message" | "automatic_reply" | "delivery_status" | "complaint" | "suspicious"
+  replyable: boolean
+  attachments: InboxAttachment[]
   deliveryStatus: string
   occurredAt: string
 }
@@ -41,6 +46,16 @@ export interface ConversationInbox {
 export interface AssignableStaff {
   userId: string
   displayName: string
+}
+
+export interface InboxAttachment {
+  id: string
+  filename: string
+  contentType: string
+  sizeBytes: number
+  disposition: "attachment" | "inline"
+  scanStatus: "pending" | "clean" | "blocked" | "failed"
+  availability: "active" | "quarantined" | "redaction_pending" | "redacted"
 }
 
 export interface InboxConversationDetail {

--- a/packages/conversations/migrations/0002_secure_content.sql
+++ b/packages/conversations/migrations/0002_secure_content.sql
@@ -1,0 +1,60 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."conversation_attachment_availability" AS ENUM('active', 'quarantined', 'redaction_pending', 'redacted');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."conversation_attachment_scan_status" AS ENUM('pending', 'clean', 'blocked', 'failed');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."conversation_part_classification" AS ENUM('message', 'automatic_reply', 'delivery_status', 'complaint', 'suspicious');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."conversation_part_content_status" AS ENUM('safe', 'quarantined', 'redacted');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE TABLE "conversation_attachments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"conversation_id" text NOT NULL,
+	"part_id" text,
+	"source_id" text,
+	"external_id" text,
+	"private_handle" text,
+	"filename" text NOT NULL,
+	"content_type" text NOT NULL,
+	"size_bytes" integer NOT NULL,
+	"disposition" text DEFAULT 'attachment' NOT NULL,
+	"inline_content_id" text,
+	"scan_status" "conversation_attachment_scan_status" DEFAULT 'pending' NOT NULL,
+	"availability" "conversation_attachment_availability" DEFAULT 'quarantined' NOT NULL,
+	"retention_until" timestamp with time zone,
+	"scanned_at" timestamp with time zone,
+	"redacted_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "conversation_parts" ADD COLUMN "content_status" "conversation_part_content_status" DEFAULT 'safe' NOT NULL;--> statement-breakpoint
+ALTER TABLE "conversation_parts" ADD COLUMN "legacy_attachment_count" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "conversation_parts" ADD COLUMN "classification" "conversation_part_classification" DEFAULT 'message' NOT NULL;--> statement-breakpoint
+ALTER TABLE "conversation_parts" ADD COLUMN "replyable" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "conversation_attachments" ADD CONSTRAINT "conversation_attachments_conversation_id_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversation_attachments" ADD CONSTRAINT "conversation_attachments_part_id_conversation_parts_id_fk" FOREIGN KEY ("part_id") REFERENCES "public"."conversation_parts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_conversation_attachment_handle" ON "conversation_attachments" USING btree ("private_handle");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_conversation_attachment_external" ON "conversation_attachments" USING btree ("source_id","external_id");--> statement-breakpoint
+CREATE INDEX "idx_conversation_attachments_conversation" ON "conversation_attachments" USING btree ("conversation_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_conversation_attachments_part" ON "conversation_attachments" USING btree ("part_id");--> statement-breakpoint
+CREATE INDEX "idx_conversation_attachments_retention" ON "conversation_attachments" USING btree ("availability","retention_until");--> statement-breakpoint
+UPDATE "conversation_parts"
+SET
+	"legacy_attachment_count" = CASE
+		WHEN jsonb_typeof("attachments") = 'array' THEN jsonb_array_length("attachments")
+		ELSE 0
+	END,
+	"content_status" = CASE
+		WHEN jsonb_typeof("attachments") = 'array' AND jsonb_array_length("attachments") > 0
+			THEN 'quarantined'::"conversation_part_content_status"
+		ELSE "content_status"
+	END;--> statement-breakpoint
+ALTER TABLE "conversation_parts" DROP COLUMN "attachments";

--- a/packages/conversations/migrations/meta/0002_snapshot.json
+++ b/packages/conversations/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1581 @@
+{
+  "id": "db1d5090-3d56-4e25-9bff-1cd129e73a26",
+  "prevId": "aed149a4-23f7-47bc-9418-a41c70427f55",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.conversation_events": {
+      "name": "conversation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_conversation_events_conversation": {
+          "name": "idx_conversation_events_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_events_conversation_id_conversations_id_fk": {
+          "name": "conversation_events_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_events",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_inbox_memberships": {
+      "name": "conversation_inbox_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "conversation_inbox_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_inbox_membership": {
+          "name": "uidx_conversation_inbox_membership",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_inbox_memberships_inbox_id_conversation_inboxes_id_fk": {
+          "name": "conversation_inbox_memberships_inbox_id_conversation_inboxes_id_fk",
+          "tableFrom": "conversation_inbox_memberships",
+          "tableTo": "conversation_inboxes",
+          "columnsFrom": [
+            "inbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_inboxes": {
+      "name": "conversation_inboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_inboxes_name": {
+          "name": "uidx_conversation_inboxes_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_inboxes_single_default": {
+          "name": "uidx_conversation_inboxes_single_default",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_inboxes\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_ingress_operations": {
+      "name": "conversation_ingress_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_envelope_id": {
+          "name": "external_envelope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint": {
+          "name": "payload_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_part_id": {
+          "name": "conversation_part_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "conversation_ingress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'committed'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_ingress_envelope": {
+          "name": "uidx_conversation_ingress_envelope",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_envelope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_ingress_message": {
+          "name": "uidx_conversation_ingress_message",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_ingress_operations_conversation_part_id_conversation_parts_id_fk": {
+          "name": "conversation_ingress_operations_conversation_part_id_conversation_parts_id_fk",
+          "tableFrom": "conversation_ingress_operations",
+          "tableTo": "conversation_parts",
+          "columnsFrom": [
+            "conversation_part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_notes": {
+      "name": "conversation_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_conversation_notes_conversation": {
+          "name": "idx_conversation_notes_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_notes_conversation_id_conversations_id_fk": {
+          "name": "conversation_notes_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_notes",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "conversation_participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_ref": {
+          "name": "person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_point_ref": {
+          "name": "contact_point_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_participant_address": {
+          "name": "uidx_conversation_participant_address",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_parts": {
+      "name": "conversation_parts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "conversation_part_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_address": {
+          "name": "sender_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_addresses": {
+          "name": "recipient_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "payload_fingerprint": {
+          "name": "payload_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_delivery_id": {
+          "name": "notification_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_status": {
+          "name": "delivery_status",
+          "type": "conversation_part_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "conversation_part_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'message'"
+        },
+        "content_status": {
+          "name": "content_status",
+          "type": "conversation_part_content_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        },
+        "legacy_attachment_count": {
+          "name": "legacy_attachment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "replyable": {
+          "name": "replyable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "uidx_conversation_parts_external_message": {
+          "name": "uidx_conversation_parts_external_message",
+          "columns": [
+            {
+              "expression": "external_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_parts_message_id": {
+          "name": "uidx_conversation_parts_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_parts_idempotency": {
+          "name": "uidx_conversation_parts_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversation_parts_conversation_occurred": {
+          "name": "idx_conversation_parts_conversation_occurred",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_parts_sequence": {
+          "name": "uidx_conversation_parts_sequence",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_parts_conversation_id_conversations_id_fk": {
+          "name": "conversation_parts_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_parts",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_read_cursors": {
+      "name": "conversation_read_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_sequence": {
+          "name": "last_read_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_read_cursor": {
+          "name": "uidx_conversation_read_cursor",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_read_cursors_conversation_id_conversations_id_fk": {
+          "name": "conversation_read_cursors_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_read_cursors",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to_user_id": {
+          "name": "assigned_to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "conversation_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_part_sequence": {
+          "name": "next_part_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_subject": {
+          "name": "suggested_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_alias": {
+          "name": "reply_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_address": {
+          "name": "customer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_ref": {
+          "name": "person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_point_ref": {
+          "name": "contact_point_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_idempotency_key": {
+          "name": "start_idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_payload_fingerprint": {
+          "name": "start_payload_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_part_at": {
+          "name": "last_part_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversations_reply_alias": {
+          "name": "uidx_conversations_reply_alias",
+          "columns": [
+            {
+              "expression": "reply_alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversations_start_idempotency": {
+          "name": "uidx_conversations_start_idempotency",
+          "columns": [
+            {
+              "expression": "start_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_last_part": {
+          "name": "idx_conversations_last_part",
+          "columns": [
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_person": {
+          "name": "idx_conversations_person",
+          "columns": [
+            {
+              "expression": "person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_inbox_status": {
+          "name": "idx_conversations_inbox_status",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_assignee": {
+          "name": "idx_conversations_assignee",
+          "columns": [
+            {
+              "expression": "assigned_to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_inbox_id_conversation_inboxes_id_fk": {
+          "name": "conversations_inbox_id_conversation_inboxes_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "conversation_inboxes",
+          "columnsFrom": [
+            "inbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_attachments": {
+      "name": "conversation_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_id": {
+          "name": "part_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_handle": {
+          "name": "private_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'attachment'"
+        },
+        "inline_content_id": {
+          "name": "inline_content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scan_status": {
+          "name": "scan_status",
+          "type": "conversation_attachment_scan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "availability": {
+          "name": "availability",
+          "type": "conversation_attachment_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'quarantined'"
+        },
+        "retention_until": {
+          "name": "retention_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redacted_at": {
+          "name": "redacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_attachment_handle": {
+          "name": "uidx_conversation_attachment_handle",
+          "columns": [
+            {
+              "expression": "private_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_attachment_external": {
+          "name": "uidx_conversation_attachment_external",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversation_attachments_conversation": {
+          "name": "idx_conversation_attachments_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversation_attachments_part": {
+          "name": "idx_conversation_attachments_part",
+          "columns": [
+            {
+              "expression": "part_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversation_attachments_retention": {
+          "name": "idx_conversation_attachments_retention",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retention_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_attachments_conversation_id_conversations_id_fk": {
+          "name": "conversation_attachments_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_attachments",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_attachments_part_id_conversation_parts_id_fk": {
+          "name": "conversation_attachments_part_id_conversation_parts_id_fk",
+          "tableFrom": "conversation_attachments",
+          "tableTo": "conversation_parts",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.conversation_inbox_membership_role": {
+      "name": "conversation_inbox_membership_role",
+      "schema": "public",
+      "values": [
+        "member",
+        "manager"
+      ]
+    },
+    "public.conversation_ingress_status": {
+      "name": "conversation_ingress_status",
+      "schema": "public",
+      "values": [
+        "committed",
+        "drifted"
+      ]
+    },
+    "public.conversation_part_delivery_status": {
+      "name": "conversation_part_delivery_status",
+      "schema": "public",
+      "values": [
+        "received",
+        "pending",
+        "accepted",
+        "delivered",
+        "failed",
+        "bounced",
+        "complained",
+        "suppressed",
+        "cancelled"
+      ]
+    },
+    "public.conversation_part_direction": {
+      "name": "conversation_part_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.conversation_participant_role": {
+      "name": "conversation_participant_role",
+      "schema": "public",
+      "values": [
+        "customer",
+        "staff"
+      ]
+    },
+    "public.conversation_priority": {
+      "name": "conversation_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.conversation_status": {
+      "name": "conversation_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed",
+        "snoozed"
+      ]
+    },
+    "public.conversation_attachment_availability": {
+      "name": "conversation_attachment_availability",
+      "schema": "public",
+      "values": [
+        "active",
+        "quarantined",
+        "redaction_pending",
+        "redacted"
+      ]
+    },
+    "public.conversation_attachment_scan_status": {
+      "name": "conversation_attachment_scan_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "clean",
+        "blocked",
+        "failed"
+      ]
+    },
+    "public.conversation_part_classification": {
+      "name": "conversation_part_classification",
+      "schema": "public",
+      "values": [
+        "message",
+        "automatic_reply",
+        "delivery_status",
+        "complaint",
+        "suspicious"
+      ]
+    },
+    "public.conversation_part_content_status": {
+      "name": "conversation_part_content_status",
+      "schema": "public",
+      "values": [
+        "safe",
+        "quarantined",
+        "redacted"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/conversations/migrations/meta/_journal.json
+++ b/packages/conversations/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1787007746929,
       "tag": "0001_collaboration",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1787012000000,
+      "tag": "0002_secure_content",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/conversations/openapi/admin/conversations.json
+++ b/packages/conversations/openapi/admin/conversations.json
@@ -425,11 +425,81 @@
                               "htmlBody": {
                                 "type": ["string", "null"]
                               },
+                              "contentStatus": {
+                                "type": "string",
+                                "enum": ["safe", "quarantined", "redacted"]
+                              },
+                              "legacyAttachmentCount": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "classification": {
+                                "type": "string",
+                                "enum": [
+                                  "message",
+                                  "automatic_reply",
+                                  "delivery_status",
+                                  "complaint",
+                                  "suspicious"
+                                ]
+                              },
+                              "replyable": {
+                                "type": "boolean"
+                              },
                               "attachments": {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "additionalProperties": {}
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "filename": {
+                                      "type": "string"
+                                    },
+                                    "contentType": {
+                                      "type": "string"
+                                    },
+                                    "sizeBytes": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    },
+                                    "disposition": {
+                                      "type": "string",
+                                      "enum": ["attachment", "inline"]
+                                    },
+                                    "inlineContentId": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "scanStatus": {
+                                      "type": "string",
+                                      "enum": ["pending", "clean", "blocked", "failed"]
+                                    },
+                                    "availability": {
+                                      "type": "string",
+                                      "enum": [
+                                        "active",
+                                        "quarantined",
+                                        "redaction_pending",
+                                        "redacted"
+                                      ]
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "filename",
+                                    "contentType",
+                                    "sizeBytes",
+                                    "disposition",
+                                    "inlineContentId",
+                                    "scanStatus",
+                                    "availability",
+                                    "createdAt"
+                                  ]
                                 }
                               },
                               "externalMessageId": {
@@ -480,6 +550,10 @@
                               "subject",
                               "textBody",
                               "htmlBody",
+                              "contentStatus",
+                              "legacyAttachmentCount",
+                              "classification",
+                              "replyable",
                               "attachments",
                               "externalMessageId",
                               "messageId",
@@ -575,11 +649,81 @@
                                       "htmlBody": {
                                         "type": ["string", "null"]
                                       },
+                                      "contentStatus": {
+                                        "type": "string",
+                                        "enum": ["safe", "quarantined", "redacted"]
+                                      },
+                                      "legacyAttachmentCount": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      },
+                                      "classification": {
+                                        "type": "string",
+                                        "enum": [
+                                          "message",
+                                          "automatic_reply",
+                                          "delivery_status",
+                                          "complaint",
+                                          "suspicious"
+                                        ]
+                                      },
+                                      "replyable": {
+                                        "type": "boolean"
+                                      },
                                       "attachments": {
                                         "type": "array",
                                         "items": {
                                           "type": "object",
-                                          "additionalProperties": {}
+                                          "properties": {
+                                            "id": {
+                                              "type": "string"
+                                            },
+                                            "filename": {
+                                              "type": "string"
+                                            },
+                                            "contentType": {
+                                              "type": "string"
+                                            },
+                                            "sizeBytes": {
+                                              "type": "integer",
+                                              "minimum": 0
+                                            },
+                                            "disposition": {
+                                              "type": "string",
+                                              "enum": ["attachment", "inline"]
+                                            },
+                                            "inlineContentId": {
+                                              "type": ["string", "null"]
+                                            },
+                                            "scanStatus": {
+                                              "type": "string",
+                                              "enum": ["pending", "clean", "blocked", "failed"]
+                                            },
+                                            "availability": {
+                                              "type": "string",
+                                              "enum": [
+                                                "active",
+                                                "quarantined",
+                                                "redaction_pending",
+                                                "redacted"
+                                              ]
+                                            },
+                                            "createdAt": {
+                                              "type": "string",
+                                              "format": "date-time"
+                                            }
+                                          },
+                                          "required": [
+                                            "id",
+                                            "filename",
+                                            "contentType",
+                                            "sizeBytes",
+                                            "disposition",
+                                            "inlineContentId",
+                                            "scanStatus",
+                                            "availability",
+                                            "createdAt"
+                                          ]
                                         }
                                       },
                                       "externalMessageId": {
@@ -630,6 +774,10 @@
                                       "subject",
                                       "textBody",
                                       "htmlBody",
+                                      "contentStatus",
+                                      "legacyAttachmentCount",
+                                      "classification",
+                                      "replyable",
                                       "attachments",
                                       "externalMessageId",
                                       "messageId",
@@ -989,11 +1137,81 @@
                               "htmlBody": {
                                 "type": ["string", "null"]
                               },
+                              "contentStatus": {
+                                "type": "string",
+                                "enum": ["safe", "quarantined", "redacted"]
+                              },
+                              "legacyAttachmentCount": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "classification": {
+                                "type": "string",
+                                "enum": [
+                                  "message",
+                                  "automatic_reply",
+                                  "delivery_status",
+                                  "complaint",
+                                  "suspicious"
+                                ]
+                              },
+                              "replyable": {
+                                "type": "boolean"
+                              },
                               "attachments": {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "additionalProperties": {}
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "filename": {
+                                      "type": "string"
+                                    },
+                                    "contentType": {
+                                      "type": "string"
+                                    },
+                                    "sizeBytes": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    },
+                                    "disposition": {
+                                      "type": "string",
+                                      "enum": ["attachment", "inline"]
+                                    },
+                                    "inlineContentId": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "scanStatus": {
+                                      "type": "string",
+                                      "enum": ["pending", "clean", "blocked", "failed"]
+                                    },
+                                    "availability": {
+                                      "type": "string",
+                                      "enum": [
+                                        "active",
+                                        "quarantined",
+                                        "redaction_pending",
+                                        "redacted"
+                                      ]
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "filename",
+                                    "contentType",
+                                    "sizeBytes",
+                                    "disposition",
+                                    "inlineContentId",
+                                    "scanStatus",
+                                    "availability",
+                                    "createdAt"
+                                  ]
                                 }
                               },
                               "externalMessageId": {
@@ -1044,6 +1262,10 @@
                               "subject",
                               "textBody",
                               "htmlBody",
+                              "contentStatus",
+                              "legacyAttachmentCount",
+                              "classification",
+                              "replyable",
                               "attachments",
                               "externalMessageId",
                               "messageId",
@@ -1139,11 +1361,81 @@
                                       "htmlBody": {
                                         "type": ["string", "null"]
                                       },
+                                      "contentStatus": {
+                                        "type": "string",
+                                        "enum": ["safe", "quarantined", "redacted"]
+                                      },
+                                      "legacyAttachmentCount": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      },
+                                      "classification": {
+                                        "type": "string",
+                                        "enum": [
+                                          "message",
+                                          "automatic_reply",
+                                          "delivery_status",
+                                          "complaint",
+                                          "suspicious"
+                                        ]
+                                      },
+                                      "replyable": {
+                                        "type": "boolean"
+                                      },
                                       "attachments": {
                                         "type": "array",
                                         "items": {
                                           "type": "object",
-                                          "additionalProperties": {}
+                                          "properties": {
+                                            "id": {
+                                              "type": "string"
+                                            },
+                                            "filename": {
+                                              "type": "string"
+                                            },
+                                            "contentType": {
+                                              "type": "string"
+                                            },
+                                            "sizeBytes": {
+                                              "type": "integer",
+                                              "minimum": 0
+                                            },
+                                            "disposition": {
+                                              "type": "string",
+                                              "enum": ["attachment", "inline"]
+                                            },
+                                            "inlineContentId": {
+                                              "type": ["string", "null"]
+                                            },
+                                            "scanStatus": {
+                                              "type": "string",
+                                              "enum": ["pending", "clean", "blocked", "failed"]
+                                            },
+                                            "availability": {
+                                              "type": "string",
+                                              "enum": [
+                                                "active",
+                                                "quarantined",
+                                                "redaction_pending",
+                                                "redacted"
+                                              ]
+                                            },
+                                            "createdAt": {
+                                              "type": "string",
+                                              "format": "date-time"
+                                            }
+                                          },
+                                          "required": [
+                                            "id",
+                                            "filename",
+                                            "contentType",
+                                            "sizeBytes",
+                                            "disposition",
+                                            "inlineContentId",
+                                            "scanStatus",
+                                            "availability",
+                                            "createdAt"
+                                          ]
                                         }
                                       },
                                       "externalMessageId": {
@@ -1194,6 +1486,10 @@
                                       "subject",
                                       "textBody",
                                       "htmlBody",
+                                      "contentStatus",
+                                      "legacyAttachmentCount",
+                                      "classification",
+                                      "replyable",
                                       "attachments",
                                       "externalMessageId",
                                       "messageId",
@@ -1659,11 +1955,20 @@
                     "minLength": 1
                   },
                   "text": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "minLength": 1
                   },
                   "html": {
                     "type": ["string", "null"]
+                  },
+                  "attachmentIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "maxItems": 10,
+                    "default": []
                   },
                   "idempotencyKey": {
                     "type": "string",
@@ -1718,11 +2023,76 @@
                         "htmlBody": {
                           "type": ["string", "null"]
                         },
+                        "contentStatus": {
+                          "type": "string",
+                          "enum": ["safe", "quarantined", "redacted"]
+                        },
+                        "legacyAttachmentCount": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "classification": {
+                          "type": "string",
+                          "enum": [
+                            "message",
+                            "automatic_reply",
+                            "delivery_status",
+                            "complaint",
+                            "suspicious"
+                          ]
+                        },
+                        "replyable": {
+                          "type": "boolean"
+                        },
                         "attachments": {
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "additionalProperties": {}
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "filename": {
+                                "type": "string"
+                              },
+                              "contentType": {
+                                "type": "string"
+                              },
+                              "sizeBytes": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "disposition": {
+                                "type": "string",
+                                "enum": ["attachment", "inline"]
+                              },
+                              "inlineContentId": {
+                                "type": ["string", "null"]
+                              },
+                              "scanStatus": {
+                                "type": "string",
+                                "enum": ["pending", "clean", "blocked", "failed"]
+                              },
+                              "availability": {
+                                "type": "string",
+                                "enum": ["active", "quarantined", "redaction_pending", "redacted"]
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "filename",
+                              "contentType",
+                              "sizeBytes",
+                              "disposition",
+                              "inlineContentId",
+                              "scanStatus",
+                              "availability",
+                              "createdAt"
+                            ]
                           }
                         },
                         "externalMessageId": {
@@ -1773,6 +2143,10 @@
                         "subject",
                         "textBody",
                         "htmlBody",
+                        "contentStatus",
+                        "legacyAttachmentCount",
+                        "classification",
+                        "replyable",
                         "attachments",
                         "externalMessageId",
                         "messageId",
@@ -2872,6 +3246,670 @@
           },
           "404": {
             "description": "Conversation resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Revision or idempotency conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/conversations/{id}/attachments/tickets": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "filename": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255
+                  },
+                  "contentType": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sizeBytes": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                },
+                "required": ["filename", "contentType", "sizeBytes"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Short-lived private upload ticket",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "token": {
+                          "type": "string"
+                        },
+                        "method": {
+                          "type": "string",
+                          "enum": ["PUT", "POST"]
+                        },
+                        "url": {
+                          "type": "string",
+                          "format": "uri"
+                        },
+                        "headers": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "expiresAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": ["token", "method", "url", "expiresAt"]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid conversation operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authenticated staff required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Inbox membership required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Conversation not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Private attachment upload unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Attachment rejected by policy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/conversations/{id}/attachments/finalize": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "filename": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255
+                  },
+                  "contentType": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sizeBytes": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "token": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": ["filename", "contentType", "sizeBytes", "token"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Attachment finalized and scanned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "filename": {
+                          "type": "string"
+                        },
+                        "contentType": {
+                          "type": "string"
+                        },
+                        "sizeBytes": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "disposition": {
+                          "type": "string",
+                          "enum": ["attachment", "inline"]
+                        },
+                        "inlineContentId": {
+                          "type": ["string", "null"]
+                        },
+                        "scanStatus": {
+                          "type": "string",
+                          "enum": ["pending", "clean", "blocked", "failed"]
+                        },
+                        "availability": {
+                          "type": "string",
+                          "enum": ["active", "quarantined", "redaction_pending", "redacted"]
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "filename",
+                        "contentType",
+                        "sizeBytes",
+                        "disposition",
+                        "inlineContentId",
+                        "scanStatus",
+                        "availability",
+                        "createdAt"
+                      ]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid conversation operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authenticated staff required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Inbox membership required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Conversation not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Upload unavailable or drifted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Attachment rejected by policy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/conversations/{id}/attachments/{attachmentId}/download": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "attachmentId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Private attachment stream",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "302": {
+            "description": "Short-lived private download redirect"
+          },
+          "400": {
+            "description": "Invalid conversation operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authenticated staff required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Inbox membership required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Clean attachment not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Private attachment runtime unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/conversations/{id}/attachments/{attachmentId}/redact": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "attachmentId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Attachment queued for redaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "filename": {
+                          "type": "string"
+                        },
+                        "contentType": {
+                          "type": "string"
+                        },
+                        "sizeBytes": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "disposition": {
+                          "type": "string",
+                          "enum": ["attachment", "inline"]
+                        },
+                        "inlineContentId": {
+                          "type": ["string", "null"]
+                        },
+                        "scanStatus": {
+                          "type": "string",
+                          "enum": ["pending", "clean", "blocked", "failed"]
+                        },
+                        "availability": {
+                          "type": "string",
+                          "enum": ["active", "quarantined", "redaction_pending", "redacted"]
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "filename",
+                        "contentType",
+                        "sizeBytes",
+                        "disposition",
+                        "inlineContentId",
+                        "scanStatus",
+                        "availability",
+                        "createdAt"
+                      ]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid conversation operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authenticated staff required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Inbox membership required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Attachment not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/conversations/package.json
+++ b/packages/conversations/package.json
@@ -9,6 +9,7 @@
     "./schema": "./src/schema.ts",
     "./runtime-port": "./src/runtime-port.ts",
     "./runtime-contributor": "./src/runtime-contributor.ts",
+    "./attachment-retention-job": "./src/attachment-retention-job.ts",
     "./ingress-job": "./src/ingress-job.ts",
     "./snooze-expiry-job": "./src/snooze-expiry-job.ts",
     "./voyant": "./src/voyant.ts",
@@ -29,12 +30,17 @@
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
+    "@voyant-travel/storage": "workspace:^",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
+    "sanitize-html": "^2.17.5",
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.4",
+    "@types/node": "catalog:",
     "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "@types/sanitize-html": "^2.16.1",
     "drizzle-kit": "^0.31.10",
     "tsx": "catalog:",
     "typescript": "catalog:",
@@ -78,6 +84,11 @@
         "types": "./dist/snooze-expiry-job.d.ts",
         "import": "./dist/snooze-expiry-job.js",
         "default": "./dist/snooze-expiry-job.js"
+      },
+      "./attachment-retention-job": {
+        "types": "./dist/attachment-retention-job.d.ts",
+        "import": "./dist/attachment-retention-job.js",
+        "default": "./dist/attachment-retention-job.js"
       },
       "./voyant": {
         "types": "./dist/voyant.d.ts",

--- a/packages/conversations/src/attachment-retention-job.ts
+++ b/packages/conversations/src/attachment-retention-job.ts
@@ -1,0 +1,18 @@
+import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { cleanupConversationAttachments } from "./attachment-service.js"
+import {
+  conversationsAttachmentRuntimePort,
+  conversationsDatabaseRuntimePort,
+} from "./runtime-port.js"
+
+export async function runConversationAttachmentRetentionJob(
+  context: VoyantGraphRuntimeFactoryContext,
+): Promise<void> {
+  if (!context.hasPort(conversationsAttachmentRuntimePort)) return
+  const [database, attachments] = await Promise.all([
+    context.getPort(conversationsDatabaseRuntimePort),
+    context.getPort(conversationsAttachmentRuntimePort),
+  ])
+  await cleanupConversationAttachments(database.resolveDb() as PostgresJsDatabase, attachments)
+}

--- a/packages/conversations/src/attachment-runtime.ts
+++ b/packages/conversations/src/attachment-runtime.ts
@@ -1,0 +1,99 @@
+import type { StorageProviderResolver } from "@voyant-travel/storage"
+
+export interface ConversationAttachmentUploadTicket {
+  token: string
+  method: "PUT" | "POST"
+  url: string
+  headers?: Readonly<Record<string, string>>
+  expiresAt: string
+}
+
+export interface ConversationAttachmentFinalizeResult {
+  privateHandle: string
+  filename: string
+  contentType: string
+  sizeBytes: number
+}
+
+export type ConversationAttachmentDownload =
+  | { kind: "response"; response: Response }
+  | { kind: "redirect"; url: string; expiresAt: string }
+
+export type ConversationAttachmentSendMaterial =
+  | { kind: "bytes"; bytes: Uint8Array; contentType: string }
+  | { kind: "private-url"; url: string; expiresAt: string; contentType: string }
+
+export interface ConversationAttachmentScanResult {
+  status: "clean" | "blocked" | "failed"
+  detectedContentType?: string
+  detectedSizeBytes?: number
+}
+
+/** Runtime-only authority for private attachment bytes. No method returns credentials. */
+export interface ConversationsAttachmentRuntime {
+  createUploadTicket?(input: {
+    conversationId: string
+    filename: string
+    contentType: string
+    sizeBytes: number
+  }): Promise<ConversationAttachmentUploadTicket>
+  finalizeUpload?(input: {
+    conversationId: string
+    token: string
+    filename: string
+    contentType: string
+    sizeBytes: number
+  }): Promise<ConversationAttachmentFinalizeResult>
+  importInbound?(input: {
+    sourceId: string
+    externalId: string
+    privateHandle: string
+    filename: string
+    contentType: string
+    sizeBytes: number
+  }): Promise<ConversationAttachmentFinalizeResult>
+  scan(input: {
+    privateHandle: string
+    filename: string
+    declaredContentType: string
+    declaredSizeBytes: number
+  }): Promise<ConversationAttachmentScanResult>
+  download(privateHandle: string): Promise<ConversationAttachmentDownload | null>
+  delete(privateHandle: string): Promise<void>
+  resolveForSend(privateHandle: string): Promise<ConversationAttachmentSendMaterial | null>
+}
+
+/**
+ * Safe fallback for deployments with the logical private documents store. It
+ * intentionally does not invent a direct-upload protocol; upload remains
+ * capability-gated while downloads, cleanup, and worker materialization work.
+ */
+export function createDocumentsConversationAttachmentRuntime(
+  resolver: StorageProviderResolver,
+): ConversationsAttachmentRuntime | null {
+  const storage = resolver.resolve("documents")
+  if (!storage?.signedUrl) return null
+  return {
+    async scan() {
+      return { status: "failed" as const }
+    },
+    async download(privateHandle) {
+      const expiresIn = 60
+      return {
+        kind: "redirect" as const,
+        url: await storage.signedUrl!(privateHandle, expiresIn),
+        expiresAt: new Date(Date.now() + expiresIn * 1_000).toISOString(),
+      }
+    },
+    delete: (privateHandle) => storage.delete(privateHandle),
+    async resolveForSend(privateHandle) {
+      const expiresIn = 60
+      return {
+        kind: "private-url" as const,
+        url: await storage.signedUrl!(privateHandle, expiresIn),
+        expiresAt: new Date(Date.now() + expiresIn * 1_000).toISOString(),
+        contentType: "application/octet-stream",
+      }
+    },
+  }
+}

--- a/packages/conversations/src/attachment-service.ts
+++ b/packages/conversations/src/attachment-service.ts
@@ -1,0 +1,392 @@
+import type { ConversationPrivateAttachmentDeliveryResolver } from "@voyant-travel/conversations-contracts"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { insertOutboxEvents } from "@voyant-travel/db/outbox"
+import { and, eq, inArray, isNotNull, isNull, lte, or, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { ConversationsAttachmentRuntime } from "./attachment-runtime.js"
+import {
+  assertAttachmentSetPolicy,
+  assertDetectedAttachmentMetadata,
+  ConversationAttachmentPolicyError,
+  normalizeAttachmentMetadata,
+} from "./content-security.js"
+import {
+  type ConversationAttachment,
+  conversationAttachments,
+  conversationEvents,
+  conversationParts,
+  conversations,
+} from "./schema.js"
+
+export class ConversationAttachmentUnavailableError extends Error {
+  readonly code = "attachment_runtime_unavailable"
+}
+
+export class ConversationAttachmentNotFoundError extends Error {
+  readonly code = "attachment_not_found"
+}
+
+export class ConversationAttachmentConflictError extends Error {
+  readonly code = "attachment_conflict"
+}
+
+export async function createAttachmentUploadTicket(
+  db: PostgresJsDatabase,
+  runtime: ConversationsAttachmentRuntime | undefined,
+  input: { conversationId: string; filename: string; contentType: string; sizeBytes: number },
+) {
+  const metadata = normalizeAttachmentMetadata(input)
+  const [conversation] = await db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(eq(conversations.id, input.conversationId))
+    .limit(1)
+  if (!conversation) throw new ConversationAttachmentNotFoundError("Conversation not found")
+  if (!runtime?.createUploadTicket || !runtime.finalizeUpload) {
+    throw new ConversationAttachmentUnavailableError("Private upload is not configured")
+  }
+  return runtime.createUploadTicket({ conversationId: input.conversationId, ...metadata })
+}
+
+export async function finalizeAttachmentUpload(
+  db: PostgresJsDatabase,
+  runtime: ConversationsAttachmentRuntime | undefined,
+  input: {
+    conversationId: string
+    token: string
+    filename: string
+    contentType: string
+    sizeBytes: number
+  },
+): Promise<ConversationAttachment> {
+  const requested = normalizeAttachmentMetadata(input)
+  if (!runtime?.finalizeUpload) {
+    throw new ConversationAttachmentUnavailableError("Private upload is not configured")
+  }
+  const finalized = await runtime.finalizeUpload({ ...input, ...requested })
+  const scan = await runtime.scan({
+    privateHandle: finalized.privateHandle,
+    filename: finalized.filename,
+    declaredContentType: finalized.contentType,
+    declaredSizeBytes: finalized.sizeBytes,
+  })
+  let verified = normalizeAttachmentMetadata(finalized)
+  let scanStatus: "clean" | "blocked" | "failed" = scan.status
+  try {
+    verified = assertDetectedAttachmentMetadata({
+      filename: finalized.filename,
+      declaredContentType: finalized.contentType,
+      declaredSizeBytes: finalized.sizeBytes,
+      detectedContentType: scan.detectedContentType,
+      detectedSizeBytes: scan.detectedSizeBytes,
+    })
+  } catch {
+    scanStatus = "blocked"
+  }
+  if (
+    verified.filename !== requested.filename ||
+    verified.contentType !== requested.contentType ||
+    verified.sizeBytes !== requested.sizeBytes ||
+    !finalized.privateHandle.trim()
+  ) {
+    throw new ConversationAttachmentConflictError("Finalized upload metadata does not match")
+  }
+  const [attachment] = await db
+    .insert(conversationAttachments)
+    .values({
+      id: newId("conversation_attachments"),
+      conversationId: input.conversationId,
+      privateHandle: finalized.privateHandle,
+      ...verified,
+      scanStatus,
+      availability: scanStatus === "clean" ? "active" : "quarantined",
+    })
+    .returning()
+  if (!attachment) throw new Error("Finalized attachment was not persisted")
+  return attachment
+}
+
+export async function downloadConversationAttachment(
+  db: PostgresJsDatabase,
+  runtime: ConversationsAttachmentRuntime | undefined,
+  input: { conversationId: string; attachmentId: string },
+) {
+  if (!runtime) throw new ConversationAttachmentUnavailableError("Private download is unavailable")
+  const [attachment] = await db
+    .select()
+    .from(conversationAttachments)
+    .where(
+      and(
+        eq(conversationAttachments.id, input.attachmentId),
+        eq(conversationAttachments.conversationId, input.conversationId),
+        eq(conversationAttachments.scanStatus, "clean"),
+        eq(conversationAttachments.availability, "active"),
+      ),
+    )
+    .limit(1)
+  if (!attachment) throw new ConversationAttachmentNotFoundError("Attachment not available")
+  if (!attachment.privateHandle)
+    throw new ConversationAttachmentNotFoundError("Attachment has been redacted")
+  const download = await runtime.download(attachment.privateHandle)
+  if (!download) throw new ConversationAttachmentNotFoundError("Attachment bytes not found")
+  return { attachment, download }
+}
+
+export async function requestAttachmentRedaction(
+  db: PostgresJsDatabase,
+  input: { conversationId: string; attachmentId: string },
+) {
+  const [attachment] = await db
+    .update(conversationAttachments)
+    .set({ availability: "redaction_pending", updatedAt: new Date() })
+    .where(
+      and(
+        eq(conversationAttachments.id, input.attachmentId),
+        eq(conversationAttachments.conversationId, input.conversationId),
+        inArray(conversationAttachments.availability, ["active", "quarantined"]),
+      ),
+    )
+    .returning()
+  if (!attachment) throw new ConversationAttachmentNotFoundError("Attachment not found")
+  return attachment
+}
+
+export async function cleanupConversationAttachments(
+  db: PostgresJsDatabase,
+  runtime: ConversationsAttachmentRuntime,
+  now = new Date(),
+  limit = 100,
+) {
+  const due = await db
+    .select()
+    .from(conversationAttachments)
+    .where(
+      or(
+        eq(conversationAttachments.availability, "redaction_pending"),
+        and(
+          isNotNull(conversationAttachments.retentionUntil),
+          lte(conversationAttachments.retentionUntil, now),
+        ),
+      ),
+    )
+    .limit(Math.min(Math.max(limit, 1), 500))
+  let redacted = 0
+  for (const attachment of due) {
+    if (attachment.privateHandle) await runtime.delete(attachment.privateHandle)
+    const didRedact = await db.transaction(async (transaction) => {
+      const tx = transaction as PostgresJsDatabase
+      const [updated] = await tx
+        .update(conversationAttachments)
+        .set({
+          availability: "redacted",
+          privateHandle: null,
+          redactedAt: now,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(conversationAttachments.id, attachment.id),
+            inArray(conversationAttachments.availability, [
+              "active",
+              "quarantined",
+              "redaction_pending",
+            ]),
+          ),
+        )
+        .returning({ id: conversationAttachments.id })
+      if (!updated) return false
+      if (attachment.partId) {
+        await tx
+          .update(conversationParts)
+          .set({ textBody: null, htmlBody: null, contentStatus: "redacted" })
+          .where(eq(conversationParts.id, attachment.partId))
+      }
+      const [conversation] = await tx
+        .update(conversations)
+        .set({ revision: sql`${conversations.revision} + 1`, updatedAt: now })
+        .where(eq(conversations.id, attachment.conversationId))
+        .returning({ inboxId: conversations.inboxId, revision: conversations.revision })
+      if (!conversation) return false
+      await tx.insert(conversationEvents).values({
+        conversationId: attachment.conversationId,
+        type: "attachment.redacted",
+        revision: conversation.revision,
+        payload: { attachmentId: attachment.id, partId: attachment.partId },
+        occurredAt: now,
+      })
+      await insertOutboxEvents(tx as never, [
+        {
+          name: "conversation.changed",
+          data: {
+            conversationId: attachment.conversationId,
+            inboxId: conversation.inboxId,
+            revision: conversation.revision,
+            change: "attachment.redacted",
+          },
+          metadata: {},
+          emittedAt: now.toISOString(),
+        },
+      ])
+      return true
+    })
+    if (didRedact) redacted += 1
+  }
+  return { inspected: due.length, redacted }
+}
+
+export async function requireSendableAttachments(
+  db: PostgresJsDatabase,
+  conversationId: string,
+  attachmentIds: readonly string[],
+) {
+  if (attachmentIds.length === 0) return []
+  if (new Set(attachmentIds).size !== attachmentIds.length) {
+    throw new ConversationAttachmentPolicyError("Duplicate attachment id")
+  }
+  const rows = await db
+    .select()
+    .from(conversationAttachments)
+    .where(
+      and(
+        eq(conversationAttachments.conversationId, conversationId),
+        inArray(conversationAttachments.id, [...attachmentIds]),
+        isNull(conversationAttachments.partId),
+      ),
+    )
+  if (
+    rows.length !== attachmentIds.length ||
+    rows.some(
+      (row) =>
+        row.partId ||
+        !row.privateHandle ||
+        row.scanStatus !== "clean" ||
+        row.availability !== "active",
+    )
+  ) {
+    throw new ConversationAttachmentConflictError("Attachments are not clean and available")
+  }
+  assertAttachmentSetPolicy(
+    rows.map((row) => ({
+      filename: row.filename,
+      contentType: row.contentType,
+      sizeBytes: row.sizeBytes,
+    })),
+  )
+  return rows.map((row) => ({ ...row, privateHandle: row.privateHandle! }))
+}
+
+export async function linkAttachmentsToPart(
+  db: PostgresJsDatabase,
+  attachmentIds: readonly string[],
+  partId: string,
+) {
+  if (attachmentIds.length === 0) return
+  const linked = await db
+    .update(conversationAttachments)
+    .set({ partId, updatedAt: new Date() })
+    .where(
+      and(
+        inArray(conversationAttachments.id, [...attachmentIds]),
+        isNull(conversationAttachments.partId),
+        eq(conversationAttachments.scanStatus, "clean"),
+        eq(conversationAttachments.availability, "active"),
+      ),
+    )
+    .returning({ id: conversationAttachments.id })
+  if (linked.length !== attachmentIds.length) {
+    throw new ConversationAttachmentConflictError("Attachment link changed concurrently")
+  }
+}
+
+export async function listPartAttachments(db: PostgresJsDatabase, partIds: readonly string[]) {
+  if (partIds.length === 0) return []
+  return db
+    .select()
+    .from(conversationAttachments)
+    .where(inArray(conversationAttachments.partId, [...partIds]))
+}
+
+/**
+ * Build the worker-only resolver. Every invocation re-reads attachment truth,
+ * re-runs scanning, and materializes an ephemeral payload immediately before a
+ * provider attempt. The durable operation continues to store only the handle.
+ */
+export function createConversationPrivateAttachmentDeliveryResolver(
+  db: PostgresJsDatabase,
+  runtime: ConversationsAttachmentRuntime,
+): ConversationPrivateAttachmentDeliveryResolver {
+  return {
+    async resolveForDelivery(input) {
+      const [attachment] = await db
+        .select()
+        .from(conversationAttachments)
+        .where(
+          and(
+            eq(conversationAttachments.privateHandle, input.privateHandle),
+            eq(conversationAttachments.partId, input.targetId),
+          ),
+        )
+        .limit(1)
+      if (
+        !attachment?.privateHandle ||
+        attachment.scanStatus !== "clean" ||
+        attachment.availability !== "active"
+      ) {
+        throw new ConversationAttachmentConflictError("Attachment is not sendable")
+      }
+      const scan = await runtime.scan({
+        privateHandle: attachment.privateHandle,
+        filename: attachment.filename,
+        declaredContentType: attachment.contentType,
+        declaredSizeBytes: attachment.sizeBytes,
+      })
+      try {
+        assertDetectedAttachmentMetadata({
+          filename: attachment.filename,
+          declaredContentType: attachment.contentType,
+          declaredSizeBytes: attachment.sizeBytes,
+          detectedContentType: scan.detectedContentType,
+          detectedSizeBytes: scan.detectedSizeBytes,
+        })
+      } catch {
+        await quarantineAttachment(db, attachment.id, "blocked")
+        throw new ConversationAttachmentConflictError("Attachment changed after admission")
+      }
+      if (scan.status !== "clean") {
+        await quarantineAttachment(db, attachment.id, scan.status)
+        throw new ConversationAttachmentConflictError("Attachment failed send-time scanning")
+      }
+      const material = await runtime.resolveForSend(attachment.privateHandle)
+      if (!material) throw new ConversationAttachmentNotFoundError("Attachment bytes not found")
+      const common = {
+        filename: attachment.filename,
+        contentType: attachment.contentType,
+        disposition:
+          attachment.disposition === "inline" ? ("inline" as const) : ("attachment" as const),
+        ...(attachment.inlineContentId ? { contentId: attachment.inlineContentId } : {}),
+      }
+      return material.kind === "private-url"
+        ? { ...common, path: material.url }
+        : { ...common, contentBase64: bytesToBase64(material.bytes) }
+    },
+  }
+}
+
+async function quarantineAttachment(
+  db: PostgresJsDatabase,
+  id: string,
+  scanStatus: "blocked" | "failed",
+) {
+  await db
+    .update(conversationAttachments)
+    .set({ scanStatus, availability: "quarantined", scannedAt: new Date(), updatedAt: new Date() })
+    .where(eq(conversationAttachments.id, id))
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ""
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000))
+  }
+  return btoa(binary)
+}

--- a/packages/conversations/src/content-security.ts
+++ b/packages/conversations/src/content-security.ts
@@ -1,0 +1,176 @@
+import sanitizeHtml from "sanitize-html"
+
+export const CONVERSATION_ATTACHMENT_LIMITS = {
+  maxCount: 10,
+  maxFileBytes: 25 * 1024 * 1024,
+  maxTotalBytes: 50 * 1024 * 1024,
+  maxFilenameLength: 255,
+} as const
+
+const BLOCKED_CONTENT_TYPES = new Set([
+  "application/java-archive",
+  "application/vnd.microsoft.portable-executable",
+  "application/x-bat",
+  "application/x-dosexec",
+  "application/x-executable",
+  "application/x-httpd-php",
+  "application/x-msdownload",
+  "application/x-sh",
+  "application/x-shellscript",
+  "text/html",
+  "image/svg+xml",
+])
+const EXTENSION_CONTENT_TYPES: Readonly<Record<string, readonly string[]>> = {
+  pdf: ["application/pdf"],
+  png: ["image/png"],
+  jpg: ["image/jpeg"],
+  jpeg: ["image/jpeg"],
+  gif: ["image/gif"],
+  webp: ["image/webp"],
+  txt: ["text/plain"],
+  csv: ["text/csv", "application/csv"],
+  json: ["application/json"],
+  zip: ["application/zip", "application/x-zip-compressed"],
+  doc: ["application/msword"],
+  docx: ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
+  xls: ["application/vnd.ms-excel"],
+  xlsx: ["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"],
+}
+
+/**
+ * Sanitize untrusted customer and staff HTML before it crosses a persistence or
+ * delivery boundary. Remote images, CSS, forms, and active/embed content are not
+ * allowed because an Inbox view must not become a tracking or execution surface.
+ */
+export function sanitizeConversationHtml(value: string | null | undefined): string | null {
+  if (!value) return null
+  const sanitized = sanitizeHtml(value, {
+    allowedTags: [
+      "p",
+      "br",
+      "div",
+      "span",
+      "strong",
+      "b",
+      "em",
+      "i",
+      "u",
+      "s",
+      "blockquote",
+      "pre",
+      "code",
+      "ul",
+      "ol",
+      "li",
+      "table",
+      "thead",
+      "tbody",
+      "tr",
+      "th",
+      "td",
+      "a",
+    ],
+    allowedAttributes: { a: ["href", "title", "rel"] },
+    allowedSchemes: ["http", "https", "mailto", "tel"],
+    allowedSchemesAppliedToAttributes: ["href"],
+    allowProtocolRelative: false,
+    disallowedTagsMode: "discard",
+    enforceHtmlBoundary: true,
+    transformTags: {
+      a: (_tagName, attributes) => ({
+        tagName: "a",
+        attribs: {
+          ...(attributes.href ? { href: attributes.href } : {}),
+          ...(attributes.title ? { title: attributes.title } : {}),
+          rel: "noopener noreferrer",
+        },
+      }),
+    },
+  }).trim()
+  return sanitized || null
+}
+
+export interface AttachmentMetadataInput {
+  filename: string
+  contentType: string
+  sizeBytes: number
+}
+
+export class ConversationAttachmentPolicyError extends Error {
+  readonly code = "attachment_policy_rejected"
+}
+
+export function normalizeAttachmentMetadata(input: AttachmentMetadataInput) {
+  const filename = input.filename
+    .normalize("NFKC")
+    .split("")
+    .map((character) => {
+      const code = character.charCodeAt(0)
+      return code < 32 || code === 127 || character === "/" || character === "\\" ? "_" : character
+    })
+    .join("")
+    .trim()
+  const contentType = input.contentType.split(";", 1)[0]!.trim().toLowerCase()
+  if (!filename || filename === "." || filename === "..") {
+    throw new ConversationAttachmentPolicyError("Attachment filename is invalid")
+  }
+  if (filename.length > CONVERSATION_ATTACHMENT_LIMITS.maxFilenameLength) {
+    throw new ConversationAttachmentPolicyError("Attachment filename is too long")
+  }
+  if (!Number.isSafeInteger(input.sizeBytes) || input.sizeBytes < 0) {
+    throw new ConversationAttachmentPolicyError("Attachment size is invalid")
+  }
+  if (input.sizeBytes > CONVERSATION_ATTACHMENT_LIMITS.maxFileBytes) {
+    throw new ConversationAttachmentPolicyError("Attachment exceeds the per-file size limit")
+  }
+  if (!contentType || BLOCKED_CONTENT_TYPES.has(contentType)) {
+    throw new ConversationAttachmentPolicyError("Attachment content type is not allowed")
+  }
+  const extension = filename.includes(".") ? filename.split(".").pop()?.toLowerCase() : undefined
+  const allowedForExtension = extension ? EXTENSION_CONTENT_TYPES[extension] : undefined
+  if (allowedForExtension && !allowedForExtension.includes(contentType)) {
+    throw new ConversationAttachmentPolicyError("Attachment extension and content type disagree")
+  }
+  return { filename, contentType, sizeBytes: input.sizeBytes }
+}
+
+export function assertDetectedAttachmentMetadata(input: {
+  filename: string
+  declaredContentType: string
+  declaredSizeBytes: number
+  detectedContentType?: string
+  detectedSizeBytes?: number
+}) {
+  const declared = normalizeAttachmentMetadata({
+    filename: input.filename,
+    contentType: input.declaredContentType,
+    sizeBytes: input.declaredSizeBytes,
+  })
+  if (input.detectedSizeBytes !== undefined && input.detectedSizeBytes !== declared.sizeBytes) {
+    throw new ConversationAttachmentPolicyError("Attachment size does not match its content")
+  }
+  if (input.detectedContentType) {
+    const detected = normalizeAttachmentMetadata({
+      filename: input.filename,
+      contentType: input.detectedContentType,
+      sizeBytes: input.detectedSizeBytes ?? declared.sizeBytes,
+    })
+    if (detected.contentType !== declared.contentType) {
+      throw new ConversationAttachmentPolicyError("Attachment type does not match its content")
+    }
+  }
+  return declared
+}
+
+export function assertAttachmentSetPolicy(items: readonly AttachmentMetadataInput[]): void {
+  if (items.length > CONVERSATION_ATTACHMENT_LIMITS.maxCount) {
+    throw new ConversationAttachmentPolicyError("Too many attachments")
+  }
+  let total = 0
+  for (const item of items) {
+    total += normalizeAttachmentMetadata(item).sizeBytes
+    if (total > CONVERSATION_ATTACHMENT_LIMITS.maxTotalBytes) {
+      throw new ConversationAttachmentPolicyError("Attachments exceed the total size limit")
+    }
+  }
+}

--- a/packages/conversations/src/index.ts
+++ b/packages/conversations/src/index.ts
@@ -4,12 +4,15 @@ import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { ApiModule } from "@voyant-travel/hono/module"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import {
+  conversationsAttachmentRuntimePort,
   conversationsDatabaseRuntimePort,
   conversationsPersonDirectoryPort,
   conversationsRenderedMessageAdmissionPort,
 } from "./runtime-port.js"
 import { conversationsModule } from "./schema.js"
 
+export * from "./attachment-runtime.js"
+export * from "./content-security.js"
 export * from "./runtime-port.js"
 export * from "./schema.js"
 export * from "./service.js"
@@ -48,6 +51,9 @@ export const createConversationsVoyantRuntime = defineGraphRuntimeFactory(
         ? await getPort(conversationsPersonDirectoryPort)
         : undefined,
       staffDirectory: await getPort(staffDirectoryRuntimePort),
+      attachments: hasPort(conversationsAttachmentRuntimePort)
+        ? await getPort(conversationsAttachmentRuntimePort)
+        : undefined,
     })
   },
 )

--- a/packages/conversations/src/ingress-job.ts
+++ b/packages/conversations/src/ingress-job.ts
@@ -3,6 +3,7 @@ import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/proje
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import {
   conversationIngressSourcePort,
+  conversationsAttachmentRuntimePort,
   conversationsDatabaseRuntimePort,
   conversationsPersonDirectoryPort,
 } from "./runtime-port.js"
@@ -19,6 +20,7 @@ export async function processConversationIngress(input: {
   db: PostgresJsDatabase
   sources: readonly import("@voyant-travel/conversations-contracts").ConversationIngressSource[]
   personDirectory?: import("./runtime-port.js").ConversationsPersonDirectory
+  attachmentRuntime?: import("./attachment-runtime.js").ConversationsAttachmentRuntime
   limit?: number
   /** Test seam for the commit boundary; production always uses `ingestEnvelope`. */
   ingest?: typeof ingestEnvelope
@@ -31,6 +33,7 @@ export async function processConversationIngress(input: {
       summary.fetched += 1
       const result = await (input.ingest ?? ingestEnvelope)(input.db, envelope, {
         personDirectory: input.personDirectory,
+        attachmentRuntime: input.attachmentRuntime,
       })
       if (result.duplicate) summary.duplicates += 1
       else summary.committed += 1
@@ -50,9 +53,13 @@ export async function runConversationIngressJob(
   const personDirectory = context.hasPort(conversationsPersonDirectoryPort)
     ? await context.getPort(conversationsPersonDirectoryPort)
     : undefined
+  const attachmentRuntime = context.hasPort(conversationsAttachmentRuntimePort)
+    ? await context.getPort(conversationsAttachmentRuntimePort)
+    : undefined
   await processConversationIngress({
     db: database.resolveDb() as PostgresJsDatabase,
     sources,
     personDirectory,
+    attachmentRuntime,
   })
 }

--- a/packages/conversations/src/routes.ts
+++ b/packages/conversations/src/routes.ts
@@ -1,6 +1,17 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { openApiValidationHook } from "@voyant-travel/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { ConversationsAttachmentRuntime } from "./attachment-runtime.js"
+import {
+  ConversationAttachmentConflictError,
+  ConversationAttachmentNotFoundError,
+  ConversationAttachmentUnavailableError,
+  createAttachmentUploadTicket,
+  downloadConversationAttachment,
+  finalizeAttachmentUpload,
+  requestAttachmentRedaction,
+} from "./attachment-service.js"
+import { ConversationAttachmentPolicyError } from "./content-security.js"
 import type {
   ConversationsPersonDirectory,
   ConversationsRenderedMessageAdmission,
@@ -9,6 +20,7 @@ import type {
 import type { Conversation, ConversationNote, ConversationPart } from "./schema.js"
 import {
   addConversationNote,
+  assertConversationInboxMembership,
   ConversationAccessDeniedError,
   type ConversationActor,
   ConversationConflictError,
@@ -40,6 +52,7 @@ export interface ConversationsRoutesOptions {
   admission?: ConversationsRenderedMessageAdmission
   personDirectory?: ConversationsPersonDirectory
   staffDirectory: ConversationsStaffDirectory
+  attachments?: ConversationsAttachmentRuntime
 }
 
 const timestamp = z.string().datetime()
@@ -74,7 +87,29 @@ const partSchema = z.object({
   subject: z.string().nullable(),
   textBody: z.string().nullable(),
   htmlBody: z.string().nullable(),
-  attachments: z.array(z.record(z.string(), z.unknown())),
+  contentStatus: z.enum(["safe", "quarantined", "redacted"]),
+  legacyAttachmentCount: z.number().int().nonnegative(),
+  classification: z.enum([
+    "message",
+    "automatic_reply",
+    "delivery_status",
+    "complaint",
+    "suspicious",
+  ]),
+  replyable: z.boolean(),
+  attachments: z.array(
+    z.object({
+      id: z.string(),
+      filename: z.string(),
+      contentType: z.string(),
+      sizeBytes: z.number().int().nonnegative(),
+      disposition: z.enum(["attachment", "inline"]),
+      inlineContentId: z.string().nullable(),
+      scanStatus: z.enum(["pending", "clean", "blocked", "failed"]),
+      availability: z.enum(["active", "quarantined", "redaction_pending", "redacted"]),
+      createdAt: timestamp,
+    }),
+  ),
   externalMessageId: z.string().nullable(),
   messageId: z.string().nullable(),
   inReplyTo: z.string().nullable(),
@@ -183,8 +218,9 @@ const detailRoute = createRoute({
 })
 const replyInput = z.object({
   channelAccountId: z.string().min(1),
-  text: z.string().trim().min(1),
+  text: z.string().trim().min(1).nullable(),
   html: z.string().nullable().optional(),
+  attachmentIds: z.array(z.string().min(1)).max(10).default([]),
   idempotencyKey: z.string().min(1),
 })
 const replyRoute = createRoute({
@@ -309,6 +345,80 @@ const assignableRoute = createRoute({
     ...standardErrors,
   },
 })
+const attachmentMetadataInput = z.object({
+  filename: z.string().min(1).max(255),
+  contentType: z.string().min(1),
+  sizeBytes: z.number().int().nonnegative(),
+})
+const attachmentSchema = partSchema.shape.attachments.element
+const ticketRoute = createRoute({
+  method: "post",
+  path: "/v1/admin/conversations/{id}/attachments/tickets",
+  request: {
+    params: z.object({ id: z.string() }),
+    body: body(attachmentMetadataInput),
+  },
+  responses: {
+    ...standardErrors,
+    201: json(
+      data(
+        z.object({
+          token: z.string(),
+          method: z.enum(["PUT", "POST"]),
+          url: z.string().url(),
+          headers: z.record(z.string(), z.string()).optional(),
+          expiresAt: timestamp,
+        }),
+      ),
+      "Short-lived private upload ticket",
+    ),
+    404: json(errorSchema, "Conversation not found"),
+    409: json(errorSchema, "Private attachment upload unavailable"),
+    422: json(errorSchema, "Attachment rejected by policy"),
+  },
+})
+const finalizeRoute = createRoute({
+  method: "post",
+  path: "/v1/admin/conversations/{id}/attachments/finalize",
+  request: {
+    params: z.object({ id: z.string() }),
+    body: body(attachmentMetadataInput.extend({ token: z.string().min(1) })),
+  },
+  responses: {
+    ...standardErrors,
+    201: json(data(attachmentSchema), "Attachment finalized and scanned"),
+    404: json(errorSchema, "Conversation not found"),
+    409: json(errorSchema, "Upload unavailable or drifted"),
+    422: json(errorSchema, "Attachment rejected by policy"),
+  },
+})
+const downloadRoute = createRoute({
+  method: "get",
+  path: "/v1/admin/conversations/{id}/attachments/{attachmentId}/download",
+  request: { params: z.object({ id: z.string(), attachmentId: z.string() }) },
+  responses: {
+    ...standardErrors,
+    200: {
+      description: "Private attachment stream",
+      content: {
+        "application/octet-stream": { schema: z.string().openapi({ format: "binary" }) },
+      },
+    },
+    302: { description: "Short-lived private download redirect" },
+    404: json(errorSchema, "Clean attachment not found"),
+    409: json(errorSchema, "Private attachment runtime unavailable"),
+  },
+})
+const redactRoute = createRoute({
+  method: "post",
+  path: "/v1/admin/conversations/{id}/attachments/{attachmentId}/redact",
+  request: { params: z.object({ id: z.string(), attachmentId: z.string() }) },
+  responses: {
+    ...standardErrors,
+    200: json(data(attachmentSchema), "Attachment queued for redaction"),
+    404: json(errorSchema, "Attachment not found"),
+  },
+})
 
 // biome-ignore lint/suspicious/noExplicitAny: Date rows serialize to the declared wire shape.
 const response = (value: unknown): any => value
@@ -331,7 +441,21 @@ function toPartDto(row: ConversationPart) {
     notificationDeliveryId: _deliveryId,
     ...dto
   } = row
-  return dto
+  return { ...dto, attachments: [] }
+}
+
+function toAttachmentDto(row: import("./schema.js").ConversationAttachment) {
+  return {
+    id: row.id,
+    filename: row.filename,
+    contentType: row.contentType,
+    sizeBytes: row.sizeBytes,
+    disposition: row.disposition === "inline" ? "inline" : "attachment",
+    inlineContentId: row.inlineContentId,
+    scanStatus: row.scanStatus,
+    availability: row.availability,
+    createdAt: row.createdAt,
+  }
 }
 
 function toNoteDto(row: ConversationNote) {
@@ -342,10 +466,25 @@ function toDetailDto(detail: Awaited<ReturnType<typeof getConversation>>) {
   if (!detail) return null
   return {
     conversation: toConversationDto(detail.conversation),
-    parts: detail.parts.map(toPartDto),
+    parts: detail.parts.map((part) => ({
+      ...toPartDto(part),
+      attachments: detail.attachments
+        .filter(({ partId }) => partId === part.id)
+        .map(toAttachmentDto),
+    })),
     notes: detail.notes.map(toNoteDto),
     timeline: detail.timeline.map((item) =>
-      item.kind === "part" ? { ...item, part: toPartDto(item.part) } : item,
+      item.kind === "part"
+        ? {
+            ...item,
+            part: {
+              ...toPartDto(item.part),
+              attachments: detail.attachments
+                .filter(({ partId }) => partId === item.part.id)
+                .map(toAttachmentDto),
+            },
+          }
+        : item,
     ),
   }
 }
@@ -356,6 +495,14 @@ function serviceError(error: unknown): { status: 400 | 403 | 404 | 409; error: s
   if (error instanceof ConversationInvalidStateError) return { status: 400, error: error.code }
   if (error instanceof ConversationConflictError || error instanceof ConversationIngressDriftError)
     return { status: 409, error: error.code }
+  if (error instanceof ConversationAttachmentNotFoundError)
+    return { status: 404, error: error.code }
+  if (
+    error instanceof ConversationAttachmentConflictError ||
+    error instanceof ConversationAttachmentUnavailableError
+  ) {
+    return { status: 409, error: error.code }
+  }
   return null
 }
 
@@ -534,6 +681,110 @@ export function createConversationsRoutes(options: ConversationsRoutesOptions) {
     )
     if (result.error) return c.json({ error: result.error.error }, result.error.status)
     return c.json(response({ data: result.value }), 200)
+  })
+  register(ticketRoute, async (c: RouteContext) => {
+    const actor = await actorFor(c)
+    if (!actor) return c.json({ error: "active_staff_required" }, 401)
+    const db = options.resolveDb(c.env)
+    const access = await handle(() =>
+      assertConversationInboxMembership(db, c.req.valid("param").id, actor.userId),
+    )
+    if (access.error) return c.json({ error: access.error.error }, access.error.status)
+    try {
+      const ticket = await createAttachmentUploadTicket(
+        db,
+        options.attachments,
+        { conversationId: c.req.valid("param").id, ...c.req.valid("json") },
+      )
+      return c.json(response({ data: ticket }), 201)
+    } catch (error) {
+      if (error instanceof ConversationAttachmentPolicyError)
+        return c.json({ error: error.code }, 422)
+      const mapped = serviceError(error)
+      if (!mapped) throw error
+      return c.json({ error: mapped.error }, mapped.status)
+    }
+  })
+  register(finalizeRoute, async (c: RouteContext) => {
+    const actor = await actorFor(c)
+    if (!actor) return c.json({ error: "active_staff_required" }, 401)
+    const db = options.resolveDb(c.env)
+    const access = await handle(() =>
+      assertConversationInboxMembership(db, c.req.valid("param").id, actor.userId),
+    )
+    if (access.error) return c.json({ error: access.error.error }, access.error.status)
+    try {
+      const attachment = await finalizeAttachmentUpload(
+        db,
+        options.attachments,
+        { conversationId: c.req.valid("param").id, ...c.req.valid("json") },
+      )
+      return c.json(response({ data: toAttachmentDto(attachment) }), 201)
+    } catch (error) {
+      if (error instanceof ConversationAttachmentPolicyError)
+        return c.json({ error: error.code }, 422)
+      const mapped = serviceError(error)
+      if (!mapped) throw error
+      return c.json({ error: mapped.error }, mapped.status)
+    }
+  })
+  register(downloadRoute, async (c: RouteContext) => {
+    const actor = await actorFor(c)
+    if (!actor) return c.json({ error: "active_staff_required" }, 401)
+    const db = options.resolveDb(c.env)
+    const access = await handle(() =>
+      assertConversationInboxMembership(db, c.req.valid("param").id, actor.userId),
+    )
+    if (access.error) return c.json({ error: access.error.error }, access.error.status)
+    try {
+      const result = await downloadConversationAttachment(
+        db,
+        options.attachments,
+        {
+          conversationId: c.req.valid("param").id,
+          attachmentId: c.req.valid("param").attachmentId,
+        },
+      )
+      if (result.download.kind === "redirect") {
+        c.header("cache-control", "private, no-store")
+        return c.redirect(result.download.url, 302)
+      }
+      const headers = new Headers(result.download.response.headers)
+      headers.set("cache-control", "private, no-store")
+      headers.set("content-type", result.attachment.contentType)
+      headers.set("x-content-type-options", "nosniff")
+      headers.set(
+        "content-disposition",
+        `attachment; filename*=UTF-8''${encodeURIComponent(result.attachment.filename)}`,
+      )
+      return new Response(result.download.response.body, {
+        status: result.download.response.status,
+        headers,
+      })
+    } catch (error) {
+      const mapped = serviceError(error)
+      if (!mapped) throw error
+      return c.json({ error: mapped.error }, mapped.status)
+    }
+  })
+  register(redactRoute, async (c: RouteContext) => {
+    const actor = await actorFor(c)
+    if (!actor) return c.json({ error: "active_staff_required" }, 401)
+    const db = options.resolveDb(c.env)
+    const access = await handle(() =>
+      assertConversationInboxMembership(db, c.req.valid("param").id, actor.userId),
+    )
+    if (access.error) return c.json({ error: access.error.error }, access.error.status)
+    try {
+      const attachment = await requestAttachmentRedaction(db, {
+        conversationId: c.req.valid("param").id,
+        attachmentId: c.req.valid("param").attachmentId,
+      })
+      return c.json(response({ data: toAttachmentDto(attachment) }), 200)
+    } catch (error) {
+      if (!(error instanceof ConversationAttachmentNotFoundError)) throw error
+      return c.json({ error: error.code }, 404)
+    }
   })
   return app
 }

--- a/packages/conversations/src/runtime-port.ts
+++ b/packages/conversations/src/runtime-port.ts
@@ -5,6 +5,7 @@ import type {
 } from "@voyant-travel/conversations-contracts"
 import { definePort } from "@voyant-travel/core/project"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
+import type { ConversationsAttachmentRuntime } from "./attachment-runtime.js"
 
 export interface ConversationsDatabaseRuntime {
   resolveDb(bindings?: unknown): AnyDrizzleDb
@@ -84,6 +85,27 @@ export const conversationsPersonDirectoryPort = definePort<ConversationsPersonDi
       throw new Error(
         "conversations.person-directory provider must implement read-only resolution methods.",
       )
+    }
+  },
+})
+
+export const conversationsAttachmentRuntimePort = definePort<ConversationsAttachmentRuntime>({
+  id: "conversations.attachments",
+  test(provider) {
+    if (
+      !provider ||
+      typeof provider !== "object" ||
+      typeof provider.download !== "function" ||
+      typeof provider.delete !== "function" ||
+      typeof provider.scan !== "function" ||
+      typeof provider.resolveForSend !== "function"
+    ) {
+      throw new Error(
+        "conversations.attachments provider must implement scan(), download(), delete(), and resolveForSend().",
+      )
+    }
+    if (provider.createUploadTicket && typeof provider.finalizeUpload !== "function") {
+      throw new Error("conversations.attachments upload capability requires finalizeUpload().")
     }
   },
 })

--- a/packages/conversations/src/schema.ts
+++ b/packages/conversations/src/schema.ts
@@ -47,6 +47,28 @@ export const conversationIngressStatusEnum = pgEnum("conversation_ingress_status
   "committed",
   "drifted",
 ])
+export const conversationPartContentStatusEnum = pgEnum("conversation_part_content_status", [
+  "safe",
+  "quarantined",
+  "redacted",
+])
+export const conversationPartClassificationEnum = pgEnum("conversation_part_classification", [
+  "message",
+  "automatic_reply",
+  "delivery_status",
+  "complaint",
+  "suspicious",
+])
+export const conversationAttachmentScanStatusEnum = pgEnum("conversation_attachment_scan_status", [
+  "pending",
+  "clean",
+  "blocked",
+  "failed",
+])
+export const conversationAttachmentAvailabilityEnum = pgEnum(
+  "conversation_attachment_availability",
+  ["active", "quarantined", "redaction_pending", "redacted"],
+)
 
 export const conversationInboxes = pgTable(
   "conversation_inboxes",
@@ -153,10 +175,12 @@ export const conversationParts = pgTable(
     subject: text("subject"),
     textBody: text("text_body"),
     htmlBody: text("html_body"),
-    attachments: jsonb("attachments")
-      .$type<readonly Record<string, unknown>[]>()
+    contentStatus: conversationPartContentStatusEnum("content_status").notNull().default("safe"),
+    legacyAttachmentCount: integer("legacy_attachment_count").notNull().default(0),
+    classification: conversationPartClassificationEnum("classification")
       .notNull()
-      .default([]),
+      .default("message"),
+    replyable: boolean("replyable").notNull().default(true),
     externalSourceId: text("external_source_id"),
     externalMessageId: text("external_message_id"),
     messageId: text("message_id"),
@@ -214,6 +238,47 @@ export const conversationNotes = pgTable(
   ],
 )
 
+/**
+ * Closed attachment metadata. Object bytes and provider credentials remain behind
+ * the runtime-only private handle; signed URLs are deliberately never persisted.
+ */
+export const conversationAttachments = pgTable(
+  "conversation_attachments",
+  {
+    id: typeId("conversation_attachments"),
+    conversationId: typeIdRef("conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    partId: typeIdRef("part_id").references(() => conversationParts.id, {
+      onDelete: "cascade",
+    }),
+    sourceId: text("source_id"),
+    externalId: text("external_id"),
+    privateHandle: text("private_handle"),
+    filename: text("filename").notNull(),
+    contentType: text("content_type").notNull(),
+    sizeBytes: integer("size_bytes").notNull(),
+    disposition: text("disposition").notNull().default("attachment"),
+    inlineContentId: text("inline_content_id"),
+    scanStatus: conversationAttachmentScanStatusEnum("scan_status").notNull().default("pending"),
+    availability: conversationAttachmentAvailabilityEnum("availability")
+      .notNull()
+      .default("quarantined"),
+    retentionUntil: timestamp("retention_until", { withTimezone: true }),
+    scannedAt: timestamp("scanned_at", { withTimezone: true }),
+    redactedAt: timestamp("redacted_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uidx_conversation_attachment_handle").on(table.privateHandle),
+    uniqueIndex("uidx_conversation_attachment_external").on(table.sourceId, table.externalId),
+    index("idx_conversation_attachments_conversation").on(table.conversationId, table.createdAt),
+    index("idx_conversation_attachments_part").on(table.partId),
+    index("idx_conversation_attachments_retention").on(table.availability, table.retentionUntil),
+  ],
+)
+
 export const conversationEvents = pgTable(
   "conversation_events",
   {
@@ -260,5 +325,6 @@ export type ConversationPart = typeof conversationParts.$inferSelect
 export type ConversationInbox = typeof conversationInboxes.$inferSelect
 export type ConversationNote = typeof conversationNotes.$inferSelect
 export type ConversationEvent = typeof conversationEvents.$inferSelect
+export type ConversationAttachment = typeof conversationAttachments.$inferSelect
 
 export const conversationsModule: Module = { name: "conversations", requiresTransactionalDb: true }

--- a/packages/conversations/src/service.ts
+++ b/packages/conversations/src/service.ts
@@ -8,6 +8,18 @@ import { newId } from "@voyant-travel/db/lib/typeid"
 import { insertOutboxEvents } from "@voyant-travel/db/outbox"
 import { and, asc, desc, eq, gt, inArray, lte, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { ConversationsAttachmentRuntime } from "./attachment-runtime.js"
+import {
+  ConversationAttachmentUnavailableError,
+  linkAttachmentsToPart,
+  listPartAttachments,
+  requireSendableAttachments,
+} from "./attachment-service.js"
+import {
+  assertDetectedAttachmentMetadata,
+  normalizeAttachmentMetadata,
+  sanitizeConversationHtml,
+} from "./content-security.js"
 import type {
   ConversationRenderedServiceMessage,
   ConversationsPersonDirectory,
@@ -19,7 +31,9 @@ import {
   type ConversationEvent,
   type ConversationInbox,
   type ConversationNote,
+  type ConversationAttachment,
   type ConversationPart,
+  conversationAttachments,
   conversationEvents,
   conversationInboxes,
   conversationInboxMemberships,
@@ -49,6 +63,7 @@ export interface ConversationDetail {
   parts: ConversationPart[]
   notes: ConversationNote[]
   timeline: ConversationTimelineItem[]
+  attachments: ConversationAttachment[]
 }
 
 export type ConversationTimelineItem =
@@ -151,6 +166,10 @@ export async function getConversation(
     .from(conversationParts)
     .where(eq(conversationParts.conversationId, id))
     .orderBy(conversationParts.sequence)
+  const attachments = await listPartAttachments(
+    db,
+    parts.map(({ id }) => id),
+  )
   const notes = await db
     .select()
     .from(conversationNotes)
@@ -189,6 +208,7 @@ export async function getConversation(
     parts,
     notes,
     timeline,
+    attachments,
   }
 }
 
@@ -220,7 +240,7 @@ async function withUnreadCount(
   return { ...conversation, unreadCount: count?.value ?? 0 }
 }
 
-async function assertInboxMembership(
+export async function assertConversationInboxMembership(
   db: PostgresJsDatabase,
   conversationId: string,
   userId: string,
@@ -326,7 +346,10 @@ async function defaultInboxId(db: PostgresJsDatabase): Promise<string> {
 export async function ingestEnvelope(
   db: PostgresJsDatabase,
   envelope: InboundEmailEnvelopeV1,
-  options: { personDirectory?: ConversationsPersonDirectory } = {},
+  options: {
+    personDirectory?: ConversationsPersonDirectory
+    attachmentRuntime?: ConversationsAttachmentRuntime
+  } = {},
 ): Promise<{ conversationId: string; partId: string; duplicate: boolean }> {
   const fingerprint = canonicalEnvelopePayload(envelope)
   const result = await db.transaction(async (tx) => {
@@ -396,6 +419,7 @@ export async function ingestEnvelope(
     if (options.personDirectory)
       resolution = await options.personDirectory.resolveEmail(tx, senderAddress)
 
+    const isCustomerMessage = envelope.classification === "message"
     if (!conversationId) {
       conversationId = newId("conversations")
       const receivingAddress = envelope.to[0]?.address
@@ -411,6 +435,7 @@ export async function ingestEnvelope(
         personRef: person?.personRef ?? null,
         contactPointRef: person?.contactPointRef ?? null,
         nextPartSequence: 2,
+        status: isCustomerMessage ? "open" : "closed",
         lastPartAt: occurredAt,
       })
       await tx.insert(conversationParticipants).values({
@@ -420,7 +445,7 @@ export async function ingestEnvelope(
         personRef: person?.personRef ?? null,
         contactPointRef: person?.contactPointRef ?? null,
       })
-    } else {
+    } else if (isCustomerMessage) {
       await tx
         .update(conversations)
         .set({
@@ -434,6 +459,7 @@ export async function ingestEnvelope(
     }
 
     const partId = newId("conversation_parts")
+    const sanitizedHtml = sanitizeConversationHtml(envelope.html)
     const messageId = envelope.threading.messageId
       ? canonicalMessageId(envelope.threading.messageId)
       : null
@@ -448,8 +474,13 @@ export async function ingestEnvelope(
       ),
       subject: envelope.subject,
       textBody: envelope.text,
-      htmlBody: envelope.html,
-      attachments: envelope.attachments,
+      htmlBody: sanitizedHtml,
+      contentStatus:
+        envelope.classification === "message" && envelope.attachments.length === 0
+          ? "safe"
+          : "quarantined",
+      classification: envelope.classification,
+      replyable: isCustomerMessage,
       externalSourceId: envelope.sourceId,
       externalMessageId: envelope.externalMessageId,
       messageId,
@@ -461,6 +492,83 @@ export async function ingestEnvelope(
       deliveryStatus: "received",
       occurredAt,
     })
+    let attachmentsSafe = true
+    for (const attachment of envelope.attachments) {
+      if (!options.attachmentRuntime?.importInbound) {
+        throw new ConversationAttachmentUnavailableError(
+          "Inbound attachment import is not configured",
+        )
+      }
+      const declared = normalizeAttachmentMetadata({
+        filename: attachment.filename,
+        contentType: attachment.contentType,
+        sizeBytes: attachment.size,
+      })
+      const imported = await options.attachmentRuntime.importInbound({
+        sourceId: envelope.sourceId,
+        externalId: attachment.externalId,
+        privateHandle: attachment.privateHandle,
+        ...declared,
+      })
+      if (!imported.privateHandle.trim()) {
+        throw new ConversationAttachmentUnavailableError("Inbound attachment import failed")
+      }
+      const scan = await options.attachmentRuntime.scan({
+        privateHandle: imported.privateHandle,
+        filename: imported.filename,
+        declaredContentType: imported.contentType,
+        declaredSizeBytes: imported.sizeBytes,
+      })
+      let verified = declared
+      let scanStatus: "clean" | "blocked" | "failed" = scan.status
+      try {
+        verified = assertDetectedAttachmentMetadata({
+          filename: imported.filename,
+          declaredContentType: imported.contentType,
+          declaredSizeBytes: imported.sizeBytes,
+          detectedContentType: scan.detectedContentType,
+          detectedSizeBytes: scan.detectedSizeBytes,
+        })
+        if (
+          verified.filename !== declared.filename ||
+          verified.contentType !== declared.contentType ||
+          verified.sizeBytes !== declared.sizeBytes
+        ) {
+          scanStatus = "blocked"
+        }
+      } catch {
+        scanStatus = "blocked"
+      }
+      if (scanStatus !== "clean") attachmentsSafe = false
+      await tx
+        .insert(conversationAttachments)
+        .values({
+          id: newId("conversation_attachments"),
+          conversationId,
+          partId,
+          sourceId: envelope.sourceId,
+          externalId: attachment.externalId,
+          privateHandle: imported.privateHandle,
+          ...verified,
+          inlineContentId: attachment.inlineContentId ?? null,
+          disposition: attachment.inlineContentId ? "inline" : "attachment",
+          scanStatus,
+          availability: scanStatus === "clean" ? "active" : "quarantined",
+        })
+        .onConflictDoNothing({
+          target: [conversationAttachments.sourceId, conversationAttachments.externalId],
+        })
+    }
+    if (
+      envelope.classification === "message" &&
+      envelope.attachments.length > 0 &&
+      attachmentsSafe
+    ) {
+      await tx
+        .update(conversationParts)
+        .set({ contentStatus: "safe" })
+        .where(eq(conversationParts.id, partId))
+    }
     await tx
       .update(conversationIngressOperations)
       .set({
@@ -478,8 +586,12 @@ export async function ingestEnvelope(
       conversationId,
       inboxId: current?.inboxId ?? (await defaultInboxId(tx as PostgresJsDatabase)),
       revision: current?.revision ?? 1,
-      type: "part.received",
-      payload: { partId, sourceId: envelope.sourceId },
+      type: isCustomerMessage ? "part.received" : "part.quarantined",
+      payload: {
+        partId,
+        sourceId: envelope.sourceId,
+        ...(isCustomerMessage ? {} : { classification: envelope.classification }),
+      },
       occurredAt,
     })
     return { kind: "result" as const, value: { conversationId, partId, duplicate: false } }
@@ -566,13 +678,18 @@ export async function replyToConversation(
     channelAccountId: string
     text: string | null
     html?: string | null
+    attachmentIds?: readonly string[]
     idempotencyKey: string
     runtimeBindings?: unknown
   },
 ): Promise<ConversationPart> {
   return db.transaction(async (transaction) => {
     const tx = transaction as PostgresJsDatabase
-    const conversation = await assertInboxMembership(tx, input.conversationId, input.actor.userId)
+    const conversation = await assertConversationInboxMembership(
+      tx,
+      input.conversationId,
+      input.actor.userId,
+    )
     return admitReplyWithinTransaction(tx, admission, conversation, input)
   })
 }
@@ -588,6 +705,8 @@ export async function startConversation(
     fromAddress: string
     subject: string | null
     text: string
+    html?: string | null
+    attachmentIds?: readonly string[]
     idempotencyKey: string
     inboxId: string
     actor: ConversationActor
@@ -617,6 +736,8 @@ export async function startConversation(
     customerAddress,
     subject: input.subject,
     text: input.text,
+    html: sanitizeConversationHtml(input.html),
+    attachmentIds: input.attachmentIds ?? [],
   })
   const conversationId = await db.transaction(async (transaction) => {
     const tx = transaction as PostgresJsDatabase
@@ -664,6 +785,8 @@ export async function startConversation(
       conversationId: id,
       channelAccountId: input.channelAccountId,
       text: input.text,
+      html: input.html,
+      attachmentIds: input.attachmentIds,
       idempotencyKey: input.idempotencyKey,
       runtimeBindings: input.runtimeBindings,
       actor: input.actor,
@@ -684,6 +807,7 @@ async function admitReplyWithinTransaction(
     channelAccountId: string
     text: string | null
     html?: string | null
+    attachmentIds?: readonly string[]
     idempotencyKey: string
     runtimeBindings?: unknown
     actor: ConversationActor
@@ -695,6 +819,9 @@ async function admitReplyWithinTransaction(
     .where(eq(conversationParts.conversationId, conversation.id))
     .orderBy(desc(conversationParts.occurredAt))
     .limit(1)
+  if (lastPart && !lastPart.replyable) {
+    throw new ConversationConflictError("The latest inbound item is not replyable")
+  }
   const [lastOutbound] = await tx
     .select()
     .from(conversationParts)
@@ -707,6 +834,12 @@ async function admitReplyWithinTransaction(
     .orderBy(desc(conversationParts.occurredAt))
     .limit(1)
   const references = lastPart?.messageId ? [...lastPart.references, lastPart.messageId] : []
+  const sanitizedHtml = sanitizeConversationHtml(input.html)
+  const attachments = await requireSendableAttachments(
+    tx,
+    conversation.id,
+    input.attachmentIds ?? [],
+  )
   const message = {
     channelAccountId: input.channelAccountId,
     target: { type: "@voyant-travel/conversations#part" as const, id: "" },
@@ -715,7 +848,19 @@ async function admitReplyWithinTransaction(
     to: conversation.customerAddress,
     ...(conversation.subject ? { subject: conversation.subject } : {}),
     ...(input.text ? { text: input.text } : {}),
-    ...(input.html ? { sanitizedHtml: input.html } : {}),
+    ...(sanitizedHtml ? { sanitizedHtml } : {}),
+    ...(attachments.length > 0
+      ? {
+          attachments: attachments.map((attachment) => ({
+            privateHandle: attachment.privateHandle,
+            filename: attachment.filename,
+            contentType: attachment.contentType,
+            disposition:
+              attachment.disposition === "inline" ? ("inline" as const) : ("attachment" as const),
+            ...(attachment.inlineContentId ? { contentId: attachment.inlineContentId } : {}),
+          })),
+        }
+      : {}),
     thread: {
       threadId: conversation.id,
       ...(lastOutbound?.notificationDeliveryId
@@ -743,7 +888,7 @@ async function admitReplyWithinTransaction(
       recipientAddresses: [conversation.customerAddress],
       subject: conversation.subject,
       textBody: input.text,
-      htmlBody: input.html ?? null,
+      htmlBody: sanitizedHtml,
       payloadFingerprint: fingerprint,
       idempotencyKey: input.idempotencyKey,
       deliveryStatus: "pending",
@@ -765,6 +910,11 @@ async function admitReplyWithinTransaction(
     }
     return existing
   }
+  await linkAttachmentsToPart(
+    tx,
+    attachments.map(({ id }) => id),
+    partId,
+  )
   let admitted: Awaited<
     ReturnType<ConversationsRenderedMessageAdmission["admitRenderedServiceMessage"]>
   >
@@ -822,7 +972,7 @@ export async function updateConversationState(
 ): Promise<Conversation> {
   return db.transaction(async (transaction) => {
     const tx = transaction as PostgresJsDatabase
-    const current = await assertInboxMembership(tx, id, input.actor.userId)
+    const current = await assertConversationInboxMembership(tx, id, input.actor.userId)
     const targetInboxId = input.inboxId ?? current.inboxId
     if (!targetInboxId) throw new ConversationInvalidStateError("Conversation has no Inbox")
     if (targetInboxId !== current.inboxId) {
@@ -908,7 +1058,7 @@ export async function markConversationRead(
   actor: ConversationActor,
   throughSequence?: number,
 ): Promise<ConversationView> {
-  const conversation = await assertInboxMembership(db, id, actor.userId)
+  const conversation = await assertConversationInboxMembership(db, id, actor.userId)
   const maximum = Math.max(0, conversation.nextPartSequence - 1)
   const sequence = Math.min(throughSequence ?? maximum, maximum)
   await db
@@ -930,7 +1080,11 @@ export async function addConversationNote(
 ): Promise<ConversationNote> {
   return db.transaction(async (transaction) => {
     const tx = transaction as PostgresJsDatabase
-    const conversation = await assertInboxMembership(tx, input.conversationId, input.actor.userId)
+    const conversation = await assertConversationInboxMembership(
+      tx,
+      input.conversationId,
+      input.actor.userId,
+    )
     const [updated] = await tx
       .update(conversations)
       .set({ revision: sql`${conversations.revision} + 1`, updatedAt: new Date() })

--- a/packages/conversations/src/voyant.ts
+++ b/packages/conversations/src/voyant.ts
@@ -2,6 +2,7 @@ import { staffDirectoryRuntimePort } from "@voyant-travel/auth/staff-directory-r
 import { defineModule, requirePort } from "@voyant-travel/core/project"
 import {
   conversationIngressSourcePort,
+  conversationsAttachmentRuntimePort,
   conversationsDatabaseRuntimePort,
   conversationsPersonDirectoryPort,
   conversationsRenderedMessageAdmissionPort,
@@ -38,6 +39,7 @@ export const conversationsVoyantModule = defineModule({
     requirePort(conversationsRenderedMessageAdmissionPort, { optional: true }),
     requirePort(conversationsPersonDirectoryPort, { optional: true }),
     requirePort(staffDirectoryRuntimePort),
+    requirePort(conversationsAttachmentRuntimePort, { optional: true }),
   ],
   api: [
     {
@@ -97,6 +99,23 @@ export const conversationsVoyantModule = defineModule({
       runtime: {
         entry: "@voyant-travel/conversations/snooze-expiry-job",
         export: "runConversationSnoozeExpiryJob",
+      },
+    },
+    {
+      id: "conversations.attachment-retention",
+      schedule: { cron: "17 * * * *", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          eager: { cron: "17 * * * *", overlap: "skip" },
+          economical: { cron: "17 */6 * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "17 3 * * *", overlap: "skip" },
+        },
+      },
+      wakeup: true,
+      runtime: {
+        entry: "@voyant-travel/conversations/attachment-retention-job",
+        export: "runConversationAttachmentRetentionJob",
       },
     },
   ],

--- a/packages/conversations/tests/integration/attachment-security.test.ts
+++ b/packages/conversations/tests/integration/attachment-security.test.ts
@@ -1,0 +1,414 @@
+import { readFileSync } from "node:fs"
+import { PGlite } from "@electric-sql/pglite"
+import type { InboundEmailEnvelopeV1 } from "@voyant-travel/conversations-contracts"
+import { and, eq } from "drizzle-orm"
+import { drizzle } from "drizzle-orm/pglite"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import type { ConversationsAttachmentRuntime } from "../../src/attachment-runtime.js"
+import {
+  ConversationAttachmentConflictError,
+  ConversationAttachmentNotFoundError,
+  cleanupConversationAttachments,
+  createConversationPrivateAttachmentDeliveryResolver,
+  downloadConversationAttachment,
+  linkAttachmentsToPart,
+  requireSendableAttachments,
+} from "../../src/attachment-service.js"
+import {
+  conversationAttachments,
+  conversationEvents,
+  conversationParts,
+  conversations,
+} from "../../src/schema.js"
+import {
+  ConversationConflictError,
+  ingestEnvelope,
+  replyToConversation,
+} from "../../src/service.js"
+
+const defaultInboxId = "cvin_01k2p3q4r5s6t7v8w9x0y1z2a3"
+const actorUserId = "user_attachment_agent"
+
+describe("attachment security state transitions", () => {
+  let client: PGlite
+  let db: ReturnType<typeof drizzle>
+
+  beforeAll(async () => {
+    client = new PGlite()
+    db = drizzle(client)
+    await client.exec(readMigration("0000_conversations_baseline.sql"))
+    await client.exec(`
+      INSERT INTO conversations
+        (id, reply_alias, customer_address, last_part_at)
+      VALUES
+        ('legacy_conversation', 'legacy@example.test', 'customer@example.test', now());
+      INSERT INTO conversation_parts
+        (id, conversation_id, direction, sender_address, recipient_addresses,
+         attachments, payload_fingerprint, delivery_status, occurred_at)
+      VALUES
+        ('legacy_part', 'legacy_conversation', 'inbound', 'customer@example.test', '[]',
+         '[{"filename":"secret.txt","path":"https://secret.invalid/token","contentBase64":"c2VjcmV0"}]',
+         'legacy', 'received', now());
+    `)
+    await client.exec(readMigration("0001_collaboration.sql"))
+    await client.exec(readMigration("0002_secure_content.sql"))
+    await client.exec(`
+      CREATE TABLE "event_outbox" (
+        "id" text PRIMARY KEY,
+        "event_id" text NOT NULL UNIQUE,
+        "name" text NOT NULL,
+        "payload" jsonb,
+        "metadata" jsonb,
+        "status" text NOT NULL DEFAULT 'pending',
+        "attempts" integer NOT NULL DEFAULT 0,
+        "max_attempts" integer NOT NULL DEFAULT 8,
+        "next_attempt_at" timestamptz NOT NULL DEFAULT now(),
+        "last_error" text,
+        "attempt_errors" jsonb,
+        "created_at" timestamptz NOT NULL DEFAULT now(),
+        "delivered_at" timestamptz
+      );
+      INSERT INTO conversation_inbox_memberships (id, inbox_id, user_id, role, active)
+      VALUES ('cvim_attachment_agent', '${defaultInboxId}', '${actorUserId}', 'member', true);
+    `)
+    const migrated = await client.query<{ row: string }>(`
+      SELECT row_to_json(part)::text AS row
+      FROM conversation_parts part
+      WHERE id = 'legacy_part'
+    `)
+    expect(migrated.rows[0]?.row).not.toMatch(/secret\.invalid|c2VjcmV0|contentBase64|attachments/)
+    expect(migrated.rows[0]?.row).toContain('"legacy_attachment_count":1')
+    expect(migrated.rows[0]?.row).toContain('"content_status":"quarantined"')
+  })
+
+  beforeEach(async () => {
+    await client.exec(`
+      TRUNCATE conversation_events, conversation_ingress_operations,
+        conversation_attachments, conversation_participants, conversation_parts,
+        conversations CASCADE
+    `)
+  })
+
+  afterAll(async () => client.close())
+
+  it("links only clean active attachments and rejects concurrent link drift", async () => {
+    await seedConversation(db)
+    await seedAttachment(db, {
+      id: "attachment_clean",
+      scanStatus: "clean",
+      availability: "active",
+    })
+    const sendable = await requireSendableAttachments(db as never, "conversation_one", [
+      "attachment_clean",
+    ])
+    expect(sendable).toHaveLength(1)
+    await linkAttachmentsToPart(db as never, ["attachment_clean"], "part_one")
+    await expect(
+      linkAttachmentsToPart(db as never, ["attachment_clean"], "part_one"),
+    ).rejects.toBeInstanceOf(ConversationAttachmentConflictError)
+  })
+
+  it.each([
+    ["pending", "quarantined"],
+    ["blocked", "quarantined"],
+    ["failed", "quarantined"],
+    ["clean", "redacted"],
+  ] as const)("rejects %s/%s attachment state", async (scanStatus, availability) => {
+    await seedConversation(db)
+    await seedAttachment(db, { id: "attachment_rejected", scanStatus, availability })
+    await expect(
+      requireSendableAttachments(db as never, "conversation_one", ["attachment_rejected"]),
+    ).rejects.toBeInstanceOf(ConversationAttachmentConflictError)
+  })
+
+  it("scopes download to the requested conversation and returns only a private redirect", async () => {
+    await seedConversation(db)
+    await db.insert(conversations).values(conversationRow("conversation_other"))
+    await seedAttachment(db, {
+      id: "attachment_clean",
+      scanStatus: "clean",
+      availability: "active",
+    })
+    const runtime = attachmentRuntime()
+    await expect(
+      downloadConversationAttachment(db as never, runtime, {
+        conversationId: "conversation_other",
+        attachmentId: "attachment_clean",
+      }),
+    ).rejects.toBeInstanceOf(ConversationAttachmentNotFoundError)
+    await expect(
+      downloadConversationAttachment(db as never, runtime, {
+        conversationId: "conversation_one",
+        attachmentId: "attachment_clean",
+      }),
+    ).resolves.toMatchObject({ download: { kind: "redirect" } })
+  })
+
+  it("keeps the handle pending after deletion failure, then nulls it and preserves redaction facts", async () => {
+    await seedConversation(db)
+    await seedAttachment(db, {
+      id: "attachment_redact",
+      scanStatus: "clean",
+      availability: "redaction_pending",
+      partId: "part_one",
+    })
+    const runtime = attachmentRuntime()
+    vi.mocked(runtime.delete).mockRejectedValueOnce(new Error("temporary deletion failure"))
+    await expect(cleanupConversationAttachments(db as never, runtime)).rejects.toThrow(
+      "temporary deletion failure",
+    )
+    let [attachment] = await db
+      .select()
+      .from(conversationAttachments)
+      .where(eq(conversationAttachments.id, "attachment_redact"))
+    expect(attachment).toMatchObject({
+      privateHandle: "private-attachment_redact",
+      availability: "redaction_pending",
+    })
+
+    await expect(cleanupConversationAttachments(db as never, runtime)).resolves.toEqual({
+      inspected: 1,
+      redacted: 1,
+    })
+    ;[attachment] = await db
+      .select()
+      .from(conversationAttachments)
+      .where(eq(conversationAttachments.id, "attachment_redact"))
+    expect(attachment).toMatchObject({ privateHandle: null, availability: "redacted" })
+    const [part] = await db
+      .select()
+      .from(conversationParts)
+      .where(eq(conversationParts.id, "part_one"))
+    expect(part).toMatchObject({ textBody: null, htmlBody: null, contentStatus: "redacted" })
+    expect(
+      await db
+        .select()
+        .from(conversationEvents)
+        .where(
+          and(
+            eq(conversationEvents.conversationId, "conversation_one"),
+            eq(conversationEvents.type, "attachment.redacted"),
+          ),
+        ),
+    ).toHaveLength(1)
+  })
+
+  it("revalidates every worker attempt and quarantines changed content", async () => {
+    await seedConversation(db)
+    await seedAttachment(db, {
+      id: "attachment_changed",
+      scanStatus: "clean",
+      availability: "active",
+      partId: "part_one",
+    })
+    const runtime = attachmentRuntime()
+    vi.mocked(runtime.scan).mockResolvedValue({
+      status: "clean",
+      detectedContentType: "application/pdf",
+      detectedSizeBytes: 11,
+    })
+    const resolver = createConversationPrivateAttachmentDeliveryResolver(db as never, runtime)
+    await expect(
+      resolver.resolveForDelivery({
+        targetId: "part_one",
+        privateHandle: "private-attachment_changed",
+        filename: "invoice.pdf",
+      }),
+    ).rejects.toBeInstanceOf(ConversationAttachmentConflictError)
+    const [attachment] = await db
+      .select()
+      .from(conversationAttachments)
+      .where(eq(conversationAttachments.id, "attachment_changed"))
+    expect(attachment).toMatchObject({ scanStatus: "blocked", availability: "quarantined" })
+  })
+
+  it("quarantines classified inbound audit facts without reopening or permitting reply", async () => {
+    await seedConversation(db, { status: "closed" })
+    const envelope: InboundEmailEnvelopeV1 = {
+      version: "1",
+      sourceId: "source",
+      externalEnvelopeId: "auto-envelope",
+      externalMessageId: "auto-message",
+      sender: { address: "customer@example.test" },
+      to: [{ address: "inbox@example.test" }],
+      cc: [],
+      replyTo: [],
+      subject: "Automatic response",
+      text: "This mailbox is unattended",
+      html: "<p>This mailbox is unattended</p>",
+      attachments: [],
+      classification: "automatic_reply",
+      threading: { messageId: "auto-message", inReplyTo: "root-message", references: [] },
+      occurredAt: "2026-08-18T00:00:00.000Z",
+    }
+    const result = await ingestEnvelope(db as never, envelope)
+    const [conversation] = await db
+      .select()
+      .from(conversations)
+      .where(eq(conversations.id, "conversation_one"))
+    expect(conversation).toMatchObject({ status: "closed" })
+    const [part] = await db
+      .select()
+      .from(conversationParts)
+      .where(eq(conversationParts.id, result.partId))
+    expect(part).toMatchObject({
+      classification: "automatic_reply",
+      replyable: false,
+      contentStatus: "quarantined",
+    })
+    const admission = { admitRenderedServiceMessage: vi.fn() }
+    await expect(
+      replyToConversation(db as never, admission, {
+        conversationId: "conversation_one",
+        actor: { userId: actorUserId },
+        channelAccountId: "account",
+        text: "loop",
+        idempotencyKey: "loop-key",
+      }),
+    ).rejects.toBeInstanceOf(ConversationConflictError)
+    expect(admission.admitRenderedServiceMessage).not.toHaveBeenCalled()
+  })
+
+  it("imports and scans inbound attachments before making them active", async () => {
+    const runtime = attachmentRuntime()
+    runtime.importInbound = vi.fn(async (input) => ({
+      privateHandle: "imported-private-handle",
+      filename: input.filename,
+      contentType: input.contentType,
+      sizeBytes: input.sizeBytes,
+    }))
+    const envelope: InboundEmailEnvelopeV1 = {
+      version: "1",
+      sourceId: "source",
+      externalEnvelopeId: "attachment-envelope",
+      externalMessageId: "attachment-message",
+      sender: { address: "customer@example.test" },
+      to: [{ address: "inbox@example.test" }],
+      cc: [],
+      replyTo: [],
+      subject: "Invoice",
+      text: "Attached",
+      html: null,
+      attachments: [
+        {
+          externalId: "external-attachment",
+          filename: "invoice.pdf",
+          contentType: "application/pdf",
+          size: 10,
+          privateHandle: "source-private-handle",
+        },
+      ],
+      classification: "message",
+      threading: { messageId: "attachment-message", inReplyTo: null, references: [] },
+      occurredAt: "2026-08-18T00:00:00.000Z",
+    }
+    const result = await ingestEnvelope(db as never, envelope, { attachmentRuntime: runtime })
+    const [attachment] = await db
+      .select()
+      .from(conversationAttachments)
+      .where(eq(conversationAttachments.partId, result.partId))
+    expect(runtime.importInbound).toHaveBeenCalledOnce()
+    expect(runtime.scan).toHaveBeenCalledOnce()
+    expect(attachment).toMatchObject({
+      privateHandle: "imported-private-handle",
+      scanStatus: "clean",
+      availability: "active",
+    })
+    const [part] = await db
+      .select()
+      .from(conversationParts)
+      .where(eq(conversationParts.id, result.partId))
+    expect(part?.contentStatus).toBe("safe")
+  })
+})
+
+function readMigration(name: string) {
+  return readFileSync(new URL(`../../migrations/${name}`, import.meta.url), "utf8").replaceAll(
+    "--> statement-breakpoint",
+    "",
+  )
+}
+
+function conversationRow(id: string) {
+  const now = new Date("2026-08-17T00:00:00.000Z")
+  return {
+    id,
+    inboxId: defaultInboxId,
+    replyAlias: `${id}@inbox.example.test`,
+    customerAddress: "customer@example.test",
+    nextPartSequence: 2,
+    lastPartAt: now,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+async function seedConversation(
+  db: ReturnType<typeof drizzle>,
+  options: { status?: "open" | "closed" } = {},
+) {
+  const now = new Date("2026-08-17T00:00:00.000Z")
+  await db.insert(conversations).values({
+    ...conversationRow("conversation_one"),
+    status: options.status ?? "open",
+  })
+  await db.insert(conversationParts).values({
+    id: "part_one",
+    conversationId: "conversation_one",
+    sequence: 1,
+    direction: "inbound",
+    senderAddress: "customer@example.test",
+    recipientAddresses: ["inbox@example.test"],
+    textBody: "Original body",
+    htmlBody: "<p>Original body</p>",
+    messageId: "root-message",
+    payloadFingerprint: "fingerprint",
+    deliveryStatus: "received",
+    occurredAt: now,
+    createdAt: now,
+  })
+}
+
+async function seedAttachment(
+  db: ReturnType<typeof drizzle>,
+  input: {
+    id: string
+    scanStatus: "pending" | "clean" | "blocked" | "failed"
+    availability: "active" | "quarantined" | "redaction_pending" | "redacted"
+    partId?: string
+  },
+) {
+  await db.insert(conversationAttachments).values({
+    id: input.id,
+    conversationId: "conversation_one",
+    partId: input.partId ?? null,
+    privateHandle: `private-${input.id}`,
+    filename: "invoice.pdf",
+    contentType: "application/pdf",
+    sizeBytes: 10,
+    scanStatus: input.scanStatus,
+    availability: input.availability,
+  })
+}
+
+function attachmentRuntime(): ConversationsAttachmentRuntime {
+  return {
+    scan: vi.fn(async () => ({
+      status: "clean" as const,
+      detectedContentType: "application/pdf",
+      detectedSizeBytes: 10,
+    })),
+    download: vi.fn(async () => ({
+      kind: "redirect" as const,
+      url: "https://private.invalid/short-lived",
+      expiresAt: "2026-08-18T00:01:00.000Z",
+    })),
+    delete: vi.fn(async () => undefined),
+    resolveForSend: vi.fn(async () => ({
+      kind: "private-url" as const,
+      url: "https://private.invalid/attempt",
+      expiresAt: "2026-08-18T00:01:00.000Z",
+      contentType: "application/pdf",
+    })),
+  }
+}

--- a/packages/conversations/tests/integration/collaboration.test.ts
+++ b/packages/conversations/tests/integration/collaboration.test.ts
@@ -227,6 +227,7 @@ describe.skipIf(!DB_AVAILABLE)("Inbox collaboration persistence", () => {
       subject: "Re: Help",
       text: "Following up",
       html: null,
+      classification: "message",
       attachments: [],
       threading: { messageId: "message-3", inReplyTo: null, references: [] },
       occurredAt: "2026-08-18T10:05:00.000Z",

--- a/packages/conversations/tests/integration/ingress-job.test.ts
+++ b/packages/conversations/tests/integration/ingress-job.test.ts
@@ -15,6 +15,7 @@ const envelope: InboundEmailEnvelopeV1 = {
   text: "Question",
   html: null,
   attachments: [],
+  classification: "message",
   threading: { messageId: "<message-1@example.test>", inReplyTo: null, references: [] },
   occurredAt: "2026-08-17T10:00:00.000Z",
 }

--- a/packages/conversations/tests/unit/attachment-runtime.test.ts
+++ b/packages/conversations/tests/unit/attachment-runtime.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest"
+import { createDocumentsConversationAttachmentRuntime } from "../../src/attachment-runtime.js"
+
+describe("documents attachment runtime", () => {
+  it("fails closed when the private store cannot issue short-lived URLs", () => {
+    expect(
+      createDocumentsConversationAttachmentRuntime({
+        resolve: () => ({
+          name: "private",
+          upload: vi.fn(),
+          delete: vi.fn(),
+          get: vi.fn(),
+        }),
+      }),
+    ).toBeNull()
+  })
+
+  it("uses expiring private URLs without calling buffered get", async () => {
+    const get = vi.fn()
+    const signedUrl = vi.fn(async () => "https://private.invalid/short-lived")
+    const runtime = createDocumentsConversationAttachmentRuntime({
+      resolve: () => ({
+        name: "private",
+        upload: vi.fn(),
+        delete: vi.fn(),
+        get,
+        signedUrl,
+      }),
+    })
+    await expect(runtime?.download("stable-handle")).resolves.toMatchObject({
+      kind: "redirect",
+      url: "https://private.invalid/short-lived",
+    })
+    await expect(runtime?.resolveForSend("stable-handle")).resolves.toMatchObject({
+      kind: "private-url",
+      url: "https://private.invalid/short-lived",
+    })
+    expect(signedUrl).toHaveBeenNthCalledWith(1, "stable-handle", 60)
+    expect(signedUrl).toHaveBeenNthCalledWith(2, "stable-handle", 60)
+    expect(get).not.toHaveBeenCalled()
+  })
+})

--- a/packages/conversations/tests/unit/content-security.test.ts
+++ b/packages/conversations/tests/unit/content-security.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest"
+import {
+  assertAttachmentSetPolicy,
+  assertDetectedAttachmentMetadata,
+  CONVERSATION_ATTACHMENT_LIMITS,
+  ConversationAttachmentPolicyError,
+  normalizeAttachmentMetadata,
+  sanitizeConversationHtml,
+} from "../../src/content-security.js"
+
+describe("conversation content security", () => {
+  it("removes executable, tracking, style, form, and remote image markup", () => {
+    const html = sanitizeConversationHtml(`
+      <style>body { display: none }</style>
+      <script>alert(1)</script>
+      <img src="https://tracker.invalid/pixel" onerror="alert(2)">
+      <form action="https://invalid"><input name="secret"></form>
+      <p style="background:url(https://tracker.invalid)">Hello</p>
+      <a href="javascript:alert(3)" onclick="alert(4)">bad</a>
+      <a href="https://example.test/path">safe</a>
+      <a href="tel:+40123456789">call</a>
+    `)
+    expect(html).not.toMatch(/script|style=|<style|<img|<form|<input|javascript:|onclick/i)
+    expect(html).toContain('href="https://example.test/path"')
+    expect(html).toContain('href="tel:+40123456789"')
+    expect(html).toContain('rel="noopener noreferrer"')
+  })
+
+  it("normalizes filenames and rejects active types and extension/type mismatches", () => {
+    expect(
+      normalizeAttachmentMetadata({
+        filename: "../invoice.pdf",
+        contentType: "application/pdf; charset=binary",
+        sizeBytes: 50,
+      }),
+    ).toEqual({ filename: ".._invoice.pdf", contentType: "application/pdf", sizeBytes: 50 })
+    expect(() =>
+      normalizeAttachmentMetadata({
+        filename: "invoice.pdf",
+        contentType: "text/html",
+        sizeBytes: 50,
+      }),
+    ).toThrow(ConversationAttachmentPolicyError)
+    expect(() =>
+      normalizeAttachmentMetadata({
+        filename: "invoice.pdf",
+        contentType: "image/png",
+        sizeBytes: 50,
+      }),
+    ).toThrow("extension and content type disagree")
+  })
+
+  it("rejects scanner drift and aggregate limit overflow", () => {
+    expect(() =>
+      assertDetectedAttachmentMetadata({
+        filename: "invoice.pdf",
+        declaredContentType: "application/pdf",
+        declaredSizeBytes: 10,
+        detectedContentType: "application/pdf",
+        detectedSizeBytes: 11,
+      }),
+    ).toThrow("size does not match")
+    expect(() =>
+      assertAttachmentSetPolicy(
+        Array.from({ length: CONVERSATION_ATTACHMENT_LIMITS.maxCount + 1 }, () => ({
+          filename: "invoice.pdf",
+          contentType: "application/pdf",
+          sizeBytes: 1,
+        })),
+      ),
+    ).toThrow("Too many attachments")
+  })
+})

--- a/packages/conversations/tsconfig.json
+++ b/packages/conversations/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@voyant-travel/voyant-typescript-config/base.json",
-  "compilerOptions": { "composite": false, "module": "ESNext", "moduleResolution": "Bundler" },
+  "compilerOptions": { "composite": false, "module": "ESNext", "moduleResolution": "Bundler", "types": ["node"] },
   "include": ["src/**/*", "tests/**/*"]
 }

--- a/packages/notifications/src/durable-provider-port.ts
+++ b/packages/notifications/src/durable-provider-port.ts
@@ -1,6 +1,11 @@
 import { definePort } from "@voyant-travel/core/project"
 
-import type { NotificationPayload, NotificationProvider, NotificationResult } from "./types.js"
+import type {
+  NotificationPayload,
+  NotificationPrivateAttachmentResolver,
+  NotificationProvider,
+  NotificationResult,
+} from "./types.js"
 
 export interface DurableNotificationProviderProbe {
   /** Isolated, non-delivering instances of the exact selected implementations. */
@@ -13,6 +18,8 @@ export interface DurableNotificationProviderProbe {
 /** Exact selected provider set plus an isolated, non-delivering behavioral probe. */
 export interface DurableNotificationProviderRuntime {
   readonly providers: ReadonlyArray<NotificationProvider>
+  /** Deployment-wired resolver; required only while private-handle sends exist. */
+  readonly privateAttachmentResolver?: NotificationPrivateAttachmentResolver
   createIsolatedProbe(): Promise<DurableNotificationProviderProbe>
 }
 
@@ -100,6 +107,14 @@ function assertRuntimeShape(runtime: DurableNotificationProviderRuntime): void {
     throw new Error("notifications.durable-provider must expose providers and an isolated probe")
   }
   for (const provider of runtime.providers) assertDurableProvider(provider)
+  if (
+    runtime.privateAttachmentResolver &&
+    typeof runtime.privateAttachmentResolver.resolveForDelivery !== "function"
+  ) {
+    throw new Error(
+      "notifications.durable-provider privateAttachmentResolver must implement resolveForDelivery()",
+    )
+  }
   assertUniqueProviderNames(runtime.providers, "selected runtime")
 }
 

--- a/packages/notifications/src/reminder-job.ts
+++ b/packages/notifications/src/reminder-job.ts
@@ -52,5 +52,11 @@ export async function runDueNotificationSendsJob(
     return
   }
   const selectedRuntime = await context.getPort(durableNotificationProviderPort)
+  if (selectedRuntime.privateAttachmentResolver) {
+    await drainDurableNotificationSends(db, selectedRuntime.providers, {
+      privateAttachmentResolver: selectedRuntime.privateAttachmentResolver,
+    })
+    return
+  }
   await drainDurableNotificationSends(db, selectedRuntime.providers)
 }

--- a/packages/notifications/src/service-durable-send.ts
+++ b/packages/notifications/src/service-durable-send.ts
@@ -36,6 +36,7 @@ import type {
   NotificationAttachment,
   NotificationChannel,
   NotificationPayload,
+  NotificationPrivateAttachmentResolver,
   NotificationProvider,
   NotificationResult,
 } from "./types.js"
@@ -548,6 +549,8 @@ export interface DrainDurableNotificationSendsOptions {
   now?: Date
   visibilityTimeoutMs?: number
   retryBaseMs?: number
+  /** Revalidates and materializes private handles immediately before every attempt. */
+  privateAttachmentResolver?: NotificationPrivateAttachmentResolver
   testHooks?: {
     afterProviderAccepted?: (
       operation: NotificationSendOperation,
@@ -626,7 +629,11 @@ export async function drainDurableNotificationSends(
 
     try {
       const context = { idempotencyKey: operation.providerIdempotencyKey }
-      const payload = notificationPayload(operation.requestPayload)
+      const payload = await materializeNotificationPrivateAttachments(
+        notificationPayload(operation.requestPayload),
+        options.privateAttachmentResolver,
+        { targetId: operation.targetId },
+      )
       const providerResult = await capability.send(payload, context)
       if (providerResult.provider !== operation.provider) {
         throw new NotificationError(
@@ -660,6 +667,40 @@ export async function drainDurableNotificationSends(
   }
 
   return result
+}
+
+export async function materializeNotificationPrivateAttachments(
+  payload: NotificationPayload,
+  resolver: NotificationPrivateAttachmentResolver | undefined,
+  target: { targetId: string },
+): Promise<NotificationPayload> {
+  const attachments = payload.attachments
+  if (!attachments?.some(({ privateHandle }) => privateHandle)) return payload
+  if (!resolver) {
+    throw new NotificationError("Private attachment resolver is not configured")
+  }
+  const materialized = await Promise.all(
+    attachments.map(async (attachment) => {
+      if (!attachment.privateHandle) return attachment
+      const resolved = await resolver.resolveForDelivery({
+        targetId: target.targetId,
+        privateHandle: attachment.privateHandle,
+        filename: attachment.filename,
+        contentType: attachment.contentType,
+        disposition: attachment.disposition,
+        contentId: attachment.contentId,
+      })
+      return {
+        filename: resolved.filename,
+        contentType: resolved.contentType,
+        disposition: resolved.disposition,
+        contentId: resolved.contentId,
+        contentBase64: resolved.contentBase64,
+        path: resolved.path,
+      }
+    }),
+  )
+  return { ...payload, attachments: materialized }
 }
 
 /** Whether queued or leased sends require the exact selected provider runtime. */

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -190,3 +190,7 @@ export interface NotificationProvider {
   /** Optional runtime-only Channel Account provisioning/validation capability. */
   readonly channelAccounts?: ChannelAccountAdapterCapability
 }
+
+export type NotificationPrivateAttachmentResolver = ConversationPrivateAttachmentDeliveryResolver
+
+import type { ConversationPrivateAttachmentDeliveryResolver } from "@voyant-travel/conversations-contracts"

--- a/packages/notifications/tests/unit/private-attachments.test.ts
+++ b/packages/notifications/tests/unit/private-attachments.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest"
+import { materializeNotificationPrivateAttachments } from "../../src/service-durable-send.js"
+
+describe("durable private attachment materialization", () => {
+  it("fails closed without a resolver and never forwards a stable handle", async () => {
+    const payload = {
+      to: "customer@example.test",
+      channel: "email",
+      template: "direct",
+      attachments: [{ filename: "invoice.pdf", privateHandle: "stable-handle" }],
+    }
+    await expect(
+      materializeNotificationPrivateAttachments(payload, undefined, { targetId: "part-one" }),
+    ).rejects.toThrow("resolver is not configured")
+    const resolveForDelivery = vi.fn(async () => ({
+      filename: "invoice.pdf",
+      contentType: "application/pdf",
+      disposition: "attachment" as const,
+      path: "https://private.invalid/attempt",
+    }))
+    const first = await materializeNotificationPrivateAttachments(
+      payload,
+      { resolveForDelivery },
+      { targetId: "part-one" },
+    )
+    const second = await materializeNotificationPrivateAttachments(
+      payload,
+      { resolveForDelivery },
+      { targetId: "part-one" },
+    )
+    expect(resolveForDelivery).toHaveBeenCalledTimes(2)
+    expect(resolveForDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({ targetId: "part-one", privateHandle: "stable-handle" }),
+    )
+    expect(first.attachments?.[0]).not.toHaveProperty("privateHandle")
+    expect(second.attachments?.[0]).not.toHaveProperty("privateHandle")
+  })
+})

--- a/packages/schema-kit/src/typeid/typeid-prefixes.ts
+++ b/packages/schema-kit/src/typeid/typeid-prefixes.ts
@@ -48,6 +48,7 @@ export const PREFIXES = {
   conversation_parts: "cvpa",
   conversation_read_cursors: "cvrc",
   conversation_notes: "cvnt",
+  conversation_attachments: "cvat",
   conversation_events: "cvev",
   conversation_ingress_operations: "cvio",
   notification_templates: "ntpl",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2180,16 +2180,31 @@ importers:
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
+      '@voyant-travel/storage':
+        specifier: workspace:^
+        version: link:../storage
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       hono:
         specifier: 4.12.25
         version: 4.12.25
+      sanitize-html:
+        specifier: ^2.17.5
+        version: 2.17.5
       zod:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.5.4
+        version: 0.5.4
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.5.2
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       '@voyant-travel/voyant-typescript-config':
         specifier: workspace:^
         version: link:../typescript-config

--- a/scripts/checks/graph/graph-conformance.json
+++ b/scripts/checks/graph/graph-conformance.json
@@ -24,7 +24,8 @@
         "conversations.ingress-source",
         "conversations.rendered-message-admission",
         "conversations.person-directory",
-        "auth.staff-directory"
+        "auth.staff-directory",
+        "conversations.attachments"
       ],
       "runtimeExport": "createConversationsRuntimePortContribution"
     },


### PR DESCRIPTION
Closes #4828

Adds sanitized message content, normalized private attachment state, scanner and storage runtime authorities, authenticated Inbox-scoped upload/download/redaction, retention cleanup, classified non-message quarantine, and retry-time attachment revalidation.

Stacked on `feat/inbox`; the umbrella remains #4836.

Validation:
- conversations typecheck and tests (including PGlite security suite)
- conversations-contracts tests/typecheck
- conversations-react typecheck
- focused Notifications attachment/reminder tests
- OpenAPI drift and graph conformance