### PR TITLE
feat(inbox): add two-way SMS conversations

### DIFF
--- a/.changeset/smart-inbox-sms.md
+++ b/.changeset/smart-inbox-sms.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/conversations-contracts": minor
+"@voyant-travel/conversations": minor
+"@voyant-travel/conversations-react": minor
+"@voyant-travel/notifications": minor
+"@voyant-travel/notifications-react": minor
+"@voyant-travel/relationships": minor
+"@voyant-travel/schema-kit": patch
+---
+
+Add provider-neutral two-way SMS Inbox conversations, strict E.164 identities,
+account-scoped hard opt-out enforcement, and SMS composer capability feedback.

--- a/packages/admin-api-client/src/generated/conversations.ts
+++ b/packages/admin-api-client/src/generated/conversations.ts
@@ -44,13 +44,17 @@ export interface paths {
                 status: "open" | "closed" | "snoozed"
                 subject: string | null
                 suggestedSubject: string | null
-                replyAlias: string
+                replyAlias: string | null
+                channelAccountId: string | null
+                localAddress: string | null
                 customerAddress: string
                 personRef: string | null
                 contactPointRef: string | null
                 unreadCount: number
                 /** Format: date-time */
                 snoozedUntil: string | null
+                /** Format: date-time */
+                closedAt: string | null
                 /** Format: date-time */
                 lastPartAt: string
                 /** Format: date-time */
@@ -128,17 +132,31 @@ export interface paths {
       }
       requestBody: {
         content: {
-          "application/json": {
-            inboxId: string
-            personRef: string
-            contactPointRef: string
-            channelAccountId: string
-            /** Format: email */
-            fromAddress: string
-            subject: string | null
-            text: string
-            idempotencyKey: string
-          }
+          "application/json":
+            | {
+                inboxId: string
+                personRef: string
+                contactPointRef: string
+                channelAccountId: string
+                text: string
+                idempotencyKey: string
+                /** @enum {string} */
+                channel: "email"
+                /** Format: email */
+                fromAddress: string
+                subject: string | null
+              }
+            | {
+                inboxId: string
+                personRef: string
+                contactPointRef: string
+                channelAccountId: string
+                text: string
+                idempotencyKey: string
+                /** @enum {string} */
+                channel: "sms"
+                subject?: null
+              }
         }
       }
       responses: {
@@ -162,13 +180,17 @@ export interface paths {
                   status: "open" | "closed" | "snoozed"
                   subject: string | null
                   suggestedSubject: string | null
-                  replyAlias: string
+                  replyAlias: string | null
+                  channelAccountId: string | null
+                  localAddress: string | null
                   customerAddress: string
                   personRef: string | null
                   contactPointRef: string | null
                   unreadCount: number
                   /** Format: date-time */
                   snoozedUntil: string | null
+                  /** Format: date-time */
+                  closedAt: string | null
                   /** Format: date-time */
                   lastPartAt: string
                   /** Format: date-time */
@@ -218,8 +240,9 @@ export interface paths {
                   inReplyTo: string | null
                   references: string[]
                   /** @enum {string} */
+                  admissionStatus: "received" | "pending" | "admitted" | "suppressed"
+                  /** @enum {string|null} */
                   deliveryStatus:
-                    | "received"
                     | "pending"
                     | "accepted"
                     | "delivered"
@@ -228,6 +251,7 @@ export interface paths {
                     | "complained"
                     | "suppressed"
                     | "cancelled"
+                    | null
                   /** Format: date-time */
                   occurredAt: string
                   /** Format: date-time */
@@ -290,8 +314,9 @@ export interface paths {
                         inReplyTo: string | null
                         references: string[]
                         /** @enum {string} */
+                        admissionStatus: "received" | "pending" | "admitted" | "suppressed"
+                        /** @enum {string|null} */
                         deliveryStatus:
-                          | "received"
                           | "pending"
                           | "accepted"
                           | "delivered"
@@ -300,6 +325,7 @@ export interface paths {
                           | "complained"
                           | "suppressed"
                           | "cancelled"
+                          | null
                         /** Format: date-time */
                         occurredAt: string
                         /** Format: date-time */
@@ -342,6 +368,14 @@ export interface paths {
                       }
                     }
                 )[]
+                channelState: {
+                  normalizedAddress: string
+                  /** @enum {string} */
+                  health: "unknown" | "healthy" | "degraded" | "unavailable"
+                  available: boolean
+                  attachmentsCapable: boolean
+                  suppressed: boolean
+                } | null
               }
             }
           }
@@ -447,13 +481,17 @@ export interface paths {
                   status: "open" | "closed" | "snoozed"
                   subject: string | null
                   suggestedSubject: string | null
-                  replyAlias: string
+                  replyAlias: string | null
+                  channelAccountId: string | null
+                  localAddress: string | null
                   customerAddress: string
                   personRef: string | null
                   contactPointRef: string | null
                   unreadCount: number
                   /** Format: date-time */
                   snoozedUntil: string | null
+                  /** Format: date-time */
+                  closedAt: string | null
                   /** Format: date-time */
                   lastPartAt: string
                   /** Format: date-time */
@@ -503,8 +541,9 @@ export interface paths {
                   inReplyTo: string | null
                   references: string[]
                   /** @enum {string} */
+                  admissionStatus: "received" | "pending" | "admitted" | "suppressed"
+                  /** @enum {string|null} */
                   deliveryStatus:
-                    | "received"
                     | "pending"
                     | "accepted"
                     | "delivered"
@@ -513,6 +552,7 @@ export interface paths {
                     | "complained"
                     | "suppressed"
                     | "cancelled"
+                    | null
                   /** Format: date-time */
                   occurredAt: string
                   /** Format: date-time */
@@ -575,8 +615,9 @@ export interface paths {
                         inReplyTo: string | null
                         references: string[]
                         /** @enum {string} */
+                        admissionStatus: "received" | "pending" | "admitted" | "suppressed"
+                        /** @enum {string|null} */
                         deliveryStatus:
-                          | "received"
                           | "pending"
                           | "accepted"
                           | "delivered"
@@ -585,6 +626,7 @@ export interface paths {
                           | "complained"
                           | "suppressed"
                           | "cancelled"
+                          | null
                         /** Format: date-time */
                         occurredAt: string
                         /** Format: date-time */
@@ -627,6 +669,14 @@ export interface paths {
                       }
                     }
                 )[]
+                channelState: {
+                  normalizedAddress: string
+                  /** @enum {string} */
+                  health: "unknown" | "healthy" | "degraded" | "unavailable"
+                  available: boolean
+                  attachmentsCapable: boolean
+                  suppressed: boolean
+                } | null
               }
             }
           }
@@ -737,13 +787,17 @@ export interface paths {
                 status: "open" | "closed" | "snoozed"
                 subject: string | null
                 suggestedSubject: string | null
-                replyAlias: string
+                replyAlias: string | null
+                channelAccountId: string | null
+                localAddress: string | null
                 customerAddress: string
                 personRef: string | null
                 contactPointRef: string | null
                 unreadCount: number
                 /** Format: date-time */
                 snoozedUntil: string | null
+                /** Format: date-time */
+                closedAt: string | null
                 /** Format: date-time */
                 lastPartAt: string
                 /** Format: date-time */
@@ -893,8 +947,9 @@ export interface paths {
                 inReplyTo: string | null
                 references: string[]
                 /** @enum {string} */
+                admissionStatus: "received" | "pending" | "admitted" | "suppressed"
+                /** @enum {string|null} */
                 deliveryStatus:
-                  | "received"
                   | "pending"
                   | "accepted"
                   | "delivered"
@@ -903,6 +958,7 @@ export interface paths {
                   | "complained"
                   | "suppressed"
                   | "cancelled"
+                  | null
                 /** Format: date-time */
                 occurredAt: string
                 /** Format: date-time */
@@ -1019,13 +1075,17 @@ export interface paths {
                 status: "open" | "closed" | "snoozed"
                 subject: string | null
                 suggestedSubject: string | null
-                replyAlias: string
+                replyAlias: string | null
+                channelAccountId: string | null
+                localAddress: string | null
                 customerAddress: string
                 personRef: string | null
                 contactPointRef: string | null
                 unreadCount: number
                 /** Format: date-time */
                 snoozedUntil: string | null
+                /** Format: date-time */
+                closedAt: string | null
                 /** Format: date-time */
                 lastPartAt: string
                 /** Format: date-time */

--- a/packages/conversations-contracts/src/index.ts
+++ b/packages/conversations-contracts/src/index.ts
@@ -38,7 +38,42 @@ export const inboundEmailEnvelopeV1Schema = z.object({
   occurredAt: z.string().datetime({ offset: true }),
 })
 
+const e164Pattern = /^\+[1-9]\d{1,14}$/
+
+/** Strict comparison form used at every SMS persistence and transport boundary. */
+export function normalizeE164(value: string): string {
+  const normalized = value.trim()
+  if (!e164Pattern.test(normalized)) {
+    throw new Error("Phone number must be normalized E.164 (for example +12025550123)")
+  }
+  return normalized
+}
+
+export const inboundSmsEnvelopeV1Schema = z.object({
+  version: z.literal("1"),
+  channel: z.literal("sms"),
+  sourceId: z.string().min(1),
+  externalEnvelopeId: z.string().min(1),
+  externalMessageId: z.string().min(1),
+  channelAccountId: z.string().min(1),
+  receivingAddress: z.string().transform(normalizeE164),
+  senderAddress: z.string().transform(normalizeE164),
+  text: z.string().min(1),
+  attachments: z.array(inboundAttachmentSchema).default([]),
+  policyEvent: z.enum(["hard_opt_out", "opt_in"]).nullable().default(null),
+  /** True when the adapter already sent a mandatory policy acknowledgement. */
+  adapterHandledResponse: z.boolean().default(false),
+  occurredAt: z.string().datetime({ offset: true }),
+})
+
+export const inboundConversationEnvelopeV1Schema = z.union([
+  inboundEmailEnvelopeV1Schema,
+  inboundSmsEnvelopeV1Schema,
+])
+
 export type InboundEmailEnvelopeV1 = z.infer<typeof inboundEmailEnvelopeV1Schema>
+export type InboundSmsEnvelopeV1 = z.infer<typeof inboundSmsEnvelopeV1Schema>
+export type InboundConversationEnvelopeV1 = z.infer<typeof inboundConversationEnvelopeV1Schema>
 export type InboundAttachment = z.infer<typeof inboundAttachmentSchema>
 
 export interface IngressItemRef {
@@ -57,12 +92,13 @@ export interface IngressListPage {
 export interface ConversationIngressSource {
   readonly id: string
   list(input: { cursor?: string; limit: number }): Promise<IngressListPage>
-  fetch(ref: IngressItemRef): Promise<InboundEmailEnvelopeV1>
+  fetch(ref: IngressItemRef): Promise<InboundConversationEnvelopeV1>
   ack(ref: IngressItemRef): Promise<void>
 }
 
 export interface ConversationRenderedServiceMessage {
   channelAccountId: string
+  channel?: "email" | "sms"
   target: { type: "@voyant-travel/conversations#part"; id: string }
   purpose: "conversation-reply"
   idempotencyKey: string
@@ -78,10 +114,10 @@ export interface ConversationRenderedServiceMessage {
     contentId?: string
   }>
   thread: { threadId: string; replyToDeliveryId?: string }
-  metadata: {
-    replyAlias: string
-    inReplyTo: string | null
-    references: readonly string[]
+  metadata?: {
+    replyAlias?: string
+    inReplyTo?: string | null
+    references?: readonly string[]
   }
 }
 
@@ -126,8 +162,8 @@ export interface ConversationPrivateAttachmentDeliveryResolver {
 }
 
 /** Stable, order-independent JSON used to detect replay payload drift. */
-export function canonicalEnvelopePayload(envelope: InboundEmailEnvelopeV1): string {
-  return canonicalJson(inboundEmailEnvelopeV1Schema.parse(envelope))
+export function canonicalEnvelopePayload(envelope: InboundConversationEnvelopeV1): string {
+  return canonicalJson(inboundConversationEnvelopeV1Schema.parse(envelope))
 }
 
 function canonicalJson(value: unknown): string {

--- a/packages/conversations-contracts/tests/contracts.test.ts
+++ b/packages/conversations-contracts/tests/contracts.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest"
+import type { InboundSmsEnvelopeV1 } from "../src/index.js"
 import {
   canonicalEnvelopePayload,
   canonicalMessageId,
   inboundEmailEnvelopeV1Schema,
+  inboundSmsEnvelopeV1Schema,
+  normalizeE164,
 } from "../src/index.js"
 
 const envelope = {
@@ -31,5 +34,34 @@ describe("provider-neutral inbound email envelope", () => {
   it("canonicalizes object key order and message identifiers", () => {
     expect(canonicalEnvelopePayload(envelope)).toBe(canonicalEnvelopePayload({ ...envelope }))
     expect(canonicalMessageId(" <Message-1@Example.Test> ")).toBe("message-1@example.test")
+  })
+})
+
+describe("provider-neutral inbound SMS envelope", () => {
+  const sms: InboundSmsEnvelopeV1 = {
+    version: "1",
+    channel: "sms",
+    sourceId: "fixture-source",
+    externalEnvelopeId: "sms-envelope-1",
+    externalMessageId: "sms-message-1",
+    channelAccountId: "ncha_fixture",
+    receivingAddress: "+12025550100",
+    senderAddress: "+12025550123",
+    text: "STOP",
+    attachments: [],
+    policyEvent: "hard_opt_out",
+    adapterHandledResponse: true,
+    occurredAt: "2026-08-17T10:00:00.000Z",
+  }
+
+  it("accepts a transport-free envelope and preserves adapter response audit metadata", () => {
+    expect(inboundSmsEnvelopeV1Schema.parse(sms)).toEqual(sms)
+    expect(canonicalEnvelopePayload(sms)).toBe(canonicalEnvelopePayload({ ...sms }))
+  })
+
+  it("uses strict E.164 rather than guessing a region or rewriting punctuation", () => {
+    expect(normalizeE164(" +12025550123 ")).toBe("+12025550123")
+    expect(() => normalizeE164("(202) 555-0123")).toThrow("E.164")
+    expect(() => normalizeE164("+02025550123")).toThrow("E.164")
   })
 })

--- a/packages/conversations-react/src/admin/inbox-page.tsx
+++ b/packages/conversations-react/src/admin/inbox-page.tsx
@@ -67,6 +67,7 @@ function StartConversation() {
     const form = new FormData(event.currentTarget)
     try {
       await conversationsApi.start(fetcher, baseUrl, {
+        channel: "email",
         inboxId: String(form.get("inboxId")),
         personRef: String(form.get("personRef")),
         contactPointRef: String(form.get("contactPointRef")),

--- a/packages/conversations-react/src/api.ts
+++ b/packages/conversations-react/src/api.ts
@@ -111,11 +111,12 @@ export const conversationsApi = {
       personRef: string
       contactPointRef: string
       channelAccountId: string
-      fromAddress: string
-      subject: string | null
       text: string
       idempotencyKey: string
-    },
+    } & (
+      | { channel: "email"; fromAddress: string; subject: string | null }
+      | { channel: "sms"; subject?: null }
+    ),
   ) {
     return request<InboxConversationDetail>(fetcher, `${baseUrl}/v1/admin/conversations`, {
       method: "POST",

--- a/packages/conversations/migrations/0003_sms_conversations.sql
+++ b/packages/conversations/migrations/0003_sms_conversations.sql
@@ -1,0 +1,22 @@
+ALTER TYPE "public"."conversation_part_delivery_status" RENAME TO "conversation_part_admission_status";--> statement-breakpoint
+ALTER TABLE "conversation_parts" RENAME COLUMN "delivery_status" TO "admission_status";--> statement-breakpoint
+ALTER TABLE "conversation_parts" ALTER COLUMN "admission_status" SET DATA TYPE text USING "admission_status"::text;--> statement-breakpoint
+DROP TYPE "public"."conversation_part_admission_status";--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."conversation_part_admission_status" AS ENUM('received', 'pending', 'admitted', 'suppressed');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+UPDATE "conversation_parts"
+SET "admission_status" = CASE
+  WHEN "admission_status" = 'received' THEN 'received'
+  WHEN "admission_status" = 'pending' THEN 'pending'
+  WHEN "admission_status" = 'suppressed' THEN 'suppressed'
+  ELSE 'admitted'
+END;--> statement-breakpoint
+ALTER TABLE "conversation_parts" ALTER COLUMN "admission_status" SET DATA TYPE "public"."conversation_part_admission_status" USING "admission_status"::"public"."conversation_part_admission_status";--> statement-breakpoint
+ALTER TABLE "conversations" ALTER COLUMN "reply_alias" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "conversations" ADD COLUMN "channel_account_id" text;--> statement-breakpoint
+ALTER TABLE "conversations" ADD COLUMN "local_address" text;--> statement-breakpoint
+ALTER TABLE "conversations" ADD COLUMN "closed_at" timestamp with time zone;--> statement-breakpoint
+UPDATE "conversations" SET "closed_at" = "updated_at" WHERE "status" = 'closed';--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_conversations_active_sms_pair" ON "conversations" USING btree ("channel_account_id","customer_address") WHERE "conversations"."channel" = 'sms' AND "conversations"."status" IN ('open', 'snoozed');

--- a/packages/conversations/migrations/meta/0003_snapshot.json
+++ b/packages/conversations/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1616 @@
+{
+  "id": "fa4e103b-8610-48b2-9423-7ff40667f5ab",
+  "prevId": "db1d5090-3d56-4e25-9bff-1cd129e73a26",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.conversation_attachments": {
+      "name": "conversation_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_id": {
+          "name": "part_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_handle": {
+          "name": "private_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'attachment'"
+        },
+        "inline_content_id": {
+          "name": "inline_content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scan_status": {
+          "name": "scan_status",
+          "type": "conversation_attachment_scan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "availability": {
+          "name": "availability",
+          "type": "conversation_attachment_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'quarantined'"
+        },
+        "retention_until": {
+          "name": "retention_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redacted_at": {
+          "name": "redacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_attachment_handle": {
+          "name": "uidx_conversation_attachment_handle",
+          "columns": [
+            {
+              "expression": "private_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_attachment_external": {
+          "name": "uidx_conversation_attachment_external",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversation_attachments_conversation": {
+          "name": "idx_conversation_attachments_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversation_attachments_part": {
+          "name": "idx_conversation_attachments_part",
+          "columns": [
+            {
+              "expression": "part_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversation_attachments_retention": {
+          "name": "idx_conversation_attachments_retention",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retention_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_attachments_conversation_id_conversations_id_fk": {
+          "name": "conversation_attachments_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_attachments",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_attachments_part_id_conversation_parts_id_fk": {
+          "name": "conversation_attachments_part_id_conversation_parts_id_fk",
+          "tableFrom": "conversation_attachments",
+          "tableTo": "conversation_parts",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_events": {
+      "name": "conversation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_conversation_events_conversation": {
+          "name": "idx_conversation_events_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_events_conversation_id_conversations_id_fk": {
+          "name": "conversation_events_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_events",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_inbox_memberships": {
+      "name": "conversation_inbox_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "conversation_inbox_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_inbox_membership": {
+          "name": "uidx_conversation_inbox_membership",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_inbox_memberships_inbox_id_conversation_inboxes_id_fk": {
+          "name": "conversation_inbox_memberships_inbox_id_conversation_inboxes_id_fk",
+          "tableFrom": "conversation_inbox_memberships",
+          "tableTo": "conversation_inboxes",
+          "columnsFrom": [
+            "inbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_inboxes": {
+      "name": "conversation_inboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_inboxes_name": {
+          "name": "uidx_conversation_inboxes_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_inboxes_single_default": {
+          "name": "uidx_conversation_inboxes_single_default",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_inboxes\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_ingress_operations": {
+      "name": "conversation_ingress_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_envelope_id": {
+          "name": "external_envelope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint": {
+          "name": "payload_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_part_id": {
+          "name": "conversation_part_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "conversation_ingress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'committed'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_ingress_envelope": {
+          "name": "uidx_conversation_ingress_envelope",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_envelope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_ingress_message": {
+          "name": "uidx_conversation_ingress_message",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_ingress_operations_conversation_part_id_conversation_parts_id_fk": {
+          "name": "conversation_ingress_operations_conversation_part_id_conversation_parts_id_fk",
+          "tableFrom": "conversation_ingress_operations",
+          "tableTo": "conversation_parts",
+          "columnsFrom": [
+            "conversation_part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_notes": {
+      "name": "conversation_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_conversation_notes_conversation": {
+          "name": "idx_conversation_notes_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_notes_conversation_id_conversations_id_fk": {
+          "name": "conversation_notes_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_notes",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "conversation_participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_ref": {
+          "name": "person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_point_ref": {
+          "name": "contact_point_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_participant_address": {
+          "name": "uidx_conversation_participant_address",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_parts": {
+      "name": "conversation_parts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "conversation_part_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_address": {
+          "name": "sender_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_addresses": {
+          "name": "recipient_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_status": {
+          "name": "content_status",
+          "type": "conversation_part_content_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        },
+        "legacy_attachment_count": {
+          "name": "legacy_attachment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification": {
+          "name": "classification",
+          "type": "conversation_part_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'message'"
+        },
+        "replyable": {
+          "name": "replyable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "payload_fingerprint": {
+          "name": "payload_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_delivery_id": {
+          "name": "notification_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admission_status": {
+          "name": "admission_status",
+          "type": "conversation_part_admission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_parts_external_message": {
+          "name": "uidx_conversation_parts_external_message",
+          "columns": [
+            {
+              "expression": "external_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_parts_message_id": {
+          "name": "uidx_conversation_parts_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_parts_idempotency": {
+          "name": "uidx_conversation_parts_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversation_parts_conversation_occurred": {
+          "name": "idx_conversation_parts_conversation_occurred",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_parts_sequence": {
+          "name": "uidx_conversation_parts_sequence",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_parts_conversation_id_conversations_id_fk": {
+          "name": "conversation_parts_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_parts",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_read_cursors": {
+      "name": "conversation_read_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_sequence": {
+          "name": "last_read_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_read_cursor": {
+          "name": "uidx_conversation_read_cursor",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_read_cursors_conversation_id_conversations_id_fk": {
+          "name": "conversation_read_cursors_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_read_cursors",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to_user_id": {
+          "name": "assigned_to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "conversation_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_part_sequence": {
+          "name": "next_part_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_subject": {
+          "name": "suggested_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_alias": {
+          "name": "reply_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_account_id": {
+          "name": "channel_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_address": {
+          "name": "local_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_address": {
+          "name": "customer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_ref": {
+          "name": "person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_point_ref": {
+          "name": "contact_point_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_idempotency_key": {
+          "name": "start_idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_payload_fingerprint": {
+          "name": "start_payload_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_part_at": {
+          "name": "last_part_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversations_reply_alias": {
+          "name": "uidx_conversations_reply_alias",
+          "columns": [
+            {
+              "expression": "reply_alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversations_active_sms_pair": {
+          "name": "uidx_conversations_active_sms_pair",
+          "columns": [
+            {
+              "expression": "channel_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "customer_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversations\".\"channel\" = 'sms' AND \"conversations\".\"status\" IN ('open', 'snoozed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversations_start_idempotency": {
+          "name": "uidx_conversations_start_idempotency",
+          "columns": [
+            {
+              "expression": "start_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_last_part": {
+          "name": "idx_conversations_last_part",
+          "columns": [
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_person": {
+          "name": "idx_conversations_person",
+          "columns": [
+            {
+              "expression": "person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_inbox_status": {
+          "name": "idx_conversations_inbox_status",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_assignee": {
+          "name": "idx_conversations_assignee",
+          "columns": [
+            {
+              "expression": "assigned_to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_inbox_id_conversation_inboxes_id_fk": {
+          "name": "conversations_inbox_id_conversation_inboxes_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "conversation_inboxes",
+          "columnsFrom": [
+            "inbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.conversation_attachment_availability": {
+      "name": "conversation_attachment_availability",
+      "schema": "public",
+      "values": [
+        "active",
+        "quarantined",
+        "redaction_pending",
+        "redacted"
+      ]
+    },
+    "public.conversation_attachment_scan_status": {
+      "name": "conversation_attachment_scan_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "clean",
+        "blocked",
+        "failed"
+      ]
+    },
+    "public.conversation_inbox_membership_role": {
+      "name": "conversation_inbox_membership_role",
+      "schema": "public",
+      "values": [
+        "member",
+        "manager"
+      ]
+    },
+    "public.conversation_ingress_status": {
+      "name": "conversation_ingress_status",
+      "schema": "public",
+      "values": [
+        "committed",
+        "drifted"
+      ]
+    },
+    "public.conversation_part_admission_status": {
+      "name": "conversation_part_admission_status",
+      "schema": "public",
+      "values": [
+        "received",
+        "pending",
+        "admitted",
+        "suppressed"
+      ]
+    },
+    "public.conversation_part_classification": {
+      "name": "conversation_part_classification",
+      "schema": "public",
+      "values": [
+        "message",
+        "automatic_reply",
+        "delivery_status",
+        "complaint",
+        "suspicious"
+      ]
+    },
+    "public.conversation_part_content_status": {
+      "name": "conversation_part_content_status",
+      "schema": "public",
+      "values": [
+        "safe",
+        "quarantined",
+        "redacted"
+      ]
+    },
+    "public.conversation_part_direction": {
+      "name": "conversation_part_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.conversation_participant_role": {
+      "name": "conversation_participant_role",
+      "schema": "public",
+      "values": [
+        "customer",
+        "staff"
+      ]
+    },
+    "public.conversation_priority": {
+      "name": "conversation_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.conversation_status": {
+      "name": "conversation_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed",
+        "snoozed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/conversations/migrations/meta/_journal.json
+++ b/packages/conversations/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1787012000000,
       "tag": "0002_secure_content",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1787017255414,
+      "tag": "0003_sms_conversations",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/conversations/openapi/admin/conversations.json
+++ b/packages/conversations/openapi/admin/conversations.json
@@ -94,7 +94,13 @@
                             "type": ["string", "null"]
                           },
                           "replyAlias": {
-                            "type": "string"
+                            "type": ["string", "null"]
+                          },
+                          "channelAccountId": {
+                            "type": ["string", "null"]
+                          },
+                          "localAddress": {
+                            "type": ["string", "null"]
                           },
                           "customerAddress": {
                             "type": "string"
@@ -110,6 +116,10 @@
                             "minimum": 0
                           },
                           "snoozedUntil": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "closedAt": {
                             "type": ["string", "null"],
                             "format": "date-time"
                           },
@@ -137,11 +147,14 @@
                           "subject",
                           "suggestedSubject",
                           "replyAlias",
+                          "channelAccountId",
+                          "localAddress",
                           "customerAddress",
                           "personRef",
                           "contactPointRef",
                           "unreadCount",
                           "snoozedUntil",
+                          "closedAt",
                           "lastPartAt",
                           "createdAt",
                           "updatedAt"
@@ -242,49 +255,103 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "inboxId": {
-                    "type": "string",
-                    "minLength": 1
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "inboxId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "personRef": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "contactPointRef": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "channelAccountId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "text": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "idempotencyKey": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "channel": {
+                        "type": "string",
+                        "enum": ["email"]
+                      },
+                      "fromAddress": {
+                        "type": "string",
+                        "format": "email"
+                      },
+                      "subject": {
+                        "type": ["string", "null"]
+                      }
+                    },
+                    "required": [
+                      "inboxId",
+                      "personRef",
+                      "contactPointRef",
+                      "channelAccountId",
+                      "text",
+                      "idempotencyKey",
+                      "channel",
+                      "fromAddress",
+                      "subject"
+                    ]
                   },
-                  "personRef": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "contactPointRef": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "channelAccountId": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "fromAddress": {
-                    "type": "string",
-                    "format": "email"
-                  },
-                  "subject": {
-                    "type": ["string", "null"]
-                  },
-                  "text": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "idempotencyKey": {
-                    "type": "string",
-                    "minLength": 1
+                  {
+                    "type": "object",
+                    "properties": {
+                      "inboxId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "personRef": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "contactPointRef": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "channelAccountId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "text": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "idempotencyKey": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "channel": {
+                        "type": "string",
+                        "enum": ["sms"]
+                      },
+                      "subject": {
+                        "type": "null"
+                      }
+                    },
+                    "required": [
+                      "inboxId",
+                      "personRef",
+                      "contactPointRef",
+                      "channelAccountId",
+                      "text",
+                      "idempotencyKey",
+                      "channel"
+                    ]
                   }
-                },
-                "required": [
-                  "inboxId",
-                  "personRef",
-                  "contactPointRef",
-                  "channelAccountId",
-                  "fromAddress",
-                  "subject",
-                  "text",
-                  "idempotencyKey"
                 ]
               }
             }
@@ -335,7 +402,13 @@
                               "type": ["string", "null"]
                             },
                             "replyAlias": {
-                              "type": "string"
+                              "type": ["string", "null"]
+                            },
+                            "channelAccountId": {
+                              "type": ["string", "null"]
+                            },
+                            "localAddress": {
+                              "type": ["string", "null"]
                             },
                             "customerAddress": {
                               "type": "string"
@@ -351,6 +424,10 @@
                               "minimum": 0
                             },
                             "snoozedUntil": {
+                              "type": ["string", "null"],
+                              "format": "date-time"
+                            },
+                            "closedAt": {
                               "type": ["string", "null"],
                               "format": "date-time"
                             },
@@ -378,11 +455,14 @@
                             "subject",
                             "suggestedSubject",
                             "replyAlias",
+                            "channelAccountId",
+                            "localAddress",
                             "customerAddress",
                             "personRef",
                             "contactPointRef",
                             "unreadCount",
                             "snoozedUntil",
+                            "closedAt",
                             "lastPartAt",
                             "createdAt",
                             "updatedAt"
@@ -517,10 +597,13 @@
                                   "type": "string"
                                 }
                               },
-                              "deliveryStatus": {
+                              "admissionStatus": {
                                 "type": "string",
+                                "enum": ["received", "pending", "admitted", "suppressed"]
+                              },
+                              "deliveryStatus": {
+                                "type": ["string", "null"],
                                 "enum": [
-                                  "received",
                                   "pending",
                                   "accepted",
                                   "delivered",
@@ -528,7 +611,8 @@
                                   "bounced",
                                   "complained",
                                   "suppressed",
-                                  "cancelled"
+                                  "cancelled",
+                                  null
                                 ]
                               },
                               "occurredAt": {
@@ -559,6 +643,7 @@
                               "messageId",
                               "inReplyTo",
                               "references",
+                              "admissionStatus",
                               "deliveryStatus",
                               "occurredAt",
                               "createdAt"
@@ -741,10 +826,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "deliveryStatus": {
+                                      "admissionStatus": {
                                         "type": "string",
+                                        "enum": ["received", "pending", "admitted", "suppressed"]
+                                      },
+                                      "deliveryStatus": {
+                                        "type": ["string", "null"],
                                         "enum": [
-                                          "received",
                                           "pending",
                                           "accepted",
                                           "delivered",
@@ -752,7 +840,8 @@
                                           "bounced",
                                           "complained",
                                           "suppressed",
-                                          "cancelled"
+                                          "cancelled",
+                                          null
                                         ]
                                       },
                                       "occurredAt": {
@@ -783,6 +872,7 @@
                                       "messageId",
                                       "inReplyTo",
                                       "references",
+                                      "admissionStatus",
                                       "deliveryStatus",
                                       "occurredAt",
                                       "createdAt"
@@ -897,9 +987,37 @@
                               }
                             ]
                           }
+                        },
+                        "channelState": {
+                          "type": ["object", "null"],
+                          "properties": {
+                            "normalizedAddress": {
+                              "type": "string"
+                            },
+                            "health": {
+                              "type": "string",
+                              "enum": ["unknown", "healthy", "degraded", "unavailable"]
+                            },
+                            "available": {
+                              "type": "boolean"
+                            },
+                            "attachmentsCapable": {
+                              "type": "boolean"
+                            },
+                            "suppressed": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "normalizedAddress",
+                            "health",
+                            "available",
+                            "attachmentsCapable",
+                            "suppressed"
+                          ]
                         }
                       },
-                      "required": ["conversation", "parts", "notes", "timeline"]
+                      "required": ["conversation", "parts", "notes", "timeline", "channelState"]
                     }
                   },
                   "required": ["data"]
@@ -1047,7 +1165,13 @@
                               "type": ["string", "null"]
                             },
                             "replyAlias": {
-                              "type": "string"
+                              "type": ["string", "null"]
+                            },
+                            "channelAccountId": {
+                              "type": ["string", "null"]
+                            },
+                            "localAddress": {
+                              "type": ["string", "null"]
                             },
                             "customerAddress": {
                               "type": "string"
@@ -1063,6 +1187,10 @@
                               "minimum": 0
                             },
                             "snoozedUntil": {
+                              "type": ["string", "null"],
+                              "format": "date-time"
+                            },
+                            "closedAt": {
                               "type": ["string", "null"],
                               "format": "date-time"
                             },
@@ -1090,11 +1218,14 @@
                             "subject",
                             "suggestedSubject",
                             "replyAlias",
+                            "channelAccountId",
+                            "localAddress",
                             "customerAddress",
                             "personRef",
                             "contactPointRef",
                             "unreadCount",
                             "snoozedUntil",
+                            "closedAt",
                             "lastPartAt",
                             "createdAt",
                             "updatedAt"
@@ -1229,10 +1360,13 @@
                                   "type": "string"
                                 }
                               },
-                              "deliveryStatus": {
+                              "admissionStatus": {
                                 "type": "string",
+                                "enum": ["received", "pending", "admitted", "suppressed"]
+                              },
+                              "deliveryStatus": {
+                                "type": ["string", "null"],
                                 "enum": [
-                                  "received",
                                   "pending",
                                   "accepted",
                                   "delivered",
@@ -1240,7 +1374,8 @@
                                   "bounced",
                                   "complained",
                                   "suppressed",
-                                  "cancelled"
+                                  "cancelled",
+                                  null
                                 ]
                               },
                               "occurredAt": {
@@ -1271,6 +1406,7 @@
                               "messageId",
                               "inReplyTo",
                               "references",
+                              "admissionStatus",
                               "deliveryStatus",
                               "occurredAt",
                               "createdAt"
@@ -1453,10 +1589,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "deliveryStatus": {
+                                      "admissionStatus": {
                                         "type": "string",
+                                        "enum": ["received", "pending", "admitted", "suppressed"]
+                                      },
+                                      "deliveryStatus": {
+                                        "type": ["string", "null"],
                                         "enum": [
-                                          "received",
                                           "pending",
                                           "accepted",
                                           "delivered",
@@ -1464,7 +1603,8 @@
                                           "bounced",
                                           "complained",
                                           "suppressed",
-                                          "cancelled"
+                                          "cancelled",
+                                          null
                                         ]
                                       },
                                       "occurredAt": {
@@ -1495,6 +1635,7 @@
                                       "messageId",
                                       "inReplyTo",
                                       "references",
+                                      "admissionStatus",
                                       "deliveryStatus",
                                       "occurredAt",
                                       "createdAt"
@@ -1609,9 +1750,37 @@
                               }
                             ]
                           }
+                        },
+                        "channelState": {
+                          "type": ["object", "null"],
+                          "properties": {
+                            "normalizedAddress": {
+                              "type": "string"
+                            },
+                            "health": {
+                              "type": "string",
+                              "enum": ["unknown", "healthy", "degraded", "unavailable"]
+                            },
+                            "available": {
+                              "type": "boolean"
+                            },
+                            "attachmentsCapable": {
+                              "type": "boolean"
+                            },
+                            "suppressed": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "normalizedAddress",
+                            "health",
+                            "available",
+                            "attachmentsCapable",
+                            "suppressed"
+                          ]
                         }
                       },
-                      "required": ["conversation", "parts", "notes", "timeline"]
+                      "required": ["conversation", "parts", "notes", "timeline", "channelState"]
                     }
                   },
                   "required": ["data"]
@@ -1789,7 +1958,13 @@
                           "type": ["string", "null"]
                         },
                         "replyAlias": {
-                          "type": "string"
+                          "type": ["string", "null"]
+                        },
+                        "channelAccountId": {
+                          "type": ["string", "null"]
+                        },
+                        "localAddress": {
+                          "type": ["string", "null"]
                         },
                         "customerAddress": {
                           "type": "string"
@@ -1805,6 +1980,10 @@
                           "minimum": 0
                         },
                         "snoozedUntil": {
+                          "type": ["string", "null"],
+                          "format": "date-time"
+                        },
+                        "closedAt": {
                           "type": ["string", "null"],
                           "format": "date-time"
                         },
@@ -1832,11 +2011,14 @@
                         "subject",
                         "suggestedSubject",
                         "replyAlias",
+                        "channelAccountId",
+                        "localAddress",
                         "customerAddress",
                         "personRef",
                         "contactPointRef",
                         "unreadCount",
                         "snoozedUntil",
+                        "closedAt",
                         "lastPartAt",
                         "createdAt",
                         "updatedAt"
@@ -2110,10 +2292,13 @@
                             "type": "string"
                           }
                         },
-                        "deliveryStatus": {
+                        "admissionStatus": {
                           "type": "string",
+                          "enum": ["received", "pending", "admitted", "suppressed"]
+                        },
+                        "deliveryStatus": {
+                          "type": ["string", "null"],
                           "enum": [
-                            "received",
                             "pending",
                             "accepted",
                             "delivered",
@@ -2121,7 +2306,8 @@
                             "bounced",
                             "complained",
                             "suppressed",
-                            "cancelled"
+                            "cancelled",
+                            null
                           ]
                         },
                         "occurredAt": {
@@ -2152,6 +2338,7 @@
                         "messageId",
                         "inReplyTo",
                         "references",
+                        "admissionStatus",
                         "deliveryStatus",
                         "occurredAt",
                         "createdAt"
@@ -2316,7 +2503,13 @@
                           "type": ["string", "null"]
                         },
                         "replyAlias": {
-                          "type": "string"
+                          "type": ["string", "null"]
+                        },
+                        "channelAccountId": {
+                          "type": ["string", "null"]
+                        },
+                        "localAddress": {
+                          "type": ["string", "null"]
                         },
                         "customerAddress": {
                           "type": "string"
@@ -2332,6 +2525,10 @@
                           "minimum": 0
                         },
                         "snoozedUntil": {
+                          "type": ["string", "null"],
+                          "format": "date-time"
+                        },
+                        "closedAt": {
                           "type": ["string", "null"],
                           "format": "date-time"
                         },
@@ -2359,11 +2556,14 @@
                         "subject",
                         "suggestedSubject",
                         "replyAlias",
+                        "channelAccountId",
+                        "localAddress",
                         "customerAddress",
                         "personRef",
                         "contactPointRef",
                         "unreadCount",
                         "snoozedUntil",
+                        "closedAt",
                         "lastPartAt",
                         "createdAt",
                         "updatedAt"

--- a/packages/conversations/src/index.ts
+++ b/packages/conversations/src/index.ts
@@ -5,7 +5,9 @@ import type { ApiModule } from "@voyant-travel/hono/module"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import {
   conversationsAttachmentRuntimePort,
+  conversationsChannelPolicyPort,
   conversationsDatabaseRuntimePort,
+  conversationsDeliveryTruthPort,
   conversationsPersonDirectoryPort,
   conversationsRenderedMessageAdmissionPort,
 } from "./runtime-port.js"
@@ -53,6 +55,12 @@ export const createConversationsVoyantRuntime = defineGraphRuntimeFactory(
       staffDirectory: await getPort(staffDirectoryRuntimePort),
       attachments: hasPort(conversationsAttachmentRuntimePort)
         ? await getPort(conversationsAttachmentRuntimePort)
+        : undefined,
+      channelPolicy: hasPort(conversationsChannelPolicyPort)
+        ? await getPort(conversationsChannelPolicyPort)
+        : undefined,
+      deliveryTruth: hasPort(conversationsDeliveryTruthPort)
+        ? await getPort(conversationsDeliveryTruthPort)
         : undefined,
     })
   },

--- a/packages/conversations/src/ingress-job.ts
+++ b/packages/conversations/src/ingress-job.ts
@@ -1,9 +1,10 @@
-import { inboundEmailEnvelopeV1Schema } from "@voyant-travel/conversations-contracts"
+import { inboundConversationEnvelopeV1Schema } from "@voyant-travel/conversations-contracts"
 import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import {
   conversationIngressSourcePort,
   conversationsAttachmentRuntimePort,
+  conversationsChannelPolicyPort,
   conversationsDatabaseRuntimePort,
   conversationsPersonDirectoryPort,
 } from "./runtime-port.js"
@@ -21,6 +22,7 @@ export async function processConversationIngress(input: {
   sources: readonly import("@voyant-travel/conversations-contracts").ConversationIngressSource[]
   personDirectory?: import("./runtime-port.js").ConversationsPersonDirectory
   attachmentRuntime?: import("./attachment-runtime.js").ConversationsAttachmentRuntime
+  channelPolicy?: import("./runtime-port.js").ConversationsChannelPolicy
   limit?: number
   /** Test seam for the commit boundary; production always uses `ingestEnvelope`. */
   ingest?: typeof ingestEnvelope
@@ -29,11 +31,15 @@ export async function processConversationIngress(input: {
   for (const source of input.sources) {
     const page = await source.list({ limit: Math.min(input.limit ?? 50, 100) })
     for (const ref of page.items) {
-      const envelope = inboundEmailEnvelopeV1Schema.parse(await source.fetch(ref))
+      const envelope = inboundConversationEnvelopeV1Schema.parse(await source.fetch(ref))
+      if (envelope.sourceId !== source.id) {
+        throw new Error("Ingress envelope source does not match the source that fetched it")
+      }
       summary.fetched += 1
       const result = await (input.ingest ?? ingestEnvelope)(input.db, envelope, {
         personDirectory: input.personDirectory,
         attachmentRuntime: input.attachmentRuntime,
+        channelPolicy: input.channelPolicy,
       })
       if (result.duplicate) summary.duplicates += 1
       else summary.committed += 1
@@ -56,10 +62,14 @@ export async function runConversationIngressJob(
   const attachmentRuntime = context.hasPort(conversationsAttachmentRuntimePort)
     ? await context.getPort(conversationsAttachmentRuntimePort)
     : undefined
+  const channelPolicy = context.hasPort(conversationsChannelPolicyPort)
+    ? await context.getPort(conversationsChannelPolicyPort)
+    : undefined
   await processConversationIngress({
     db: database.resolveDb() as PostgresJsDatabase,
     sources,
     personDirectory,
     attachmentRuntime,
+    channelPolicy,
   })
 }

--- a/packages/conversations/src/routes.ts
+++ b/packages/conversations/src/routes.ts
@@ -13,6 +13,8 @@ import {
 } from "./attachment-service.js"
 import { ConversationAttachmentPolicyError } from "./content-security.js"
 import type {
+  ConversationsChannelPolicy,
+  ConversationsDeliveryTruthReader,
   ConversationsPersonDirectory,
   ConversationsRenderedMessageAdmission,
   ConversationsStaffDirectory,
@@ -53,6 +55,8 @@ export interface ConversationsRoutesOptions {
   personDirectory?: ConversationsPersonDirectory
   staffDirectory: ConversationsStaffDirectory
   attachments?: ConversationsAttachmentRuntime
+  channelPolicy?: ConversationsChannelPolicy
+  deliveryTruth?: ConversationsDeliveryTruthReader
 }
 
 const timestamp = z.string().datetime()
@@ -67,12 +71,15 @@ const conversationSchema = z.object({
   status: z.enum(["open", "closed", "snoozed"]),
   subject: z.string().nullable(),
   suggestedSubject: z.string().nullable(),
-  replyAlias: z.string(),
+  replyAlias: z.string().nullable(),
+  channelAccountId: z.string().nullable(),
+  localAddress: z.string().nullable(),
   customerAddress: z.string(),
   personRef: z.string().nullable(),
   contactPointRef: z.string().nullable(),
   unreadCount: z.number().int().nonnegative(),
   snoozedUntil: timestamp.nullable(),
+  closedAt: timestamp.nullable(),
   lastPartAt: timestamp,
   createdAt: timestamp,
   updatedAt: timestamp,
@@ -114,17 +121,19 @@ const partSchema = z.object({
   messageId: z.string().nullable(),
   inReplyTo: z.string().nullable(),
   references: z.array(z.string()),
-  deliveryStatus: z.enum([
-    "received",
-    "pending",
-    "accepted",
-    "delivered",
-    "failed",
-    "bounced",
-    "complained",
-    "suppressed",
-    "cancelled",
-  ]),
+  admissionStatus: z.enum(["received", "pending", "admitted", "suppressed"]),
+  deliveryStatus: z
+    .enum([
+      "pending",
+      "accepted",
+      "delivered",
+      "failed",
+      "bounced",
+      "complained",
+      "suppressed",
+      "cancelled",
+    ])
+    .nullable(),
   occurredAt: timestamp,
   createdAt: timestamp,
 })
@@ -163,6 +172,20 @@ const timelineItemSchema = z.discriminatedUnion("kind", [
     }),
   }),
 ])
+const smsChannelStateSchema = z.object({
+  normalizedAddress: z.string(),
+  health: z.enum(["unknown", "healthy", "degraded", "unavailable"]),
+  available: z.boolean(),
+  attachmentsCapable: z.boolean(),
+  suppressed: z.boolean(),
+})
+const conversationDetailSchema = z.object({
+  conversation: conversationSchema,
+  parts: z.array(partSchema),
+  notes: z.array(noteSchema),
+  timeline: z.array(timelineItemSchema),
+  channelState: smsChannelStateSchema.nullable(),
+})
 const errorSchema = z.object({ error: z.string() })
 const data = <T extends z.ZodTypeAny>(schema: T) => z.object({ data: schema })
 const json = <T extends z.ZodTypeAny>(schema: T, description: string) => ({
@@ -202,17 +225,7 @@ const detailRoute = createRoute({
   path: "/v1/admin/conversations/{id}",
   request: { params: z.object({ id: z.string() }) },
   responses: {
-    200: json(
-      data(
-        z.object({
-          conversation: conversationSchema,
-          parts: z.array(partSchema),
-          notes: z.array(noteSchema),
-          timeline: z.array(timelineItemSchema),
-        }),
-      ),
-      "Conversation activity",
-    ),
+    200: json(data(conversationDetailSchema), "Conversation activity"),
     ...standardErrors,
   },
 })
@@ -229,32 +242,28 @@ const replyRoute = createRoute({
   request: { params: z.object({ id: z.string() }), body: body(replyInput) },
   responses: { 201: json(data(partSchema), "Atomically admitted reply"), ...standardErrors },
 })
-const startInput = z.object({
+const startBase = z.object({
   inboxId: z.string().min(1),
   personRef: z.string().min(1),
   contactPointRef: z.string().min(1),
   channelAccountId: z.string().min(1),
-  fromAddress: z.string().email(),
-  subject: z.string().nullable(),
   text: z.string().trim().min(1),
   idempotencyKey: z.string().min(1),
 })
+const startInput = z.discriminatedUnion("channel", [
+  startBase.extend({
+    channel: z.literal("email"),
+    fromAddress: z.string().email(),
+    subject: z.string().nullable(),
+  }),
+  startBase.extend({ channel: z.literal("sms"), subject: z.null().optional() }),
+])
 const startRoute = createRoute({
   method: "post",
   path: "/v1/admin/conversations",
   request: { body: body(startInput) },
   responses: {
-    201: json(
-      data(
-        z.object({
-          conversation: conversationSchema,
-          parts: z.array(partSchema),
-          notes: z.array(noteSchema),
-          timeline: z.array(timelineItemSchema),
-        }),
-      ),
-      "Started conversation",
-    ),
+    201: json(data(conversationDetailSchema), "Started conversation"),
     ...standardErrors,
   },
 })
@@ -433,7 +442,10 @@ function toConversationDto(row: Conversation & { unreadCount?: number }) {
   return { ...dto, unreadCount: row.unreadCount ?? 0 }
 }
 
-function toPartDto(row: ConversationPart) {
+function toPartDto(
+  row: ConversationPart,
+  deliveryStatus: import("./runtime-port.js").ConversationDeliveryTruth | null = null,
+) {
   const {
     externalSourceId: _source,
     payloadFingerprint: _fingerprint,
@@ -441,7 +453,7 @@ function toPartDto(row: ConversationPart) {
     notificationDeliveryId: _deliveryId,
     ...dto
   } = row
-  return { ...dto, attachments: [] }
+  return { ...dto, attachments: [], deliveryStatus }
 }
 
 function toAttachmentDto(row: import("./schema.js").ConversationAttachment) {
@@ -462,12 +474,36 @@ function toNoteDto(row: ConversationNote) {
   return row
 }
 
-function toDetailDto(detail: Awaited<ReturnType<typeof getConversation>>) {
+async function toDetailDto(
+  detail: Awaited<ReturnType<typeof getConversation>>,
+  options: ConversationsRoutesOptions,
+  db: PostgresJsDatabase,
+) {
   if (!detail) return null
+  const deliveryIds = detail.parts.flatMap((part) =>
+    part.notificationDeliveryId ? [part.notificationDeliveryId] : [],
+  )
+  const truth = options.deliveryTruth
+    ? await options.deliveryTruth.getDeliveryTruth(db, deliveryIds)
+    : {}
+  const partDto = (part: ConversationPart) =>
+    toPartDto(
+      part,
+      part.notificationDeliveryId ? (truth[part.notificationDeliveryId] ?? null) : null,
+    )
+  const channelState =
+    detail.conversation.channel === "sms" &&
+    detail.conversation.channelAccountId &&
+    options.channelPolicy
+      ? await options.channelPolicy.getOutboundSmsState(db, {
+          channelAccountId: detail.conversation.channelAccountId,
+          destinationAddress: detail.conversation.customerAddress,
+        })
+      : null
   return {
     conversation: toConversationDto(detail.conversation),
     parts: detail.parts.map((part) => ({
-      ...toPartDto(part),
+      ...partDto(part),
       attachments: detail.attachments
         .filter(({ partId }) => partId === part.id)
         .map(toAttachmentDto),
@@ -478,7 +514,7 @@ function toDetailDto(detail: Awaited<ReturnType<typeof getConversation>>) {
         ? {
             ...item,
             part: {
-              ...toPartDto(item.part),
+              ...partDto(item.part),
               attachments: detail.attachments
                 .filter(({ partId }) => partId === item.part.id)
                 .map(toAttachmentDto),
@@ -486,6 +522,7 @@ function toDetailDto(detail: Awaited<ReturnType<typeof getConversation>>) {
           }
         : item,
     ),
+    channelState,
   }
 }
 
@@ -544,13 +581,10 @@ export function createConversationsRoutes(options: ConversationsRoutesOptions) {
   register(detailRoute, async (c: RouteContext) => {
     const actor = await actorFor(c)
     if (!actor) return c.json({ error: "active_staff_required" }, 401)
-    const detail = await getConversation(
-      options.resolveDb(c.env),
-      c.req.valid("param").id,
-      actor.userId,
-    )
+    const db = options.resolveDb(c.env)
+    const detail = await getConversation(db, c.req.valid("param").id, actor.userId)
     return detail
-      ? c.json(response({ data: toDetailDto(detail) }), 200)
+      ? c.json(response({ data: await toDetailDto(detail, options, db) }), 200)
       : c.json({ error: "conversation_not_found" }, 404)
   })
   register(replyRoute, async (c: RouteContext) => {
@@ -566,7 +600,22 @@ export function createConversationsRoutes(options: ConversationsRoutesOptions) {
       }),
     )
     if (result.error) return c.json({ error: result.error.error }, result.error.status)
-    return c.json(response({ data: toPartDto(result.value!) }), 201)
+    const part = result.value!
+    const truth =
+      options.deliveryTruth && part.notificationDeliveryId
+        ? await options.deliveryTruth.getDeliveryTruth(options.resolveDb(c.env), [
+            part.notificationDeliveryId,
+          ])
+        : {}
+    return c.json(
+      response({
+        data: toPartDto(
+          part,
+          part.notificationDeliveryId ? (truth[part.notificationDeliveryId] ?? null) : null,
+        ),
+      }),
+      201,
+    )
   })
   register(startRoute, async (c: RouteContext) => {
     const actor = await actorFor(c)
@@ -574,14 +623,21 @@ export function createConversationsRoutes(options: ConversationsRoutesOptions) {
     if (!options.admission || !options.personDirectory)
       return c.json({ error: "conversation_runtime_unavailable" }, 409)
     const result = await handle(() =>
-      startConversation(options.resolveDb(c.env), options.admission!, options.personDirectory!, {
-        ...c.req.valid("json"),
-        actor,
-        runtimeBindings: c.env,
-      }),
+      startConversation(
+        options.resolveDb(c.env),
+        options.admission!,
+        options.personDirectory!,
+        { ...c.req.valid("json"), actor, runtimeBindings: c.env },
+        options.channelPolicy,
+      ),
     )
     if (result.error) return c.json({ error: result.error.error }, result.error.status)
-    return c.json(response({ data: toDetailDto(result.value!) }), 201)
+    return c.json(
+      response({
+        data: await toDetailDto(result.value!, options, options.resolveDb(c.env)),
+      }),
+      201,
+    )
   })
   register(stateRoute, async (c: RouteContext) => {
     const actor = await actorFor(c)
@@ -691,11 +747,10 @@ export function createConversationsRoutes(options: ConversationsRoutesOptions) {
     )
     if (access.error) return c.json({ error: access.error.error }, access.error.status)
     try {
-      const ticket = await createAttachmentUploadTicket(
-        db,
-        options.attachments,
-        { conversationId: c.req.valid("param").id, ...c.req.valid("json") },
-      )
+      const ticket = await createAttachmentUploadTicket(db, options.attachments, {
+        conversationId: c.req.valid("param").id,
+        ...c.req.valid("json"),
+      })
       return c.json(response({ data: ticket }), 201)
     } catch (error) {
       if (error instanceof ConversationAttachmentPolicyError)
@@ -714,11 +769,10 @@ export function createConversationsRoutes(options: ConversationsRoutesOptions) {
     )
     if (access.error) return c.json({ error: access.error.error }, access.error.status)
     try {
-      const attachment = await finalizeAttachmentUpload(
-        db,
-        options.attachments,
-        { conversationId: c.req.valid("param").id, ...c.req.valid("json") },
-      )
+      const attachment = await finalizeAttachmentUpload(db, options.attachments, {
+        conversationId: c.req.valid("param").id,
+        ...c.req.valid("json"),
+      })
       return c.json(response({ data: toAttachmentDto(attachment) }), 201)
     } catch (error) {
       if (error instanceof ConversationAttachmentPolicyError)
@@ -737,14 +791,10 @@ export function createConversationsRoutes(options: ConversationsRoutesOptions) {
     )
     if (access.error) return c.json({ error: access.error.error }, access.error.status)
     try {
-      const result = await downloadConversationAttachment(
-        db,
-        options.attachments,
-        {
-          conversationId: c.req.valid("param").id,
-          attachmentId: c.req.valid("param").attachmentId,
-        },
-      )
+      const result = await downloadConversationAttachment(db, options.attachments, {
+        conversationId: c.req.valid("param").id,
+        attachmentId: c.req.valid("param").attachmentId,
+      })
       if (result.download.kind === "redirect") {
         c.header("cache-control", "private, no-store")
         return c.redirect(result.download.url, 302)

--- a/packages/conversations/src/runtime-port.ts
+++ b/packages/conversations/src/runtime-port.ts
@@ -2,6 +2,7 @@ import type { StaffDirectoryRuntimeProvider } from "@voyant-travel/auth/staff-di
 import type {
   ConversationIngressSource,
   ConversationsRenderedMessageAdmission,
+  InboundSmsEnvelopeV1,
 } from "@voyant-travel/conversations-contracts"
 import { definePort } from "@voyant-travel/core/project"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
@@ -25,13 +26,53 @@ export type PersonEmailResolution =
 /** Read-only People boundary. It deliberately has no create or merge operation. */
 export interface ConversationsPersonDirectory {
   resolveEmail(db: unknown, address: string): Promise<PersonEmailResolution>
+  resolvePhone?(db: unknown, address: string): Promise<PersonEmailResolution>
   resolvePersonContactPoint(
     db: unknown,
-    input: { personRef: string; contactPointRef: string },
+    input: { personRef: string; contactPointRef: string; channel?: "email" | "sms" },
   ): Promise<{ address: string } | null>
 }
 
 export type ConversationsStaffDirectory = StaffDirectoryRuntimeProvider
+
+export interface ConversationsChannelPolicy {
+  inspectInboundSms(
+    db: unknown,
+    envelope: InboundSmsEnvelopeV1,
+  ): Promise<
+    | { kind: "ready"; accountId: string; normalizedAddress: string }
+    | { kind: "missing" | "ambiguous" | "unavailable" }
+  >
+  projectInboundSmsPolicy(db: unknown, envelope: InboundSmsEnvelopeV1): Promise<void>
+  getOutboundSmsState(
+    db: unknown,
+    input: { channelAccountId: string; destinationAddress: string },
+  ): Promise<{
+    normalizedAddress: string
+    health: "unknown" | "healthy" | "degraded" | "unavailable"
+    available: boolean
+    attachmentsCapable: boolean
+    suppressed: boolean
+  } | null>
+}
+
+export type ConversationDeliveryTruth =
+  | "pending"
+  | "accepted"
+  | "delivered"
+  | "failed"
+  | "bounced"
+  | "complained"
+  | "suppressed"
+  | "cancelled"
+
+/** Read-only projection. Notifications remains the sole delivery lifecycle authority. */
+export interface ConversationsDeliveryTruthReader {
+  getDeliveryTruth(
+    db: unknown,
+    deliveryIds: readonly string[],
+  ): Promise<Readonly<Record<string, ConversationDeliveryTruth>>>
+}
 
 export const conversationsDatabaseRuntimePort = definePort<ConversationsDatabaseRuntime>({
   id: "conversations.database",
@@ -88,7 +129,6 @@ export const conversationsPersonDirectoryPort = definePort<ConversationsPersonDi
     }
   },
 })
-
 export const conversationsAttachmentRuntimePort = definePort<ConversationsAttachmentRuntime>({
   id: "conversations.attachments",
   test(provider) {
@@ -106,6 +146,33 @@ export const conversationsAttachmentRuntimePort = definePort<ConversationsAttach
     }
     if (provider.createUploadTicket && typeof provider.finalizeUpload !== "function") {
       throw new Error("conversations.attachments upload capability requires finalizeUpload().")
+    }
+  },
+})
+
+export const conversationsChannelPolicyPort = definePort<ConversationsChannelPolicy>({
+  id: "conversations.channel-policy",
+  test(provider) {
+    if (
+      !provider ||
+      typeof provider !== "object" ||
+      typeof provider.inspectInboundSms !== "function" ||
+      typeof provider.projectInboundSmsPolicy !== "function" ||
+      typeof provider.getOutboundSmsState !== "function"
+    ) {
+      throw new Error("conversations.channel-policy provider must inspect and project SMS policy.")
+    }
+  },
+})
+export const conversationsDeliveryTruthPort = definePort<ConversationsDeliveryTruthReader>({
+  id: "conversations.delivery-truth",
+  test(provider) {
+    if (
+      !provider ||
+      typeof provider !== "object" ||
+      typeof provider.getDeliveryTruth !== "function"
+    ) {
+      throw new Error("conversations.delivery-truth provider must implement getDeliveryTruth().")
     }
   },
 })

--- a/packages/conversations/src/schema.ts
+++ b/packages/conversations/src/schema.ts
@@ -28,16 +28,11 @@ export const conversationPartDirectionEnum = pgEnum("conversation_part_direction
   "inbound",
   "outbound",
 ])
-export const conversationPartDeliveryStatusEnum = pgEnum("conversation_part_delivery_status", [
+export const conversationPartAdmissionStatusEnum = pgEnum("conversation_part_admission_status", [
   "received",
   "pending",
-  "accepted",
-  "delivered",
-  "failed",
-  "bounced",
-  "complained",
+  "admitted",
   "suppressed",
-  "cancelled",
 ])
 export const conversationParticipantRoleEnum = pgEnum("conversation_participant_role", [
   "customer",
@@ -118,19 +113,25 @@ export const conversations = pgTable(
     status: conversationStatusEnum("status").notNull().default("open"),
     subject: text("subject"),
     suggestedSubject: text("suggested_subject"),
-    replyAlias: text("reply_alias").notNull(),
+    replyAlias: text("reply_alias"),
+    channelAccountId: text("channel_account_id"),
+    localAddress: text("local_address"),
     customerAddress: text("customer_address").notNull(),
     personRef: text("person_ref"),
     contactPointRef: text("contact_point_ref"),
     startIdempotencyKey: text("start_idempotency_key"),
     startPayloadFingerprint: text("start_payload_fingerprint"),
     snoozedUntil: timestamp("snoozed_until", { withTimezone: true }),
+    closedAt: timestamp("closed_at", { withTimezone: true }),
     lastPartAt: timestamp("last_part_at", { withTimezone: true }).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
     uniqueIndex("uidx_conversations_reply_alias").on(table.replyAlias),
+    uniqueIndex("uidx_conversations_active_sms_pair")
+      .on(table.channelAccountId, table.customerAddress)
+      .where(sql`${table.channel} = 'sms' AND ${table.status} IN ('open', 'snoozed')`),
     uniqueIndex("uidx_conversations_start_idempotency").on(table.startIdempotencyKey),
     index("idx_conversations_last_part").on(table.lastPartAt),
     index("idx_conversations_person").on(table.personRef),
@@ -189,7 +190,7 @@ export const conversationParts = pgTable(
     payloadFingerprint: text("payload_fingerprint").notNull(),
     notificationDeliveryId: text("notification_delivery_id"),
     idempotencyKey: text("idempotency_key"),
-    deliveryStatus: conversationPartDeliveryStatusEnum("delivery_status").notNull(),
+    admissionStatus: conversationPartAdmissionStatusEnum("admission_status").notNull(),
     occurredAt: timestamp("occurred_at", { withTimezone: true }).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/conversations/src/service.ts
+++ b/packages/conversations/src/service.ts
@@ -1,12 +1,15 @@
 import {
   canonicalEnvelopePayload,
   canonicalMessageId,
+  type InboundConversationEnvelopeV1,
   type InboundEmailEnvelopeV1,
+  type InboundSmsEnvelopeV1,
+  normalizeE164,
   normalizeEmailAddress,
 } from "@voyant-travel/conversations-contracts"
 import { newId } from "@voyant-travel/db/lib/typeid"
 import { insertOutboxEvents } from "@voyant-travel/db/outbox"
-import { and, asc, desc, eq, gt, inArray, lte, or, sql } from "drizzle-orm"
+import { and, asc, desc, eq, gt, gte, inArray, lte, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { ConversationsAttachmentRuntime } from "./attachment-runtime.js"
 import {
@@ -22,16 +25,17 @@ import {
 } from "./content-security.js"
 import type {
   ConversationRenderedServiceMessage,
+  ConversationsChannelPolicy,
   ConversationsPersonDirectory,
   ConversationsRenderedMessageAdmission,
   ConversationsStaffDirectory,
 } from "./runtime-port.js"
 import {
   type Conversation,
+  type ConversationAttachment,
   type ConversationEvent,
   type ConversationInbox,
   type ConversationNote,
-  type ConversationAttachment,
   type ConversationPart,
   conversationAttachments,
   conversationEvents,
@@ -44,7 +48,12 @@ import {
   conversationReadCursors,
   conversations,
 } from "./schema.js"
-import { createReplyAlias, inboundThreadIds, selectExactConversation } from "./threading.js"
+import {
+  createReplyAlias,
+  inboundThreadIds,
+  SMS_RECENTLY_CLOSED_REOPEN_DAYS,
+  selectExactConversation,
+} from "./threading.js"
 
 export class ConversationIngressDriftError extends Error {
   readonly code = "ingress_payload_drift"
@@ -345,6 +354,20 @@ async function defaultInboxId(db: PostgresJsDatabase): Promise<string> {
 /** Idempotently commit one provider-neutral envelope. Acknowledgement happens outside this transaction. */
 export async function ingestEnvelope(
   db: PostgresJsDatabase,
+  envelope: InboundConversationEnvelopeV1,
+  options: {
+    personDirectory?: ConversationsPersonDirectory
+    channelPolicy?: ConversationsChannelPolicy
+    attachmentRuntime?: ConversationsAttachmentRuntime
+  } = {},
+): Promise<{ conversationId: string; partId: string; duplicate: boolean }> {
+  return "channel" in envelope
+    ? ingestSmsEnvelope(db, envelope, options)
+    : ingestEmailEnvelope(db, envelope, options)
+}
+
+async function ingestEmailEnvelope(
+  db: PostgresJsDatabase,
   envelope: InboundEmailEnvelopeV1,
   options: {
     personDirectory?: ConversationsPersonDirectory
@@ -431,6 +454,7 @@ export async function ingestEnvelope(
         subject: envelope.subject,
         suggestedSubject: envelope.subject,
         replyAlias: createReplyAlias(conversationId, receivingAddress),
+        localAddress: normalizeEmailAddress(receivingAddress),
         customerAddress: senderAddress,
         personRef: person?.personRef ?? null,
         contactPointRef: person?.contactPointRef ?? null,
@@ -451,7 +475,8 @@ export async function ingestEnvelope(
         .set({
           status: "open",
           snoozedUntil: null,
-          lastPartAt: occurredAt,
+          closedAt: null,
+          lastPartAt: sql`GREATEST(${conversations.lastPartAt}, ${occurredAt.toISOString()}::timestamptz)`,
           revision: sql`${conversations.revision} + 1`,
           updatedAt: new Date(),
         })
@@ -489,7 +514,7 @@ export async function ingestEnvelope(
         : null,
       references: envelope.threading.references.map(canonicalMessageId),
       payloadFingerprint: fingerprint,
-      deliveryStatus: "received",
+      admissionStatus: "received",
       occurredAt,
     })
     let attachmentsSafe = true
@@ -623,7 +648,306 @@ async function currentOrAllocatedSequence(
   return nextSequence(db, conversationId)
 }
 
-async function findIngressIdentities(db: PostgresJsDatabase, envelope: InboundEmailEnvelopeV1) {
+async function ingestSmsEnvelope(
+  db: PostgresJsDatabase,
+  envelope: InboundSmsEnvelopeV1,
+  options: {
+    personDirectory?: ConversationsPersonDirectory
+    channelPolicy?: ConversationsChannelPolicy
+    attachmentRuntime?: ConversationsAttachmentRuntime
+  },
+): Promise<{ conversationId: string; partId: string; duplicate: boolean }> {
+  if (!options.channelPolicy) {
+    throw new ConversationConflictError("SMS channel policy runtime is unavailable")
+  }
+  const parsed = {
+    ...envelope,
+    receivingAddress: normalizeE164(envelope.receivingAddress),
+    senderAddress: normalizeE164(envelope.senderAddress),
+  }
+  const fingerprint = canonicalEnvelopePayload(parsed)
+  const result = await db.transaction(async (transaction) => {
+    const tx = transaction as PostgresJsDatabase
+    const operationId = newId("conversation_ingress_operations")
+    const [claimed] = await tx
+      .insert(conversationIngressOperations)
+      .values({
+        id: operationId,
+        sourceId: parsed.sourceId,
+        externalEnvelopeId: parsed.externalEnvelopeId,
+        externalMessageId: parsed.externalMessageId,
+        payloadFingerprint: fingerprint,
+        status: "committed",
+      })
+      .onConflictDoNothing()
+      .returning({ id: conversationIngressOperations.id })
+    if (!claimed) return replayIngress(tx, parsed, fingerprint)
+
+    const account = await options.channelPolicy!.inspectInboundSms(tx, parsed)
+    if (account.kind !== "ready" || account.accountId !== parsed.channelAccountId) {
+      throw new ConversationConflictError(`SMS receiving identity is ${account.kind}`)
+    }
+    if (account.normalizedAddress !== parsed.receivingAddress) {
+      throw new ConversationConflictError("SMS receiving identity is ambiguous")
+    }
+    await options.channelPolicy!.projectInboundSmsPolicy(tx, parsed)
+
+    const occurredAt = new Date(parsed.occurredAt)
+    const active = await tx
+      .select()
+      .from(conversations)
+      .where(
+        and(
+          eq(conversations.channel, "sms"),
+          eq(conversations.channelAccountId, account.accountId),
+          eq(conversations.customerAddress, parsed.senderAddress),
+          inArray(conversations.status, ["open", "snoozed"]),
+        ),
+      )
+      .limit(2)
+    if (active.length > 1)
+      throw new ConversationConflictError("SMS receiving identity is ambiguous")
+    let conversation = active[0]
+    if (!conversation) {
+      const cutoff = new Date(occurredAt)
+      cutoff.setUTCDate(cutoff.getUTCDate() - SMS_RECENTLY_CLOSED_REOPEN_DAYS)
+      const [recent] = await tx
+        .select()
+        .from(conversations)
+        .where(
+          and(
+            eq(conversations.channel, "sms"),
+            eq(conversations.channelAccountId, account.accountId),
+            eq(conversations.customerAddress, parsed.senderAddress),
+            eq(conversations.status, "closed"),
+            gte(conversations.closedAt, cutoff),
+            lte(conversations.closedAt, occurredAt),
+          ),
+        )
+        .orderBy(desc(conversations.closedAt))
+        .limit(1)
+      conversation = recent
+    }
+    let resolution: Awaited<ReturnType<ConversationsPersonDirectory["resolveEmail"]>> = {
+      kind: "none",
+    }
+    if (options.personDirectory?.resolvePhone) {
+      resolution = await options.personDirectory.resolvePhone(tx, parsed.senderAddress)
+    }
+    if (!conversation) {
+      const person = resolution.kind === "unique" ? resolution : null
+      const [created] = await tx
+        .insert(conversations)
+        .values({
+          id: newId("conversations"),
+          channel: "sms",
+          channelAccountId: account.accountId,
+          localAddress: account.normalizedAddress,
+          replyAlias: null,
+          customerAddress: parsed.senderAddress,
+          personRef: person?.personRef ?? null,
+          contactPointRef: person?.contactPointRef ?? null,
+          inboxId: await defaultInboxId(tx),
+          nextPartSequence: 2,
+          lastPartAt: occurredAt,
+        })
+        .onConflictDoNothing()
+        .returning()
+      if (created) conversation = created
+      else {
+        ;[conversation] = await tx
+          .select()
+          .from(conversations)
+          .where(
+            and(
+              eq(conversations.channel, "sms"),
+              eq(conversations.channelAccountId, account.accountId),
+              eq(conversations.customerAddress, parsed.senderAddress),
+              inArray(conversations.status, ["open", "snoozed"]),
+            ),
+          )
+          .limit(1)
+      }
+      if (!conversation) throw new ConversationConflictError("SMS thread claim was lost")
+      if (created) {
+        await tx.insert(conversationParticipants).values({
+          conversationId: conversation.id,
+          role: "customer",
+          address: parsed.senderAddress,
+          personRef: person?.personRef ?? null,
+          contactPointRef: person?.contactPointRef ?? null,
+        })
+      }
+    } else {
+      await tx
+        .update(conversations)
+        .set({
+          status: "open",
+          snoozedUntil: null,
+          closedAt: null,
+          lastPartAt: sql`GREATEST(${conversations.lastPartAt}, ${occurredAt.toISOString()}::timestamptz)`,
+          revision: sql`${conversations.revision} + 1`,
+          updatedAt: new Date(),
+        })
+        .where(eq(conversations.id, conversation.id))
+    }
+
+    const partId = newId("conversation_parts")
+    await tx.insert(conversationParts).values({
+      id: partId,
+      conversationId: conversation.id,
+      sequence: await currentOrAllocatedSequence(tx, conversation.id),
+      direction: "inbound",
+      senderAddress: parsed.senderAddress,
+      recipientAddresses: [account.normalizedAddress],
+      textBody: parsed.text,
+      contentStatus: parsed.attachments.length === 0 ? "safe" : "quarantined",
+      classification: "message",
+      replyable: true,
+      externalSourceId: parsed.sourceId,
+      externalMessageId: parsed.externalMessageId,
+      payloadFingerprint: fingerprint,
+      admissionStatus: "received",
+      occurredAt,
+    })
+    let attachmentsSafe = true
+    for (const attachment of parsed.attachments) {
+      if (!options.attachmentRuntime?.importInbound) {
+        throw new ConversationAttachmentUnavailableError(
+          "Inbound attachment import is not configured",
+        )
+      }
+      const declared = normalizeAttachmentMetadata({
+        filename: attachment.filename,
+        contentType: attachment.contentType,
+        sizeBytes: attachment.size,
+      })
+      const imported = await options.attachmentRuntime.importInbound({
+        sourceId: parsed.sourceId,
+        externalId: attachment.externalId,
+        privateHandle: attachment.privateHandle,
+        ...declared,
+      })
+      const scan = await options.attachmentRuntime.scan({
+        privateHandle: imported.privateHandle,
+        filename: imported.filename,
+        declaredContentType: imported.contentType,
+        declaredSizeBytes: imported.sizeBytes,
+      })
+      let verified = declared
+      let scanStatus: "clean" | "blocked" | "failed" = scan.status
+      try {
+        verified = assertDetectedAttachmentMetadata({
+          filename: imported.filename,
+          declaredContentType: imported.contentType,
+          declaredSizeBytes: imported.sizeBytes,
+          detectedContentType: scan.detectedContentType,
+          detectedSizeBytes: scan.detectedSizeBytes,
+        })
+      } catch {
+        scanStatus = "blocked"
+      }
+      if (scanStatus !== "clean") attachmentsSafe = false
+      await tx
+        .insert(conversationAttachments)
+        .values({
+          id: newId("conversation_attachments"),
+          conversationId: conversation.id,
+          partId,
+          sourceId: parsed.sourceId,
+          externalId: attachment.externalId,
+          privateHandle: imported.privateHandle,
+          ...verified,
+          inlineContentId: attachment.inlineContentId ?? null,
+          disposition: attachment.inlineContentId ? "inline" : "attachment",
+          scanStatus,
+          availability: scanStatus === "clean" ? "active" : "quarantined",
+        })
+        .onConflictDoNothing({
+          target: [conversationAttachments.sourceId, conversationAttachments.externalId],
+        })
+    }
+    if (parsed.attachments.length > 0 && attachmentsSafe) {
+      await tx
+        .update(conversationParts)
+        .set({ contentStatus: "safe" })
+        .where(eq(conversationParts.id, partId))
+    }
+    await tx
+      .update(conversationIngressOperations)
+      .set({ conversationPartId: partId, committedAt: new Date() })
+      .where(eq(conversationIngressOperations.id, operationId))
+    const [current] = await tx
+      .select({ inboxId: conversations.inboxId, revision: conversations.revision })
+      .from(conversations)
+      .where(eq(conversations.id, conversation.id))
+      .limit(1)
+    await appendChange(tx, {
+      conversationId: conversation.id,
+      type: "part.received",
+      inboxId: current?.inboxId ?? (await defaultInboxId(tx)),
+      revision: current?.revision ?? 1,
+      payload: {
+        partId,
+        sourceId: parsed.sourceId,
+        channel: "sms",
+        adapterHandledResponse: parsed.adapterHandledResponse,
+      },
+      occurredAt,
+    })
+    return {
+      kind: "result" as const,
+      value: { conversationId: conversation.id, partId, duplicate: false },
+    }
+  })
+  if (result.kind === "drift") {
+    throw new ConversationIngressDriftError("Inbound identity was replayed with different content")
+  }
+  return result.value
+}
+
+async function replayIngress(
+  db: PostgresJsDatabase,
+  envelope: InboundConversationEnvelopeV1,
+  fingerprint: string,
+) {
+  const identities = await findIngressIdentities(db, envelope)
+  if (identities.length === 0) throw new ConversationConflictError("Ingress claim was lost")
+  if (identities.some((identity) => identity.payloadFingerprint !== fingerprint)) {
+    await db
+      .update(conversationIngressOperations)
+      .set({ status: "drifted", error: "A replay reused an identity with different content" })
+      .where(
+        inArray(
+          conversationIngressOperations.id,
+          identities.map(({ id }) => id),
+        ),
+      )
+    return { kind: "drift" as const }
+  }
+  const existing = identities[0]!
+  if (!existing.conversationPartId)
+    throw new ConversationConflictError("Committed ingress is missing its part")
+  const [part] = await db
+    .select({ conversationId: conversationParts.conversationId })
+    .from(conversationParts)
+    .where(eq(conversationParts.id, existing.conversationPartId))
+    .limit(1)
+  if (!part) throw new ConversationConflictError("Committed ingress references a missing part")
+  return {
+    kind: "result" as const,
+    value: {
+      conversationId: part.conversationId,
+      partId: existing.conversationPartId,
+      duplicate: true,
+    },
+  }
+}
+
+async function findIngressIdentities(
+  db: PostgresJsDatabase,
+  envelope: InboundConversationEnvelopeV1,
+) {
   return db
     .select()
     .from(conversationIngressOperations)
@@ -699,11 +1023,12 @@ export async function startConversation(
   admission: ConversationsRenderedMessageAdmission,
   directory: ConversationsPersonDirectory,
   input: {
+    channel?: "email" | "sms"
     personRef: string
     contactPointRef: string
     channelAccountId: string
-    fromAddress: string
-    subject: string | null
+    fromAddress?: string
+    subject?: string | null
     text: string
     html?: string | null
     attachmentIds?: readonly string[]
@@ -712,10 +1037,13 @@ export async function startConversation(
     actor: ConversationActor
     runtimeBindings?: unknown
   },
+  channelPolicy?: ConversationsChannelPolicy,
 ): Promise<ConversationDetail> {
-  const contact = await directory.resolvePersonContactPoint(db, input)
+  const channel = input.channel ?? "email"
+  const contact = await directory.resolvePersonContactPoint(db, { ...input, channel })
   if (!contact) throw new ConversationNotFoundError("Known Person contact point not found")
-  const customerAddress = normalizeEmailAddress(contact.address)
+  const customerAddress =
+    channel === "sms" ? normalizeE164(contact.address) : normalizeEmailAddress(contact.address)
   const [membership] = await db
     .select({ id: conversationInboxMemberships.id })
     .from(conversationInboxMemberships)
@@ -728,13 +1056,27 @@ export async function startConversation(
     )
     .limit(1)
   if (!membership) throw new ConversationAccessDeniedError("Staff member is not an Inbox member")
+  let fromAddress: string
+  if (channel === "sms") {
+    if (!channelPolicy) throw new ConversationConflictError("SMS channel policy is unavailable")
+    const account = await channelPolicy.getOutboundSmsState(db, {
+      channelAccountId: input.channelAccountId,
+      destinationAddress: customerAddress,
+    })
+    if (!account) throw new ConversationConflictError("SMS Channel Account was not found")
+    fromAddress = normalizeE164(account.normalizedAddress)
+  } else {
+    if (!input.fromAddress) throw new ConversationConflictError("Email sender address is required")
+    fromAddress = normalizeEmailAddress(input.fromAddress)
+  }
   const startFingerprint = JSON.stringify({
     personRef: input.personRef,
     contactPointRef: input.contactPointRef,
     channelAccountId: input.channelAccountId,
-    fromAddress: normalizeEmailAddress(input.fromAddress),
+    channel,
+    fromAddress,
     customerAddress,
-    subject: input.subject,
+    subject: input.subject ?? null,
     text: input.text,
     html: sanitizeConversationHtml(input.html),
     attachmentIds: input.attachmentIds ?? [],
@@ -748,9 +1090,12 @@ export async function startConversation(
       .values({
         id,
         inboxId: input.inboxId,
-        subject: input.subject,
+        channel,
+        channelAccountId: input.channelAccountId,
+        localAddress: fromAddress,
+        subject: input.subject ?? null,
         suggestedSubject: null,
-        replyAlias: createReplyAlias(id, input.fromAddress),
+        replyAlias: channel === "email" ? createReplyAlias(id, fromAddress) : null,
         customerAddress,
         personRef: input.personRef,
         contactPointRef: input.contactPointRef,
@@ -758,20 +1103,45 @@ export async function startConversation(
         startPayloadFingerprint: startFingerprint,
         lastPartAt: now,
       })
-      .onConflictDoNothing({ target: conversations.startIdempotencyKey })
+      .onConflictDoNothing()
       .returning()
     if (!created) {
       const [existing] = await tx
         .select()
         .from(conversations)
-        .where(eq(conversations.startIdempotencyKey, input.idempotencyKey))
+        .where(
+          or(
+            eq(conversations.startIdempotencyKey, input.idempotencyKey),
+            ...(channel === "sms"
+              ? [
+                  and(
+                    eq(conversations.channel, "sms"),
+                    eq(conversations.channelAccountId, input.channelAccountId),
+                    eq(conversations.customerAddress, customerAddress),
+                    inArray(conversations.status, ["open", "snoozed"]),
+                  ),
+                ]
+              : []),
+          ),
+        )
         .limit(1)
       if (!existing) throw new ConversationConflictError("Conversation start claim was lost")
-      if (existing.startPayloadFingerprint !== startFingerprint) {
+      if (
+        existing.startIdempotencyKey === input.idempotencyKey &&
+        existing.startPayloadFingerprint !== startFingerprint
+      ) {
         throw new ConversationConflictError(
           "Start idempotency key was reused with different content",
         )
       }
+      await admitReplyWithinTransaction(tx, admission, existing, {
+        conversationId: existing.id,
+        actor: input.actor,
+        channelAccountId: input.channelAccountId,
+        text: input.text,
+        idempotencyKey: input.idempotencyKey,
+        runtimeBindings: input.runtimeBindings,
+      })
       return existing.id
     }
     await tx.insert(conversationParticipants).values({
@@ -813,6 +1183,24 @@ async function admitReplyWithinTransaction(
     actor: ConversationActor
   },
 ): Promise<ConversationPart> {
+  if (conversation.channelAccountId && conversation.channelAccountId !== input.channelAccountId) {
+    throw new ConversationConflictError("Reply must use the conversation Channel Account")
+  }
+  const [claimedReply] = await tx
+    .select()
+    .from(conversationParts)
+    .where(eq(conversationParts.idempotencyKey, input.idempotencyKey))
+    .limit(1)
+  if (claimedReply) {
+    if (
+      claimedReply.conversationId !== conversation.id ||
+      claimedReply.textBody !== input.text ||
+      claimedReply.htmlBody !== (input.html ?? null)
+    ) {
+      throw new ConversationConflictError("Reply idempotency key was reused with different content")
+    }
+    return claimedReply
+  }
   const [lastPart] = await tx
     .select()
     .from(conversationParts)
@@ -840,13 +1228,15 @@ async function admitReplyWithinTransaction(
     conversation.id,
     input.attachmentIds ?? [],
   )
+  const channel: "email" | "sms" = conversation.channel === "sms" ? "sms" : "email"
   const message = {
     channelAccountId: input.channelAccountId,
+    channel,
     target: { type: "@voyant-travel/conversations#part" as const, id: "" },
     purpose: "conversation-reply" as const,
     idempotencyKey: input.idempotencyKey,
     to: conversation.customerAddress,
-    ...(conversation.subject ? { subject: conversation.subject } : {}),
+    ...(channel === "email" && conversation.subject ? { subject: conversation.subject } : {}),
     ...(input.text ? { text: input.text } : {}),
     ...(sanitizedHtml ? { sanitizedHtml } : {}),
     ...(attachments.length > 0
@@ -867,11 +1257,15 @@ async function admitReplyWithinTransaction(
         ? { replyToDeliveryId: lastOutbound.notificationDeliveryId }
         : {}),
     },
-    metadata: {
-      replyAlias: conversation.replyAlias,
-      inReplyTo: lastPart?.messageId ?? null,
-      references,
-    },
+    ...(channel === "email"
+      ? {
+          metadata: {
+            ...(conversation.replyAlias ? { replyAlias: conversation.replyAlias } : {}),
+            inReplyTo: lastPart?.messageId ?? null,
+            references,
+          },
+        }
+      : {}),
   }
   const fingerprint = conversationReplyFingerprint(message)
   const partId = newId("conversation_parts")
@@ -884,14 +1278,14 @@ async function admitReplyWithinTransaction(
       conversationId: conversation.id,
       sequence: await nextSequence(tx, conversation.id),
       direction: "outbound",
-      senderAddress: conversation.replyAlias,
+      senderAddress: conversation.localAddress ?? conversation.replyAlias ?? "",
       recipientAddresses: [conversation.customerAddress],
       subject: conversation.subject,
       textBody: input.text,
       htmlBody: sanitizedHtml,
       payloadFingerprint: fingerprint,
       idempotencyKey: input.idempotencyKey,
-      deliveryStatus: "pending",
+      admissionStatus: "pending",
       occurredAt: now,
       inReplyTo: lastPart?.messageId ?? null,
       references,
@@ -929,7 +1323,7 @@ async function admitReplyWithinTransaction(
     .update(conversationParts)
     .set({
       notificationDeliveryId: admitted.deliveryId,
-      deliveryStatus: admitted.state,
+      admissionStatus: admitted.state === "suppressed" ? "suppressed" : "admitted",
     })
     .where(eq(conversationParts.id, partId))
     .returning()
@@ -1023,6 +1417,7 @@ export async function updateConversationState(
       .set({
         ...(input.status ? { status: input.status } : {}),
         ...(input.status ? { snoozedUntil } : {}),
+        ...(input.status ? { closedAt: input.status === "closed" ? new Date() : null } : {}),
         ...(input.priority ? { priority: input.priority } : {}),
         ...(input.assignedToUserId !== undefined
           ? { assignedToUserId: input.assignedToUserId }

--- a/packages/conversations/src/threading.ts
+++ b/packages/conversations/src/threading.ts
@@ -1,4 +1,8 @@
-import { canonicalMessageId, normalizeEmailAddress } from "@voyant-travel/conversations-contracts"
+import {
+  canonicalMessageId,
+  normalizeE164,
+  normalizeEmailAddress,
+} from "@voyant-travel/conversations-contracts"
 
 export class ConversationThreadConflictError extends Error {
   readonly code = "ambiguous_thread"
@@ -34,4 +38,16 @@ export function createReplyAlias(conversationId: string, receivingAddress: strin
   if (separator <= 0)
     throw new Error("Cannot derive a reply alias from an invalid receiving address")
   return `${normalized.slice(0, separator)}+${conversationId}@${normalized.slice(separator + 1)}`
+}
+
+export const SMS_RECENTLY_CLOSED_REOPEN_DAYS = 30
+
+/** Account identity is part of the key: two local numbers never share an SMS thread. */
+export function smsConversationPairKey(channelAccountId: string, remoteAddress: string): string {
+  return `${channelAccountId}\u0000${normalizeE164(remoteAddress)}`
+}
+
+export function isSmsConversationRecentlyClosed(closedAt: Date, inboundAt: Date): boolean {
+  const age = inboundAt.getTime() - closedAt.getTime()
+  return age >= 0 && age <= SMS_RECENTLY_CLOSED_REOPEN_DAYS * 24 * 60 * 60 * 1_000
 }

--- a/packages/conversations/src/voyant.ts
+++ b/packages/conversations/src/voyant.ts
@@ -3,7 +3,9 @@ import { defineModule, requirePort } from "@voyant-travel/core/project"
 import {
   conversationIngressSourcePort,
   conversationsAttachmentRuntimePort,
+  conversationsChannelPolicyPort,
   conversationsDatabaseRuntimePort,
+  conversationsDeliveryTruthPort,
   conversationsPersonDirectoryPort,
   conversationsRenderedMessageAdmissionPort,
 } from "./runtime-port.js"
@@ -40,6 +42,8 @@ export const conversationsVoyantModule = defineModule({
     requirePort(conversationsPersonDirectoryPort, { optional: true }),
     requirePort(staffDirectoryRuntimePort),
     requirePort(conversationsAttachmentRuntimePort, { optional: true }),
+    requirePort(conversationsChannelPolicyPort, { optional: true }),
+    requirePort(conversationsDeliveryTruthPort, { optional: true }),
   ],
   api: [
     {

--- a/packages/conversations/tests/integration/attachment-security.test.ts
+++ b/packages/conversations/tests/integration/attachment-security.test.ts
@@ -52,6 +52,7 @@ describe("attachment security state transitions", () => {
     `)
     await client.exec(readMigration("0001_collaboration.sql"))
     await client.exec(readMigration("0002_secure_content.sql"))
+    await client.exec(readMigration("0003_sms_conversations.sql"))
     await client.exec(`
       CREATE TABLE "event_outbox" (
         "id" text PRIMARY KEY,
@@ -363,7 +364,7 @@ async function seedConversation(
     htmlBody: "<p>Original body</p>",
     messageId: "root-message",
     payloadFingerprint: "fingerprint",
-    deliveryStatus: "received",
+    admissionStatus: "received",
     occurredAt: now,
     createdAt: now,
   })

--- a/packages/conversations/tests/integration/collaboration.test.ts
+++ b/packages/conversations/tests/integration/collaboration.test.ts
@@ -66,7 +66,7 @@ describe.skipIf(!DB_AVAILABLE)("Inbox collaboration persistence", () => {
         senderAddress: "customer@example.test",
         recipientAddresses: ["reply@example.test"],
         payloadFingerprint: "one",
-        deliveryStatus: "received",
+        admissionStatus: "received",
         occurredAt: new Date("2026-08-18T10:00:00.000Z"),
       },
       {
@@ -76,7 +76,7 @@ describe.skipIf(!DB_AVAILABLE)("Inbox collaboration persistence", () => {
         senderAddress: "customer@example.test",
         recipientAddresses: ["reply@example.test"],
         payloadFingerprint: "two",
-        deliveryStatus: "received",
+        admissionStatus: "received",
         occurredAt: new Date("2026-08-18T10:01:00.000Z"),
       },
     ])

--- a/packages/conversations/tests/integration/ingress-job.test.ts
+++ b/packages/conversations/tests/integration/ingress-job.test.ts
@@ -66,4 +66,19 @@ describe("durable ingress list/fetch/ack", () => {
     expect(ingest).not.toHaveBeenCalled()
     expect(source.ack).not.toHaveBeenCalled()
   })
+
+  it("rejects an envelope claimed by a different ingress source", async () => {
+    const source = {
+      id: "different-source",
+      list: vi.fn(async () => ({ items: [{ id: "env-1" }] })),
+      fetch: vi.fn(async () => envelope),
+      ack: vi.fn(async () => undefined),
+    }
+    const ingest = vi.fn()
+    await expect(
+      processConversationIngress({ db: {} as never, sources: [source], ingest }),
+    ).rejects.toThrow("does not match")
+    expect(ingest).not.toHaveBeenCalled()
+    expect(source.ack).not.toHaveBeenCalled()
+  })
 })

--- a/packages/conversations/tests/integration/sms-conversations.test.ts
+++ b/packages/conversations/tests/integration/sms-conversations.test.ts
@@ -1,0 +1,212 @@
+import type { InboundSmsEnvelopeV1 } from "@voyant-travel/conversations-contracts"
+import { createTestDb } from "@voyant-travel/db/test-utils"
+import { eq, sql } from "drizzle-orm"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { ConversationsChannelPolicy } from "../../src/runtime-port.js"
+import { conversationEvents, conversationParts, conversations } from "../../src/schema.js"
+import {
+  ConversationConflictError,
+  ingestEnvelope,
+  replyToConversation,
+  startConversation,
+} from "../../src/service.js"
+
+const DB_AVAILABLE = !!(globalThis as { process?: { env?: Record<string, string | undefined> } })
+  .process?.env?.TEST_DATABASE_URL
+const db = DB_AVAILABLE ? createTestDb() : (null as never)
+
+function sms(
+  externalMessageId: string,
+  overrides: Partial<InboundSmsEnvelopeV1> = {},
+): InboundSmsEnvelopeV1 {
+  return {
+    version: "1",
+    channel: "sms",
+    sourceId: "fixture-source",
+    externalEnvelopeId: `envelope-${externalMessageId}`,
+    externalMessageId,
+    channelAccountId: "ncha_fixture_1",
+    receivingAddress: "+12025550100",
+    senderAddress: "+12025550123",
+    text: "Hello",
+    attachments: [],
+    policyEvent: null,
+    adapterHandledResponse: false,
+    occurredAt: "2026-08-17T10:00:00.000Z",
+    ...overrides,
+  }
+}
+
+const readyPolicy: ConversationsChannelPolicy = {
+  async inspectInboundSms(_db, envelope) {
+    return {
+      kind: "ready",
+      accountId: envelope.channelAccountId,
+      normalizedAddress: envelope.receivingAddress,
+    }
+  },
+  async projectInboundSmsPolicy() {},
+  async getOutboundSmsState() {
+    return {
+      normalizedAddress: "+12025550100",
+      health: "healthy",
+      available: true,
+      attachmentsCapable: false,
+      suppressed: false,
+    }
+  },
+}
+
+describe.skipIf(!DB_AVAILABLE)("SMS conversation integration", () => {
+  beforeEach(async () => {
+    await db.execute(sql`
+      TRUNCATE
+        conversation_ingress_operations,
+        conversation_events,
+        conversation_parts,
+        conversation_participants,
+        conversations
+      CASCADE
+    `)
+  })
+
+  it("fails closed for an ambiguous receiving identity", async () => {
+    const policy: ConversationsChannelPolicy = {
+      ...readyPolicy,
+      async inspectInboundSms() {
+        return { kind: "ambiguous" }
+      },
+    }
+    await expect(
+      ingestEnvelope(db, sms("ambiguous"), { channelPolicy: policy }),
+    ).rejects.toBeInstanceOf(ConversationConflictError)
+    expect(await db.select().from(conversationParts)).toHaveLength(0)
+  })
+
+  it("resolves the remote phone through the channel-aware read-only Person port", async () => {
+    const resolvePhone = vi.fn(async () => ({
+      kind: "unique" as const,
+      personRef: "pers_fixture",
+      contactPointRef: "icpt_fixture",
+      address: "+12025550123",
+    }))
+    const result = await ingestEnvelope(db, sms("person-resolution"), {
+      channelPolicy: readyPolicy,
+      personDirectory: {
+        resolveEmail: async () => ({ kind: "none" }),
+        resolvePhone,
+        resolvePersonContactPoint: async () => null,
+      },
+    })
+    expect(resolvePhone).toHaveBeenCalledWith(expect.anything(), "+12025550123")
+    const [conversation] = await db
+      .select()
+      .from(conversations)
+      .where(eq(conversations.id, result.conversationId))
+    expect(conversation).toMatchObject({
+      personRef: "pers_fixture",
+      contactPointRef: "icpt_fixture",
+    })
+  })
+
+  it("commits duplicate ingress once and converges concurrent messages on one account pair", async () => {
+    const first = await ingestEnvelope(db, sms("duplicate"), { channelPolicy: readyPolicy })
+    const replay = await ingestEnvelope(db, sms("duplicate"), { channelPolicy: readyPolicy })
+    expect(replay).toEqual({ ...first, duplicate: true })
+
+    const [left, right] = await Promise.all([
+      ingestEnvelope(db, sms("concurrent-left"), { channelPolicy: readyPolicy }),
+      ingestEnvelope(db, sms("concurrent-right"), { channelPolicy: readyPolicy }),
+    ])
+    expect(left.conversationId).toBe(first.conversationId)
+    expect(right.conversationId).toBe(first.conversationId)
+    expect(await db.select().from(conversations)).toHaveLength(1)
+    expect(await db.select().from(conversationParts)).toHaveLength(3)
+    expect(await db.select().from(conversationEvents)).toHaveLength(3)
+  })
+
+  it("separates Channel Accounts and reopens only a recently closed pair", async () => {
+    const first = await ingestEnvelope(db, sms("first"), { channelPolicy: readyPolicy })
+    await db
+      .update(conversations)
+      .set({ status: "closed", closedAt: new Date("2026-07-20T10:00:00.000Z") })
+      .where(eq(conversations.id, first.conversationId))
+    const reopened = await ingestEnvelope(db, sms("recent"), { channelPolicy: readyPolicy })
+    expect(reopened.conversationId).toBe(first.conversationId)
+
+    await db
+      .update(conversations)
+      .set({ status: "closed", closedAt: new Date("2026-07-01T10:00:00.000Z") })
+      .where(eq(conversations.id, first.conversationId))
+    const newer = await ingestEnvelope(db, sms("old-closed"), { channelPolicy: readyPolicy })
+    expect(newer.conversationId).not.toBe(first.conversationId)
+
+    const otherAccount = await ingestEnvelope(
+      db,
+      sms("other-account", {
+        channelAccountId: "ncha_fixture_2",
+        receivingAddress: "+12025550101",
+      }),
+      { channelPolicy: readyPolicy },
+    )
+    expect(otherAccount.conversationId).not.toBe(newer.conversationId)
+  })
+
+  it("does not regress thread ordering when an older message arrives late", async () => {
+    const recent = await ingestEnvelope(
+      db,
+      sms("recent-order", { occurredAt: "2026-08-17T11:00:00.000Z" }),
+      { channelPolicy: readyPolicy },
+    )
+    await ingestEnvelope(db, sms("late-order", { occurredAt: "2026-08-17T09:00:00.000Z" }), {
+      channelPolicy: readyPolicy,
+    })
+    const [conversation] = await db
+      .select()
+      .from(conversations)
+      .where(eq(conversations.id, recent.conversationId))
+    expect(conversation?.lastPartAt.toISOString()).toBe("2026-08-17T11:00:00.000Z")
+  })
+
+  it("admits a retry-safe reply once and keeps only admission truth on the Part", async () => {
+    const inbound = await ingestEnvelope(db, sms("reply"), { channelPolicy: readyPolicy })
+    const admit = vi.fn(async () => ({ deliveryId: "ntdl_fixture", state: "pending" as const }))
+    const input = {
+      conversationId: inbound.conversationId,
+      actor: { userId: "user_fixture" },
+      channelAccountId: "ncha_fixture_1",
+      text: "A reply",
+      idempotencyKey: "reply-once",
+    }
+    const first = await replyToConversation(db, { admitRenderedServiceMessage: admit }, input)
+    const replay = await replyToConversation(db, { admitRenderedServiceMessage: admit }, input)
+    expect(replay.id).toBe(first.id)
+    expect(first.admissionStatus).toBe("admitted")
+    expect(admit).toHaveBeenCalledOnce()
+  })
+
+  it("derives the SMS sender from the authoritative Channel Account", async () => {
+    const admit = vi.fn(async () => ({ deliveryId: "ntdl_start", state: "pending" as const }))
+    const detail = await startConversation(
+      db,
+      { admitRenderedServiceMessage: admit },
+      {
+        resolveEmail: async () => ({ kind: "none" }),
+        resolvePersonContactPoint: async () => ({ address: "+12025550123" }),
+      },
+      {
+        channel: "sms",
+        inboxId: "cinb_fixture",
+        actor: { userId: "user_fixture" },
+        personRef: "pers_fixture",
+        contactPointRef: "icpt_fixture",
+        channelAccountId: "ncha_fixture_1",
+        text: "Hello",
+        idempotencyKey: "start-authoritative-sender",
+      },
+      readyPolicy,
+    )
+    expect(detail.conversation.localAddress).toBe("+12025550100")
+    expect(detail.parts[0]?.senderAddress).toBe("+12025550100")
+  })
+})

--- a/packages/conversations/tests/integration/sms-migration-upgrade.test.ts
+++ b/packages/conversations/tests/integration/sms-migration-upgrade.test.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from "node:crypto"
+import { readFile } from "node:fs/promises"
+
+import { createDbClient } from "@voyant-travel/db"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it } from "vitest"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+type UnsafeClient = {
+  unsafe<T = unknown>(query: string): Promise<T>
+  end(options?: { timeout?: number | null }): Promise<unknown>
+}
+
+describe.skipIf(!DB_AVAILABLE)("SMS conversations migration upgrade", () => {
+  it("applies the real baseline then converts legacy delivery truth to admission truth", async () => {
+    const schemaName = `conversation_sms_upgrade_${randomUUID().replaceAll("-", "")}`
+    const db = createDbClient(process.env.TEST_DATABASE_URL as string, {
+      adapter: "node",
+      nodeMaxConnections: 1,
+      timeouts: { statementMs: false, queryMs: false, connectMs: false },
+    }) as PostgresJsDatabase & { $client: UnsafeClient }
+    const client = db.$client
+    try {
+      await client.unsafe(`CREATE SCHEMA "${schemaName}"`)
+      await client.unsafe(`SET search_path TO "${schemaName}", public`)
+      const baseline = await readFile(
+        new URL("../../migrations/0000_conversations_baseline.sql", import.meta.url),
+        "utf8",
+      )
+      await client.unsafe(baseline.replaceAll('"public".', `"${schemaName}".`))
+      await client.unsafe(`
+        INSERT INTO conversations (
+          id, reply_alias, customer_address, last_part_at
+        ) VALUES (
+          'conv_upgrade', 'reply@example.test', 'customer@example.test', now()
+        );
+        INSERT INTO conversation_parts (
+          id, conversation_id, direction, sender_address, recipient_addresses,
+          payload_fingerprint, delivery_status, occurred_at
+        ) VALUES (
+          'cvpa_upgrade', 'conv_upgrade', 'outbound', 'reply@example.test',
+          '["customer@example.test"]'::jsonb, 'fingerprint', 'delivered', now()
+        );
+      `)
+      const smsMigration = await readFile(
+        new URL("../../migrations/0001_sms_conversations.sql", import.meta.url),
+        "utf8",
+      )
+      await client.unsafe(smsMigration.replaceAll('"public".', `"${schemaName}".`))
+      const rows = await client.unsafe<
+        Array<{ admission_status: string; closed_at: Date | null }>
+      >(`
+        SELECT p.admission_status::text AS admission_status, c.closed_at
+        FROM conversation_parts p
+        JOIN conversations c ON c.id = p.conversation_id
+      `)
+      expect(rows).toEqual([{ admission_status: "admitted", closed_at: null }])
+    } finally {
+      await client.unsafe(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+      await client.end({ timeout: 0 })
+    }
+  })
+})

--- a/packages/conversations/tests/unit/threading.test.ts
+++ b/packages/conversations/tests/unit/threading.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest"
 import { conversationReplyFingerprint } from "../../src/service.js"
-import { createReplyAlias, inboundThreadIds, selectExactConversation } from "../../src/threading.js"
+import {
+  createReplyAlias,
+  inboundThreadIds,
+  isSmsConversationRecentlyClosed,
+  selectExactConversation,
+  smsConversationPairKey,
+} from "../../src/threading.js"
 
 describe("exact email threading", () => {
   it("selects an exact alias or standard header identity", () => {
@@ -30,6 +36,31 @@ describe("exact email threading", () => {
     ).toEqual(["first@example.test", "second@example.test"])
     expect(createReplyAlias("conv_opaque", "Inbox@Example.Test")).toBe(
       "inbox+conv_opaque@example.test",
+    )
+  })
+})
+
+describe("SMS pair threading", () => {
+  it("separates Channel Accounts and normalized remote numbers", () => {
+    expect(smsConversationPairKey("account_1", "+12025550123")).toBe(
+      smsConversationPairKey("account_1", " +12025550123 "),
+    )
+    expect(smsConversationPairKey("account_1", "+12025550123")).not.toBe(
+      smsConversationPairKey("account_2", "+12025550123"),
+    )
+    expect(() => smsConversationPairKey("account_1", "customer@example.test")).toThrow("E.164")
+  })
+
+  it("reopens at the 30-day boundary, but not older or future closed threads", () => {
+    const inbound = new Date("2026-08-17T10:00:00.000Z")
+    expect(isSmsConversationRecentlyClosed(new Date("2026-07-18T10:00:00.000Z"), inbound)).toBe(
+      true,
+    )
+    expect(isSmsConversationRecentlyClosed(new Date("2026-07-18T09:59:59.999Z"), inbound)).toBe(
+      false,
+    )
+    expect(isSmsConversationRecentlyClosed(new Date("2026-08-17T10:00:01.000Z"), inbound)).toBe(
+      false,
     )
   })
 })

--- a/packages/notifications-react/src/components/channel-accounts-list.tsx
+++ b/packages/notifications-react/src/components/channel-accounts-list.tsx
@@ -40,6 +40,8 @@ export function ChannelAccountsList() {
             <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
               {account.inboundCapable && <span>{copy.inbound}</span>}
               {account.outboundCapable && <span>{copy.outbound}</span>}
+              {account.inboundIdentity === "ambiguous" && <span>{copy.ambiguousInbound}</span>}
+              <span>{account.attachmentsCapable ? copy.attachments : copy.noAttachments}</span>
               {account.allowedPurposes.length > 0 && (
                 <span>
                   {copy.purposes}: {account.allowedPurposes.join(", ")}

--- a/packages/notifications-react/src/i18n/en.ts
+++ b/packages/notifications-react/src/i18n/en.ts
@@ -110,6 +110,9 @@ export const notificationsUiEn: NotificationsUiMessages = {
       empty: "No Channel Accounts are configured.",
       inbound: "Inbound",
       outbound: "Outbound",
+      ambiguousInbound: "Inbound identity needs attention",
+      attachments: "Attachments supported",
+      noAttachments: "No attachments",
       purposes: "Purposes",
     },
     sections: {

--- a/packages/notifications-react/src/i18n/messages.ts
+++ b/packages/notifications-react/src/i18n/messages.ts
@@ -108,6 +108,9 @@ export type NotificationsUiMessages = {
       empty: string
       inbound: string
       outbound: string
+      ambiguousInbound: string
+      attachments: string
+      noAttachments: string
       purposes: string
     }
     sections: {

--- a/packages/notifications-react/src/i18n/ro.ts
+++ b/packages/notifications-react/src/i18n/ro.ts
@@ -111,6 +111,9 @@ export const notificationsUiRo: NotificationsUiMessages = {
       empty: "Nu este configurat niciun cont de canal.",
       inbound: "Intrare",
       outbound: "Ieșire",
+      ambiguousInbound: "Identitatea de intrare necesită atenție",
+      attachments: "Atașamente acceptate",
+      noAttachments: "Fără atașamente",
       purposes: "Scopuri",
     },
     sections: {

--- a/packages/notifications-react/src/schemas.ts
+++ b/packages/notifications-react/src/schemas.ts
@@ -83,6 +83,8 @@ export const notificationChannelAccountRecordSchema = z.object({
   health: z.enum(["unknown", "healthy", "degraded", "unavailable"]),
   inboundCapable: z.boolean(),
   outboundCapable: z.boolean(),
+  inboundIdentity: z.enum(["unambiguous", "ambiguous"]).nullable(),
+  attachmentsCapable: z.boolean(),
   allowedPurposes: z.array(z.string()),
   lastValidatedAt: z.string().nullable(),
   createdAt: z.string(),

--- a/packages/notifications/migrations/0006_sms_transport_policy.sql
+++ b/packages/notifications/migrations/0006_sms_transport_policy.sql
@@ -1,0 +1,30 @@
+CREATE TABLE "sms_transport_policies" (
+	"id" text PRIMARY KEY NOT NULL,
+	"channel_account_id" text NOT NULL,
+	"destination_address" text NOT NULL,
+	"state" text NOT NULL,
+	"last_event_occurred_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sms_transport_policy_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"channel_account_id" text NOT NULL,
+	"destination_address" text NOT NULL,
+	"source_id" text NOT NULL,
+	"external_message_id" text NOT NULL,
+	"kind" text NOT NULL,
+	"adapter_handled_response" boolean DEFAULT false NOT NULL,
+	"occurred_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "notification_channel_accounts" ADD COLUMN "inbound_identity" text DEFAULT null;--> statement-breakpoint
+ALTER TABLE "notification_channel_accounts" ADD COLUMN "inbound_source_id" text;--> statement-breakpoint
+ALTER TABLE "notification_channel_accounts" ADD COLUMN "attachments_capable" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "sms_transport_policies" ADD CONSTRAINT "sms_transport_policies_channel_account_id_notification_channel_accounts_id_fk" FOREIGN KEY ("channel_account_id") REFERENCES "public"."notification_channel_accounts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_transport_policy_events" ADD CONSTRAINT "sms_transport_policy_events_channel_account_id_notification_channel_accounts_id_fk" FOREIGN KEY ("channel_account_id") REFERENCES "public"."notification_channel_accounts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_sms_transport_policy_scope" ON "sms_transport_policies" USING btree ("channel_account_id","destination_address");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_sms_transport_policy_event_external" ON "sms_transport_policy_events" USING btree ("source_id","external_message_id");--> statement-breakpoint
+CREATE INDEX "idx_sms_transport_policy_events_scope" ON "sms_transport_policy_events" USING btree ("channel_account_id","destination_address","occurred_at");

--- a/packages/notifications/migrations/meta/0006_snapshot.json
+++ b/packages/notifications/migrations/meta/0006_snapshot.json
@@ -1,0 +1,2980 @@
+{
+  "id": "8193874c-c327-4a30-b874-893475bff501",
+  "prevId": "662b1cbd-94c0-4623-864a-d252bd490bc2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.notification_channel_accounts": {
+      "name": "notification_channel_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_address": {
+          "name": "normalized_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_address": {
+          "name": "display_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifecycle": {
+          "name": "lifecycle",
+          "type": "channel_account_lifecycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "health": {
+          "name": "health",
+          "type": "channel_account_health",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "inbound_capable": {
+          "name": "inbound_capable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "outbound_capable": {
+          "name": "outbound_capable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "inbound_identity": {
+          "name": "inbound_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "inbound_source_id": {
+          "name": "inbound_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments_capable": {
+          "name": "attachments_capable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_purposes": {
+          "name": "allowed_purposes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "adapter_ref": {
+          "name": "adapter_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_notification_channel_accounts_channel_address": {
+          "name": "uidx_notification_channel_accounts_channel_address",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_notification_channel_accounts_adapter_ref": {
+          "name": "uidx_notification_channel_accounts_adapter_ref",
+          "columns": [
+            {
+              "expression": "adapter_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_channel_accounts_lifecycle_health": {
+          "name": "idx_notification_channel_accounts_lifecycle_health",
+          "columns": [
+            {
+              "expression": "lifecycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "health",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_account_id": {
+          "name": "channel_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_slug": {
+          "name": "template_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "notification_target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualified_target_type": {
+          "name": "qualified_target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_session_id": {
+          "name": "payment_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_data": {
+          "name": "payload_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_deliveries_created": {
+          "name": "idx_notification_deliveries_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_channel_account_created": {
+          "name": "idx_notification_deliveries_channel_account_created",
+          "columns": [
+            {
+              "expression": "channel_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_template_created": {
+          "name": "idx_notification_deliveries_template_created",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_target_created": {
+          "name": "idx_notification_deliveries_target_created",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_person_created": {
+          "name": "idx_notification_deliveries_person_created",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_org_created": {
+          "name": "idx_notification_deliveries_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_booking_created": {
+          "name": "idx_notification_deliveries_booking_created",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_invoice_created": {
+          "name": "idx_notification_deliveries_invoice_created",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_payment_session_created": {
+          "name": "idx_notification_deliveries_payment_session_created",
+          "columns": [
+            {
+              "expression": "payment_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_channel_created": {
+          "name": "idx_notification_deliveries_channel_created",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_provider_created": {
+          "name": "idx_notification_deliveries_provider_created",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_status_created": {
+          "name": "idx_notification_deliveries_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_scheduled_for": {
+          "name": "idx_notification_deliveries_scheduled_for",
+          "columns": [
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_channel_account_id_notification_channel_accounts_id_fk": {
+          "name": "notification_deliveries_channel_account_id_notification_channel_accounts_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_channel_accounts",
+          "columnsFrom": [
+            "channel_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_template_id_notification_templates_id_fk": {
+          "name": "notification_deliveries_template_id_notification_templates_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery_events": {
+      "name": "notification_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter_ref": {
+          "name": "adapter_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter_event_id": {
+          "name": "adapter_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_delivery_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_notification_delivery_events_adapter_event": {
+          "name": "uidx_notification_delivery_events_adapter_event",
+          "columns": [
+            {
+              "expression": "adapter_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "adapter_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_delivery_events_delivery_occurred": {
+          "name": "idx_notification_delivery_events_delivery_occurred",
+          "columns": [
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_events_delivery_id_notification_deliveries_id_fk": {
+          "name": "notification_delivery_events_delivery_id_notification_deliveries_id_fk",
+          "tableFrom": "notification_delivery_events",
+          "tableTo": "notification_deliveries",
+          "columnsFrom": [
+            "delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_reminder_rule_authoring_requests": {
+      "name": "notification_reminder_rule_authoring_requests",
+      "schema": "",
+      "columns": {
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reminder_rule_id": {
+          "name": "reminder_rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_reminder_rule_authoring_rule": {
+          "name": "idx_notification_reminder_rule_authoring_rule",
+          "columns": [
+            {
+              "expression": "reminder_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_reminder_rule_authoring_requests_reminder_rule_id_notification_reminder_rules_id_fk": {
+          "name": "notification_reminder_rule_authoring_requests_reminder_rule_id_notification_reminder_rules_id_fk",
+          "tableFrom": "notification_reminder_rule_authoring_requests",
+          "tableTo": "notification_reminder_rules",
+          "columnsFrom": [
+            "reminder_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_reminder_rule_stages": {
+      "name": "notification_reminder_rule_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reminder_rule_id": {
+          "name": "reminder_rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "notification_reminder_stage_anchor",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start_days": {
+          "name": "window_start_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end_days": {
+          "name": "window_end_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cadence_kind": {
+          "name": "cadence_kind",
+          "type": "notification_reminder_stage_cadence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cadence_every_days": {
+          "name": "cadence_every_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cadence_intervals": {
+          "name": "cadence_intervals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_sends_in_stage": {
+          "name": "max_sends_in_stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respect_quiet_hours": {
+          "name": "respect_quiet_hours",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_notification_reminder_rule_stages_rule_order": {
+          "name": "uidx_notification_reminder_rule_stages_rule_order",
+          "columns": [
+            {
+              "expression": "reminder_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_rule_stages_rule": {
+          "name": "idx_notification_reminder_rule_stages_rule",
+          "columns": [
+            {
+              "expression": "reminder_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_rule_stages_anchor": {
+          "name": "idx_notification_reminder_rule_stages_anchor",
+          "columns": [
+            {
+              "expression": "anchor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_reminder_rule_stages_reminder_rule_id_notification_reminder_rules_id_fk": {
+          "name": "notification_reminder_rule_stages_reminder_rule_id_notification_reminder_rules_id_fk",
+          "tableFrom": "notification_reminder_rule_stages",
+          "tableTo": "notification_reminder_rules",
+          "columnsFrom": [
+            "reminder_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_reminder_rules": {
+      "name": "notification_reminder_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_reminder_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "notification_reminder_target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_slug": {
+          "name": "template_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suppression_group": {
+          "name": "suppression_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_reminder_rules_updated": {
+          "name": "idx_notification_reminder_rules_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_rules_status_updated": {
+          "name": "idx_notification_reminder_rules_status_updated",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_rules_target_updated": {
+          "name": "idx_notification_reminder_rules_target_updated",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_rules_channel_updated": {
+          "name": "idx_notification_reminder_rules_channel_updated",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_rules_priority": {
+          "name": "idx_notification_reminder_rules_priority",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_rules_suppression_group": {
+          "name": "idx_notification_reminder_rules_suppression_group",
+          "columns": [
+            {
+              "expression": "suppression_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_notification_reminder_rules_slug": {
+          "name": "uidx_notification_reminder_rules_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_reminder_rules_template_id_notification_templates_id_fk": {
+          "name": "notification_reminder_rules_template_id_notification_templates_id_fk",
+          "tableFrom": "notification_reminder_rules",
+          "tableTo": "notification_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_reminder_rules_slug_unique": {
+          "name": "notification_reminder_rules_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_reminder_runs": {
+      "name": "notification_reminder_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reminder_rule_id": {
+          "name": "reminder_rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "notification_reminder_target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_session_id": {
+          "name": "payment_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_delivery_id": {
+          "name": "notification_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_reminder_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_reminder_runs_created": {
+          "name": "idx_notification_reminder_runs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_runs_rule_created": {
+          "name": "idx_notification_reminder_runs_rule_created",
+          "columns": [
+            {
+              "expression": "reminder_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_runs_target_created": {
+          "name": "idx_notification_reminder_runs_target_created",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_runs_booking_created": {
+          "name": "idx_notification_reminder_runs_booking_created",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_runs_payment_session_created": {
+          "name": "idx_notification_reminder_runs_payment_session_created",
+          "columns": [
+            {
+              "expression": "payment_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_runs_delivery_created": {
+          "name": "idx_notification_reminder_runs_delivery_created",
+          "columns": [
+            {
+              "expression": "notification_delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_runs_person_created": {
+          "name": "idx_notification_reminder_runs_person_created",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_runs_org_created": {
+          "name": "idx_notification_reminder_runs_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_runs_recipient_created": {
+          "name": "idx_notification_reminder_runs_recipient_created",
+          "columns": [
+            {
+              "expression": "recipient",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_runs_status_created": {
+          "name": "idx_notification_reminder_runs_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_notification_reminder_runs_dedupe": {
+          "name": "uidx_notification_reminder_runs_dedupe",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_reminder_runs_reminder_rule_id_notification_reminder_rules_id_fk": {
+          "name": "notification_reminder_runs_reminder_rule_id_notification_reminder_rules_id_fk",
+          "tableFrom": "notification_reminder_runs",
+          "tableTo": "notification_reminder_rules",
+          "columnsFrom": [
+            "reminder_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_reminder_runs_notification_delivery_id_notification_deliveries_id_fk": {
+          "name": "notification_reminder_runs_notification_delivery_id_notification_deliveries_id_fk",
+          "tableFrom": "notification_reminder_runs",
+          "tableTo": "notification_deliveries",
+          "columnsFrom": [
+            "notification_delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_reminder_runs_dedupe_key_unique": {
+          "name": "notification_reminder_runs_dedupe_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dedupe_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_reminder_stage_channels": {
+      "name": "notification_reminder_stage_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_slug": {
+          "name": "template_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_kind": {
+          "name": "recipient_kind",
+          "type": "notification_stage_recipient_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "recipient_role": {
+          "name": "recipient_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_reminder_stage_channels_stage": {
+          "name": "idx_notification_reminder_stage_channels_stage",
+          "columns": [
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_reminder_stage_channels_template": {
+          "name": "idx_notification_reminder_stage_channels_template",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_reminder_stage_channels_stage_id_notification_reminder_rule_stages_id_fk": {
+          "name": "notification_reminder_stage_channels_stage_id_notification_reminder_rule_stages_id_fk",
+          "tableFrom": "notification_reminder_stage_channels",
+          "tableTo": "notification_reminder_rule_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_reminder_stage_channels_template_id_notification_templates_id_fk": {
+          "name": "notification_reminder_stage_channels_template_id_notification_templates_id_fk",
+          "tableFrom": "notification_reminder_stage_channels",
+          "tableTo": "notification_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_send_operations": {
+      "name": "notification_send_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "command_scope": {
+          "name": "command_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_action_id": {
+          "name": "claim_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_idempotency_key": {
+          "name": "provider_idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_payload": {
+          "name": "request_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_snapshot": {
+          "name": "result_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_event": {
+          "name": "terminal_event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_send_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_notification_send_operations_command": {
+          "name": "uidx_notification_send_operations_command",
+          "columns": [
+            {
+              "expression": "command_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_notification_send_operations_provider_key": {
+          "name": "uidx_notification_send_operations_provider_key",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_send_operations_due": {
+          "name": "idx_notification_send_operations_due",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_send_operations_delivery": {
+          "name": "idx_notification_send_operations_delivery",
+          "columns": [
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_send_operations_delivery_id_notification_deliveries_id_fk": {
+          "name": "notification_send_operations_delivery_id_notification_deliveries_id_fk",
+          "tableFrom": "notification_send_operations",
+          "tableTo": "notification_deliveries",
+          "columnsFrom": [
+            "delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_send_operations_claim_action_id_unique": {
+          "name": "notification_send_operations_claim_action_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "claim_action_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "quiet_hours_local": {
+          "name": "quiet_hours_local",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blackout_dates": {
+          "name": "blackout_dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_weekends": {
+          "name": "skip_weekends",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recipient_rate_limit_per_day": {
+          "name": "recipient_rate_limit_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_window_hours": {
+          "name": "suppression_window_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_notification_settings_scope": {
+          "name": "uidx_notification_settings_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_templates": {
+      "name": "notification_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_template_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subject_template": {
+          "name": "subject_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_template": {
+          "name": "html_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_template": {
+          "name": "text_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_templates_updated": {
+          "name": "idx_notification_templates_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_templates_channel_updated": {
+          "name": "idx_notification_templates_channel_updated",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_templates_provider_updated": {
+          "name": "idx_notification_templates_provider_updated",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_templates_status_updated": {
+          "name": "idx_notification_templates_status_updated",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_notification_templates_slug": {
+          "name": "uidx_notification_templates_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_templates_slug_unique": {
+          "name": "notification_templates_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_transport_policies": {
+      "name": "sms_transport_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_account_id": {
+          "name": "channel_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_address": {
+          "name": "destination_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_occurred_at": {
+          "name": "last_event_occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_sms_transport_policy_scope": {
+          "name": "uidx_sms_transport_policy_scope",
+          "columns": [
+            {
+              "expression": "channel_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_transport_policies_channel_account_id_notification_channel_accounts_id_fk": {
+          "name": "sms_transport_policies_channel_account_id_notification_channel_accounts_id_fk",
+          "tableFrom": "sms_transport_policies",
+          "tableTo": "notification_channel_accounts",
+          "columnsFrom": [
+            "channel_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_transport_policy_events": {
+      "name": "sms_transport_policy_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_account_id": {
+          "name": "channel_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_address": {
+          "name": "destination_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter_handled_response": {
+          "name": "adapter_handled_response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_sms_transport_policy_event_external": {
+          "name": "uidx_sms_transport_policy_event_external",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sms_transport_policy_events_scope": {
+          "name": "idx_sms_transport_policy_events_scope",
+          "columns": [
+            {
+              "expression": "channel_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_transport_policy_events_channel_account_id_notification_channel_accounts_id_fk": {
+          "name": "sms_transport_policy_events_channel_account_id_notification_channel_accounts_id_fk",
+          "tableFrom": "sms_transport_policy_events",
+          "tableTo": "notification_channel_accounts",
+          "columnsFrom": [
+            "channel_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_alert_preferences": {
+      "name": "staff_alert_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_staff_alert_preferences_user_event": {
+          "name": "uidx_staff_alert_preferences_user_event",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_staff_alert_preferences_event": {
+          "name": "idx_staff_alert_preferences_event",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_alert_settings": {
+      "name": "staff_alert_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "route_to_assignee": {
+          "name": "route_to_assignee",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "route_to_roles": {
+          "name": "route_to_roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "extra_addresses": {
+          "name": "extra_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_staff_alert_settings_event_key": {
+          "name": "uidx_staff_alert_settings_event_key",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.channel_account_health": {
+      "name": "channel_account_health",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "healthy",
+        "degraded",
+        "unavailable"
+      ]
+    },
+    "public.channel_account_lifecycle": {
+      "name": "channel_account_lifecycle",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "disabled",
+        "archived"
+      ]
+    },
+    "public.notification_channel": {
+      "name": "notification_channel",
+      "schema": "public",
+      "values": [
+        "email",
+        "sms"
+      ]
+    },
+    "public.notification_delivery_event_status": {
+      "name": "notification_delivery_event_status",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "delivered",
+        "failed",
+        "bounced",
+        "complained",
+        "suppressed",
+        "cancelled"
+      ]
+    },
+    "public.notification_delivery_status": {
+      "name": "notification_delivery_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "delivered",
+        "failed",
+        "bounced",
+        "complained",
+        "suppressed",
+        "cancelled"
+      ]
+    },
+    "public.notification_reminder_run_status": {
+      "name": "notification_reminder_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "sent",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.notification_reminder_stage_anchor": {
+      "name": "notification_reminder_stage_anchor",
+      "schema": "public",
+      "values": [
+        "due_date",
+        "booking_created_at",
+        "departure_date",
+        "invoice_issued_at",
+        "last_send_at"
+      ]
+    },
+    "public.notification_reminder_stage_cadence_kind": {
+      "name": "notification_reminder_stage_cadence_kind",
+      "schema": "public",
+      "values": [
+        "once",
+        "every_n_days",
+        "escalating"
+      ]
+    },
+    "public.notification_reminder_status": {
+      "name": "notification_reminder_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.notification_reminder_target_type": {
+      "name": "notification_reminder_target_type",
+      "schema": "public",
+      "values": [
+        "booking_confirmed",
+        "booking_payment_schedule",
+        "payment_complete",
+        "booking_cancelled_non_payment",
+        "invoice"
+      ]
+    },
+    "public.notification_send_operation_status": {
+      "name": "notification_send_operation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "retry",
+        "sent",
+        "dead_letter"
+      ]
+    },
+    "public.notification_stage_recipient_kind": {
+      "name": "notification_stage_recipient_kind",
+      "schema": "public",
+      "values": [
+        "primary",
+        "cc",
+        "bcc"
+      ]
+    },
+    "public.notification_target_type": {
+      "name": "notification_target_type",
+      "schema": "public",
+      "values": [
+        "booking",
+        "booking_payment_schedule",
+        "booking_guarantee",
+        "invoice",
+        "payment_session",
+        "person",
+        "organization",
+        "other"
+      ]
+    },
+    "public.notification_template_status": {
+      "name": "notification_template_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/notifications/migrations/meta/_journal.json
+++ b/packages/notifications/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1786978800000,
       "tag": "0005_channel_accounts",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1787010238233,
+      "tag": "0006_sms_transport_policy",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/notifications/src/conversations-runtime.ts
+++ b/packages/notifications/src/conversations-runtime.ts
@@ -1,8 +1,19 @@
+import type {
+  ConversationsChannelPolicy,
+  ConversationsDeliveryTruthReader,
+} from "@voyant-travel/conversations/runtime-port"
 import type { ConversationsRenderedMessageAdmission } from "@voyant-travel/conversations-contracts"
+import { inArray } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import type { NotificationsRuntimeProvider } from "./runtime-port.js"
+import { notificationDeliveries } from "./schema.js"
 import { admitRenderedServiceMessage } from "./service-channel-accounts.js"
+import {
+  getOutboundSmsState,
+  inspectInboundSmsAccount,
+  projectInboundSmsPolicy,
+} from "./service-sms-policy.js"
 import type { RenderedServiceMessage } from "./types.js"
 
 /**
@@ -25,6 +36,33 @@ export function createConversationsRenderedMessageAdmission(
         message satisfies RenderedServiceMessage,
       )
       return { deliveryId: delivery.id, state: delivery.status }
+    },
+  }
+}
+
+export function createConversationsChannelPolicy(): ConversationsChannelPolicy {
+  return {
+    inspectInboundSms(db, envelope) {
+      return inspectInboundSmsAccount(db as PostgresJsDatabase, envelope)
+    },
+    projectInboundSmsPolicy(db, envelope) {
+      return projectInboundSmsPolicy(db as PostgresJsDatabase, envelope)
+    },
+    getOutboundSmsState(db, input) {
+      return getOutboundSmsState(db as PostgresJsDatabase, input)
+    },
+  }
+}
+
+export function createConversationsDeliveryTruthReader(): ConversationsDeliveryTruthReader {
+  return {
+    async getDeliveryTruth(db, deliveryIds) {
+      if (deliveryIds.length === 0) return {}
+      const rows = await (db as PostgresJsDatabase)
+        .select({ id: notificationDeliveries.id, status: notificationDeliveries.status })
+        .from(notificationDeliveries)
+        .where(inArray(notificationDeliveries.id, [...new Set(deliveryIds)]))
+      return Object.fromEntries(rows.map((row) => [row.id, row.status]))
     },
   }
 }

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -68,6 +68,8 @@ export type {
   NotificationSendOperation,
   NotificationsApiModule,
   NotificationTemplate,
+  SmsTransportPolicy,
+  SmsTransportPolicyEvent,
   StaffAlertPreference,
   StaffAlertRoleRouting,
   StaffAlertSettings,
@@ -89,6 +91,8 @@ export {
   notificationTargetTypeEnum,
   notificationTemplateStatusEnum,
   notificationTemplates,
+  smsTransportPolicies,
+  smsTransportPolicyEvents,
   staffAlertPreferences,
   staffAlertSettings,
 } from "./schema.js"

--- a/packages/notifications/src/response-schemas.ts
+++ b/packages/notifications/src/response-schemas.ts
@@ -59,6 +59,8 @@ export const notificationChannelAccountSchema = z.object({
   health: channelAccountHealthSchema,
   inboundCapable: z.boolean(),
   outboundCapable: z.boolean(),
+  inboundIdentity: z.enum(["unambiguous", "ambiguous"]).nullable(),
+  attachmentsCapable: z.boolean(),
   allowedPurposes: z.array(z.string()),
   lastValidatedAt: isoTimestamp.nullable(),
   createdAt: isoTimestamp,

--- a/packages/notifications/src/routes.ts
+++ b/packages/notifications/src/routes.ts
@@ -190,6 +190,7 @@ const jsonMetadata = z.record(z.string(), z.unknown())
 
 function toChannelAccountResponse({
   adapterRef: _adapterRef,
+  inboundSourceId: _inboundSourceId,
   ...account
 }: NotificationChannelAccount) {
   return account

--- a/packages/notifications/src/runtime-contributor.ts
+++ b/packages/notifications/src/runtime-contributor.ts
@@ -1,4 +1,8 @@
-import { conversationsRenderedMessageAdmissionPort } from "@voyant-travel/conversations/runtime-port"
+import {
+  conversationsChannelPolicyPort,
+  conversationsDeliveryTruthPort,
+  conversationsRenderedMessageAdmissionPort,
+} from "@voyant-travel/conversations/runtime-port"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type { VoyantPort } from "@voyant-travel/core/project"
 import {
@@ -12,7 +16,11 @@ import {
   proposalsNotificationsRuntimePort,
 } from "@voyant-travel/proposals/runtime-port"
 import { relationshipsPersonNotificationsRuntimePort } from "@voyant-travel/relationships/runtime-port"
-import { createConversationsRenderedMessageAdmission } from "./conversations-runtime.js"
+import {
+  createConversationsChannelPolicy,
+  createConversationsDeliveryTruthReader,
+  createConversationsRenderedMessageAdmission,
+} from "./conversations-runtime.js"
 import { toCustomerVerificationNotificationProviders } from "./customer-verification-runtime.js"
 import {
   type DurableNotificationProviderRuntime,
@@ -49,6 +57,8 @@ export function createNotificationsRuntimePortContribution(
     [notificationsRuntimePort.id]: runtime,
     [conversationsRenderedMessageAdmissionPort.id]:
       createConversationsRenderedMessageAdmission(runtime),
+    [conversationsChannelPolicyPort.id]: createConversationsChannelPolicy(),
+    [conversationsDeliveryTruthPort.id]: createConversationsDeliveryTruthReader(),
     [notificationsReminderJobRuntimePort.id]: runtime.resolveReminderJobRuntime(undefined),
     [customerVerificationRuntimePort.id]: verification,
     [financeNotificationsRuntimePort.id]: createFinanceNotificationsRuntime(

--- a/packages/notifications/src/schema.ts
+++ b/packages/notifications/src/schema.ts
@@ -161,6 +161,12 @@ export const notificationChannelAccounts = pgTable(
     health: channelAccountHealthEnum("health").notNull().default("unknown"),
     inboundCapable: boolean("inbound_capable").notNull().default(false),
     outboundCapable: boolean("outbound_capable").notNull().default(false),
+    inboundIdentity: text("inbound_identity")
+      .$type<"unambiguous" | "ambiguous" | null>()
+      .default(null),
+    /** Opaque runtime source id authorized to deliver inbound traffic for this identity. */
+    inboundSourceId: text("inbound_source_id"),
+    attachmentsCapable: boolean("attachments_capable").notNull().default(false),
     allowedPurposes: jsonb("allowed_purposes").$type<string[]>().notNull().default([]),
     adapterRef: text("adapter_ref").notNull(),
     lastValidatedAt: timestamp("last_validated_at", { withTimezone: true }),
@@ -179,6 +185,60 @@ export const notificationChannelAccounts = pgTable(
 
 export type NotificationChannelAccount = typeof notificationChannelAccounts.$inferSelect
 export type NewNotificationChannelAccount = typeof notificationChannelAccounts.$inferInsert
+
+/** Current hard SMS consent authority, scoped to one sending identity and destination. */
+export const smsTransportPolicies = pgTable(
+  "sms_transport_policies",
+  {
+    id: typeId("sms_transport_policies"),
+    channelAccountId: typeIdRef("channel_account_id")
+      .notNull()
+      .references(() => notificationChannelAccounts.id, { onDelete: "cascade" }),
+    destinationAddress: text("destination_address").notNull(),
+    state: text("state").$type<"allowed" | "hard_opt_out">().notNull(),
+    lastEventOccurredAt: timestamp("last_event_occurred_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uidx_sms_transport_policy_scope").on(
+      table.channelAccountId,
+      table.destinationAddress,
+    ),
+  ],
+)
+
+/** Immutable inbound opt-in/opt-out ledger; adapter replay cannot project twice. */
+export const smsTransportPolicyEvents = pgTable(
+  "sms_transport_policy_events",
+  {
+    id: typeId("sms_transport_policy_events"),
+    channelAccountId: typeIdRef("channel_account_id")
+      .notNull()
+      .references(() => notificationChannelAccounts.id, { onDelete: "cascade" }),
+    destinationAddress: text("destination_address").notNull(),
+    sourceId: text("source_id").notNull(),
+    externalMessageId: text("external_message_id").notNull(),
+    kind: text("kind").$type<"hard_opt_out" | "opt_in">().notNull(),
+    adapterHandledResponse: boolean("adapter_handled_response").notNull().default(false),
+    occurredAt: timestamp("occurred_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uidx_sms_transport_policy_event_external").on(
+      table.sourceId,
+      table.externalMessageId,
+    ),
+    index("idx_sms_transport_policy_events_scope").on(
+      table.channelAccountId,
+      table.destinationAddress,
+      table.occurredAt,
+    ),
+  ],
+)
+
+export type SmsTransportPolicy = typeof smsTransportPolicies.$inferSelect
+export type SmsTransportPolicyEvent = typeof smsTransportPolicyEvents.$inferSelect
 
 export const notificationDeliveries = pgTable(
   "notification_deliveries",

--- a/packages/notifications/src/service-channel-accounts.ts
+++ b/packages/notifications/src/service-channel-accounts.ts
@@ -1,3 +1,4 @@
+import { normalizeE164 } from "@voyant-travel/conversations-contracts"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 import { desc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -9,6 +10,7 @@ import {
 } from "./schema.js"
 import { enqueueNotification } from "./service-durable-send.js"
 import { createNotificationService, NotificationError } from "./service-shared.js"
+import { assertSmsAdmissionAllowed } from "./service-sms-policy.js"
 import type {
   ChannelAccountDraft,
   NormalizedNotificationDeliveryEvent,
@@ -48,17 +50,33 @@ export async function provisionChannelAccount(
     allowedPurposes: normalizePurposes(draft.allowedPurposes),
   })
   const validation = await capability.validate(provisioned.adapterRef)
+  const normalizedAddress =
+    draft.channel === "sms"
+      ? normalizeE164(provisioned.normalizedAddress)
+      : provisioned.normalizedAddress
+  if (
+    draft.channel === "sms" &&
+    draft.inboundCapable &&
+    (!validation.inboundCapable ||
+      validation.inboundIdentity !== "unambiguous" ||
+      !validation.inboundSourceId)
+  ) {
+    throw new NotificationError("Inbound SMS requires one unambiguous receiving identity")
+  }
   const [account] = await db
     .insert(notificationChannelAccounts)
     .values({
       channel: draft.channel,
-      normalizedAddress: provisioned.normalizedAddress,
+      normalizedAddress,
       displayName: draft.displayName,
       displayAddress: provisioned.displayAddress,
       lifecycle: "active",
       health: validation.health,
       inboundCapable: validation.inboundCapable,
       outboundCapable: validation.outboundCapable,
+      inboundIdentity: validation.inboundIdentity ?? null,
+      inboundSourceId: validation.inboundSourceId ?? null,
+      attachmentsCapable: validation.attachmentsCapable ?? false,
       allowedPurposes: normalizePurposes(draft.allowedPurposes),
       adapterRef: provisioned.adapterRef,
       lastValidatedAt: new Date(),
@@ -86,6 +104,15 @@ export async function validateChannelAccount(
       .set({ health: "unavailable", lastValidatedAt: new Date(), updatedAt: new Date() })
       .where(eq(notificationChannelAccounts.id, id))
     throw error
+  }
+  if (
+    account.channel === "sms" &&
+    account.inboundCapable &&
+    (!validation.inboundCapable ||
+      validation.inboundIdentity !== "unambiguous" ||
+      !validation.inboundSourceId)
+  ) {
+    throw new NotificationError("Inbound SMS identity became ambiguous")
   }
   const [updated] = await db
     .update(notificationChannelAccounts)
@@ -142,9 +169,15 @@ export async function admitRenderedServiceMessage(
   if (!account.allowedPurposes.includes(message.purpose)) {
     throw new NotificationError(`Channel Account does not allow purpose "${message.purpose}"`)
   }
+  if (message.channel && message.channel !== account.channel) {
+    throw new NotificationError("Rendered message channel does not match its Channel Account")
+  }
   const adapter = resolveAccountAdapter(adapters, account.adapterRef)
   if (!adapter.channels.includes(account.channel)) {
     throw new NotificationError("Channel Account adapter does not support its channel")
+  }
+  if (account.channel === "sms") {
+    await assertSmsAdmissionAllowed(db, account.id, message.to)
   }
 
   return enqueueNotification({

--- a/packages/notifications/src/service-sms-policy.ts
+++ b/packages/notifications/src/service-sms-policy.ts
@@ -1,0 +1,153 @@
+import type { InboundSmsEnvelopeV1 } from "@voyant-travel/conversations-contracts"
+import { normalizeE164 } from "@voyant-travel/conversations-contracts"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { and, eq, lt, or } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import {
+  notificationChannelAccounts,
+  smsTransportPolicies,
+  smsTransportPolicyEvents,
+} from "./schema.js"
+import { NotificationError } from "./service-shared.js"
+
+export async function inspectInboundSmsAccount(
+  db: PostgresJsDatabase,
+  envelope: InboundSmsEnvelopeV1,
+) {
+  const rows = await db
+    .select()
+    .from(notificationChannelAccounts)
+    .where(
+      and(
+        eq(notificationChannelAccounts.id, envelope.channelAccountId),
+        eq(notificationChannelAccounts.channel, "sms"),
+        eq(notificationChannelAccounts.normalizedAddress, normalizeE164(envelope.receivingAddress)),
+        eq(notificationChannelAccounts.inboundSourceId, envelope.sourceId),
+      ),
+    )
+    .limit(2)
+  if (rows.length === 0) return { kind: "missing" as const }
+  if (rows.length > 1 || rows[0]!.inboundIdentity !== "unambiguous") {
+    return { kind: "ambiguous" as const }
+  }
+  const account = rows[0]!
+  if (
+    account.lifecycle !== "active" ||
+    !account.inboundCapable ||
+    account.health === "unavailable"
+  ) {
+    return { kind: "unavailable" as const }
+  }
+  return {
+    kind: "ready" as const,
+    accountId: account.id,
+    normalizedAddress: account.normalizedAddress,
+  }
+}
+
+export async function projectInboundSmsPolicy(
+  db: PostgresJsDatabase,
+  envelope: InboundSmsEnvelopeV1,
+): Promise<void> {
+  if (!envelope.policyEvent) return
+  const destinationAddress = normalizeE164(envelope.senderAddress)
+  const occurredAt = new Date(envelope.occurredAt)
+  await db
+    .insert(smsTransportPolicyEvents)
+    .values({
+      id: newId("sms_transport_policy_events"),
+      channelAccountId: envelope.channelAccountId,
+      destinationAddress,
+      sourceId: envelope.sourceId,
+      externalMessageId: envelope.externalMessageId,
+      kind: envelope.policyEvent,
+      adapterHandledResponse: envelope.adapterHandledResponse,
+      occurredAt,
+    })
+    .onConflictDoNothing()
+  // Always repair the current projection on replay. The immutable ledger insert
+  // may have committed before a prior projection attempt was interrupted.
+
+  const state = envelope.policyEvent === "hard_opt_out" ? "hard_opt_out" : "allowed"
+  await db
+    .insert(smsTransportPolicies)
+    .values({
+      id: newId("sms_transport_policies"),
+      channelAccountId: envelope.channelAccountId,
+      destinationAddress,
+      state,
+      lastEventOccurredAt: occurredAt,
+    })
+    .onConflictDoUpdate({
+      target: [smsTransportPolicies.channelAccountId, smsTransportPolicies.destinationAddress],
+      set: { state, lastEventOccurredAt: occurredAt, updatedAt: new Date() },
+      setWhere:
+        state === "hard_opt_out"
+          ? or(
+              lt(smsTransportPolicies.lastEventOccurredAt, occurredAt),
+              and(
+                eq(smsTransportPolicies.lastEventOccurredAt, occurredAt),
+                eq(smsTransportPolicies.state, "allowed"),
+              ),
+            )
+          : lt(smsTransportPolicies.lastEventOccurredAt, occurredAt),
+    })
+}
+
+export async function assertSmsAdmissionAllowed(
+  db: PostgresJsDatabase,
+  channelAccountId: string,
+  destination: string,
+): Promise<void> {
+  const [policy] = await db
+    .select({ state: smsTransportPolicies.state })
+    .from(smsTransportPolicies)
+    .where(
+      and(
+        eq(smsTransportPolicies.channelAccountId, channelAccountId),
+        eq(smsTransportPolicies.destinationAddress, normalizeE164(destination)),
+      ),
+    )
+    .limit(1)
+  if (policy?.state === "hard_opt_out") {
+    throw new NotificationError("SMS destination has a hard opt-out")
+  }
+}
+
+export async function getOutboundSmsState(
+  db: PostgresJsDatabase,
+  input: { channelAccountId: string; destinationAddress: string },
+) {
+  const [account] = await db
+    .select()
+    .from(notificationChannelAccounts)
+    .where(
+      and(
+        eq(notificationChannelAccounts.id, input.channelAccountId),
+        eq(notificationChannelAccounts.channel, "sms"),
+      ),
+    )
+    .limit(1)
+  if (!account) return null
+  const [policy] = await db
+    .select({ state: smsTransportPolicies.state })
+    .from(smsTransportPolicies)
+    .where(
+      and(
+        eq(smsTransportPolicies.channelAccountId, account.id),
+        eq(smsTransportPolicies.destinationAddress, normalizeE164(input.destinationAddress)),
+      ),
+    )
+    .limit(1)
+  return {
+    normalizedAddress: account.normalizedAddress,
+    health: account.health,
+    available:
+      account.lifecycle === "active" &&
+      account.outboundCapable &&
+      account.health !== "unavailable" &&
+      account.allowedPurposes.includes("conversation-reply"),
+    attachmentsCapable: account.attachmentsCapable,
+    suppressed: policy?.state === "hard_opt_out",
+  }
+}

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -45,6 +45,7 @@ export interface RenderedServiceMessageAttachment {
 /** Provider-neutral, already-rendered service message admitted to the durable sender. */
 export interface RenderedServiceMessage {
   channelAccountId: string
+  channel?: "email" | "sms"
   to: string
   target: QualifiedNotificationTargetRef
   purpose: string
@@ -99,6 +100,11 @@ export interface ValidatedChannelAccount {
   health: "healthy" | "degraded" | "unavailable"
   inboundCapable: boolean
   outboundCapable: boolean
+  /** Required and unambiguous before an SMS identity can receive Inbox traffic. */
+  inboundIdentity?: "unambiguous" | "ambiguous"
+  /** Opaque ingress source id bound by the adapter to this receiving identity. */
+  inboundSourceId?: string
+  attachmentsCapable?: boolean
 }
 
 /** Runtime-only authority for provisioning and validating adapter identities. */

--- a/packages/notifications/src/voyant.ts
+++ b/packages/notifications/src/voyant.ts
@@ -2,7 +2,11 @@ import {
   bookingActionProjectionRuntimePort,
   bookingActionSourceRuntimePort,
 } from "@voyant-travel/bookings/runtime-port"
-import { conversationsRenderedMessageAdmissionPort } from "@voyant-travel/conversations/runtime-port"
+import {
+  conversationsChannelPolicyPort,
+  conversationsDeliveryTruthPort,
+  conversationsRenderedMessageAdmissionPort,
+} from "@voyant-travel/conversations/runtime-port"
 import {
   defineExtension,
   defineModule,
@@ -37,6 +41,8 @@ export const notificationsVoyantModule = defineModule({
     ports: [
       providePort(customerVerificationRuntimePort),
       providePort(conversationsRenderedMessageAdmissionPort),
+      providePort(conversationsChannelPolicyPort),
+      providePort(conversationsDeliveryTruthPort),
       providePort(financeNotificationsRuntimePort),
       providePort(notificationsRuntimePort),
       providePort(notificationsReminderJobRuntimePort),

--- a/packages/notifications/tests/integration/channel-accounts.test.ts
+++ b/packages/notifications/tests/integration/channel-accounts.test.ts
@@ -1,26 +1,34 @@
-import { eq } from "drizzle-orm"
-import { describe, expect, it, vi } from "vitest"
-
+import { and, eq } from "drizzle-orm"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { createConversationsDeliveryTruthReader } from "../../src/conversations-runtime.js"
 import {
   notificationChannelAccounts,
   notificationDeliveries,
   notificationDeliveryEvents,
   notificationSendOperations,
+  smsTransportPolicies,
+  smsTransportPolicyEvents,
 } from "../../src/schema.js"
 import {
   admitRenderedServiceMessage,
   provisionChannelAccount,
   reconcileNotificationDeliveryEvent,
 } from "../../src/service-channel-accounts.js"
+import {
+  getOutboundSmsState,
+  inspectInboundSmsAccount,
+  projectInboundSmsPolicy,
+} from "../../src/service-sms-policy.js"
 import type { NotificationProvider, NotificationResult } from "../../src/types.js"
 import { createNotificationsTestContext, DB_AVAILABLE } from "./test-helpers.js"
 
 const submitted = vi.fn()
 const accepted = new Map<string, NotificationResult>()
 let validationFailure: Error | null = null
+let inboundIdentity: "unambiguous" | "ambiguous" = "unambiguous"
 const adapter: NotificationProvider = {
   name: "fixture-adapter",
-  channels: ["email"],
+  channels: ["email", "sms"],
   durableDelivery: {
     protocol: "notification-provider-idempotency-v1",
     async send(payload, context) {
@@ -44,7 +52,14 @@ const adapter: NotificationProvider = {
     },
     async validate() {
       if (validationFailure) throw validationFailure
-      return { health: "healthy", inboundCapable: true, outboundCapable: true }
+      return {
+        health: "healthy",
+        inboundCapable: true,
+        outboundCapable: true,
+        inboundIdentity,
+        inboundSourceId: "fixture-inbound",
+        attachmentsCapable: false,
+      }
     },
   },
 }
@@ -52,10 +67,16 @@ const adapter: NotificationProvider = {
 describe.skipIf(!DB_AVAILABLE)("Channel Account rendered delivery", () => {
   const context = createNotificationsTestContext({ providers: [adapter] })
 
+  beforeEach(() => {
+    validationFailure = null
+    inboundIdentity = "unambiguous"
+  })
+
   it("moves one fixture-adapter message from pending through accepted to delivered exactly once", async () => {
     accepted.clear()
     submitted.mockReset()
     validationFailure = null
+    inboundIdentity = "unambiguous"
     const account = await provisionChannelAccount(context.db, adapter, {
       channel: "email",
       address: "Service@Example.test",
@@ -102,6 +123,9 @@ describe.skipIf(!DB_AVAILABLE)("Channel Account rendered delivery", () => {
       qualifiedTargetType: "@voyant-travel/conversations#thread",
       purpose: "guest-support",
     })
+    await expect(
+      createConversationsDeliveryTruthReader().getDeliveryTruth(context.db, [pending.id]),
+    ).resolves.toEqual({ [pending.id]: "pending" })
     expect(await context.db.select().from(notificationSendOperations)).toHaveLength(1)
 
     await expect(context.drain()).resolves.toMatchObject({ sent: 1 })
@@ -204,5 +228,190 @@ describe.skipIf(!DB_AVAILABLE)("Channel Account rendered delivery", () => {
       .from(notificationChannelAccounts)
       .where(eq(notificationChannelAccounts.id, account.id))
     expect(unavailableAccount?.health).toBe("unavailable")
+  })
+
+  it("rejects Inbox setup for an ambiguous inbound SMS identity", async () => {
+    inboundIdentity = "ambiguous"
+    await expect(
+      provisionChannelAccount(context.db, adapter, {
+        channel: "sms",
+        address: "+12025550999",
+        displayName: "Ambiguous SMS",
+        allowedPurposes: ["conversation-reply"],
+        inboundCapable: true,
+        outboundCapable: true,
+      }),
+    ).rejects.toThrow("unambiguous")
+    expect(await context.db.select().from(notificationChannelAccounts)).toHaveLength(0)
+    inboundIdentity = "unambiguous"
+  })
+
+  it("enforces account-scoped hard opt-out for staff and automated SMS until a newer opt-in", async () => {
+    const account = await provisionChannelAccount(context.db, adapter, {
+      channel: "sms",
+      address: "+12025550100",
+      displayName: "SMS service",
+      allowedPurposes: ["conversation-reply", "automated-reminder"],
+      inboundCapable: true,
+      outboundCapable: true,
+    })
+    const otherAccount = await provisionChannelAccount(context.db, adapter, {
+      channel: "sms",
+      address: "+12025550101",
+      displayName: "Other SMS service",
+      allowedPurposes: ["conversation-reply"],
+      inboundCapable: true,
+      outboundCapable: true,
+    })
+    const optOut = {
+      version: "1" as const,
+      channel: "sms" as const,
+      sourceId: "fixture-inbound",
+      externalEnvelopeId: "policy-envelope-1",
+      externalMessageId: "policy-message-1",
+      channelAccountId: account.id,
+      receivingAddress: account.normalizedAddress,
+      senderAddress: "+12025550123",
+      text: "STOP",
+      attachments: [],
+      policyEvent: "hard_opt_out" as const,
+      adapterHandledResponse: true,
+      occurredAt: "2026-08-17T10:00:00.000Z",
+    }
+    await expect(
+      inspectInboundSmsAccount(context.db, { ...optOut, sourceId: "unbound-source" }),
+    ).resolves.toEqual({ kind: "missing" })
+    await projectInboundSmsPolicy(context.db, optOut)
+    await projectInboundSmsPolicy(context.db, optOut)
+    expect(await context.db.select().from(smsTransportPolicyEvents)).toHaveLength(1)
+    expect(await context.db.select().from(smsTransportPolicies)).toHaveLength(1)
+    expect(await context.db.select().from(notificationDeliveries)).toHaveLength(0)
+
+    // A replay repairs the projection if a previous non-transactional caller
+    // committed the immutable ledger before its current-state write.
+    await context.db
+      .delete(smsTransportPolicies)
+      .where(
+        and(
+          eq(smsTransportPolicies.channelAccountId, account.id),
+          eq(smsTransportPolicies.destinationAddress, optOut.senderAddress),
+        ),
+      )
+    await projectInboundSmsPolicy(context.db, optOut)
+    expect(await context.db.select().from(smsTransportPolicies)).toHaveLength(1)
+    await expect(
+      getOutboundSmsState(context.db, {
+        channelAccountId: account.id,
+        destinationAddress: optOut.senderAddress,
+      }),
+    ).resolves.toMatchObject({
+      health: "healthy",
+      available: true,
+      attachmentsCapable: false,
+      suppressed: true,
+    })
+
+    const command = {
+      channelAccountId: account.id,
+      to: optOut.senderAddress,
+      target: { type: "@voyant-travel/conversations#part", id: "cvpa_policy" },
+      purpose: "conversation-reply",
+      idempotencyKey: "sms-policy-staff",
+      text: "Can we help?",
+    }
+    await expect(admitRenderedServiceMessage(context.db, [adapter], command)).rejects.toThrow(
+      "hard opt-out",
+    )
+    await expect(
+      admitRenderedServiceMessage(context.db, [adapter], {
+        ...command,
+        purpose: "automated-reminder",
+        idempotencyKey: "sms-policy-automated",
+      }),
+    ).rejects.toThrow("hard opt-out")
+
+    await expect(
+      admitRenderedServiceMessage(context.db, [adapter], {
+        ...command,
+        channelAccountId: otherAccount.id,
+        idempotencyKey: "sms-policy-other-account",
+      }),
+    ).resolves.toMatchObject({ status: "pending" })
+
+    await projectInboundSmsPolicy(context.db, {
+      ...optOut,
+      externalEnvelopeId: "policy-envelope-older",
+      externalMessageId: "policy-message-older",
+      text: "START",
+      policyEvent: "opt_in",
+      adapterHandledResponse: false,
+      occurredAt: "2026-08-17T09:59:00.000Z",
+    })
+    await expect(
+      admitRenderedServiceMessage(context.db, [adapter], {
+        ...command,
+        idempotencyKey: "sms-policy-after-old-opt-in",
+      }),
+    ).rejects.toThrow("hard opt-out")
+
+    await projectInboundSmsPolicy(context.db, {
+      ...optOut,
+      externalEnvelopeId: "policy-envelope-2",
+      externalMessageId: "policy-message-2",
+      text: "START",
+      policyEvent: "opt_in",
+      adapterHandledResponse: false,
+      occurredAt: "2026-08-17T10:01:00.000Z",
+    })
+    await expect(
+      admitRenderedServiceMessage(context.db, [adapter], {
+        ...command,
+        idempotencyKey: "sms-policy-recovered",
+      }),
+    ).resolves.toMatchObject({ status: "pending" })
+  })
+
+  it("orders equal-time policy conflicts fail-closed under concurrency", async () => {
+    const account = await provisionChannelAccount(context.db, adapter, {
+      channel: "sms",
+      address: "+12025550100",
+      displayName: "SMS service",
+      allowedPurposes: ["conversation-reply"],
+      inboundCapable: true,
+      outboundCapable: true,
+    })
+    const common = {
+      version: "1" as const,
+      channel: "sms" as const,
+      sourceId: "fixture-inbound",
+      channelAccountId: account.id,
+      receivingAddress: account.normalizedAddress,
+      senderAddress: "+12025550123",
+      attachments: [],
+      adapterHandledResponse: false,
+      occurredAt: "2026-08-17T10:00:00.000Z",
+    }
+    await Promise.all([
+      projectInboundSmsPolicy(context.db, {
+        ...common,
+        externalEnvelopeId: "equal-opt-in-envelope",
+        externalMessageId: "equal-opt-in-message",
+        text: "START",
+        policyEvent: "opt_in",
+      }),
+      projectInboundSmsPolicy(context.db, {
+        ...common,
+        externalEnvelopeId: "equal-opt-out-envelope",
+        externalMessageId: "equal-opt-out-message",
+        text: "STOP",
+        policyEvent: "hard_opt_out",
+      }),
+    ])
+    await expect(
+      getOutboundSmsState(context.db, {
+        channelAccountId: account.id,
+        destinationAddress: common.senderAddress,
+      }),
+    ).resolves.toMatchObject({ suppressed: true })
   })
 })

--- a/packages/notifications/tests/integration/test-helpers.ts
+++ b/packages/notifications/tests/integration/test-helpers.ts
@@ -58,6 +58,8 @@ async function cleanupNotificationsTestData(
       notification_reminder_rules,
       notification_settings,
       notification_send_operations,
+      sms_transport_policy_events,
+      sms_transport_policies,
       notification_delivery_events,
       notification_deliveries,
       notification_channel_accounts,
@@ -446,12 +448,50 @@ export function createNotificationsTestContext(options?: {
         health channel_account_health NOT NULL DEFAULT 'unknown',
         inbound_capable boolean NOT NULL DEFAULT false,
         outbound_capable boolean NOT NULL DEFAULT false,
+        inbound_identity text,
+        inbound_source_id text,
+        attachments_capable boolean NOT NULL DEFAULT false,
         allowed_purposes jsonb NOT NULL DEFAULT '[]'::jsonb,
         adapter_ref text NOT NULL UNIQUE,
         last_validated_at timestamp with time zone,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         updated_at timestamp with time zone DEFAULT now() NOT NULL,
         UNIQUE (channel, normalized_address)
+      )
+    `)
+    await db.execute(
+      sql`ALTER TABLE notification_channel_accounts ADD COLUMN IF NOT EXISTS inbound_identity text`,
+    )
+    await db.execute(
+      sql`ALTER TABLE notification_channel_accounts ADD COLUMN IF NOT EXISTS inbound_source_id text`,
+    )
+    await db.execute(
+      sql`ALTER TABLE notification_channel_accounts ADD COLUMN IF NOT EXISTS attachments_capable boolean NOT NULL DEFAULT false`,
+    )
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS sms_transport_policies (
+        id text PRIMARY KEY NOT NULL,
+        channel_account_id text NOT NULL REFERENCES notification_channel_accounts(id) ON DELETE CASCADE,
+        destination_address text NOT NULL,
+        state text NOT NULL,
+        last_event_occurred_at timestamp with time zone NOT NULL,
+        created_at timestamp with time zone DEFAULT now() NOT NULL,
+        updated_at timestamp with time zone DEFAULT now() NOT NULL,
+        UNIQUE (channel_account_id, destination_address)
+      )
+    `)
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS sms_transport_policy_events (
+        id text PRIMARY KEY NOT NULL,
+        channel_account_id text NOT NULL REFERENCES notification_channel_accounts(id) ON DELETE CASCADE,
+        destination_address text NOT NULL,
+        source_id text NOT NULL,
+        external_message_id text NOT NULL,
+        kind text NOT NULL,
+        adapter_handled_response boolean NOT NULL DEFAULT false,
+        occurred_at timestamp with time zone NOT NULL,
+        created_at timestamp with time zone DEFAULT now() NOT NULL,
+        UNIQUE (source_id, external_message_id)
       )
     `)
     await db.execute(sql`

--- a/packages/notifications/tests/unit/voyant-manifest.test.ts
+++ b/packages/notifications/tests/unit/voyant-manifest.test.ts
@@ -26,6 +26,8 @@ describe("notifications deployment manifest", () => {
         ports: [
           { id: customerVerificationRuntimePort.id },
           { id: "conversations.rendered-message-admission" },
+          { id: "conversations.channel-policy" },
+          { id: "conversations.delivery-truth" },
           { id: financeNotificationsRuntimePort.id },
           { id: "notifications.runtime" },
           { id: "notifications.reminder-job" },

--- a/packages/relationships/package.json
+++ b/packages/relationships/package.json
@@ -33,6 +33,8 @@
     "@voyant-travel/bookings": "workspace:^",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/custom-fields": "workspace:^",
+    "@voyant-travel/conversations": "workspace:^",
+    "@voyant-travel/conversations-contracts": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/finance": "workspace:^",
     "@voyant-travel/hono": "workspace:^",

--- a/packages/relationships/src/runtime-contributor.ts
+++ b/packages/relationships/src/runtime-contributor.ts
@@ -2,6 +2,9 @@ import {
   type BookingsRelationshipsRuntime,
   bookingsRelationshipsRuntimePort,
 } from "@voyant-travel/bookings/runtime-port"
+import type { ConversationsPersonDirectory } from "@voyant-travel/conversations/runtime-port"
+import { conversationsPersonDirectoryPort } from "@voyant-travel/conversations/runtime-port"
+import { normalizeE164, normalizeEmailAddress } from "@voyant-travel/conversations-contracts"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import {
   type CustomFieldsRuntime,
@@ -22,7 +25,8 @@ import {
   type FinanceStoredInstrumentRuntime,
   financeStoredInstrumentRuntimePort,
 } from "@voyant-travel/finance/runtime-port"
-import { sql } from "drizzle-orm"
+import { identityContactPoints } from "@voyant-travel/identity/schema"
+import { and, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { createPublicApiIntakePersistence } from "./public-api-intake-runtime.js"
 import type { RelationshipsRouteRuntimeOptions } from "./route-runtime.js"
@@ -86,6 +90,62 @@ const relationshipCustomFieldValues: CustomFieldValueLifecycleRuntime = {
           WHERE custom_fields -> ${definition.namespace} ? ${definition.key}`,
     )
   },
+}
+
+const conversationsPersonDirectory: ConversationsPersonDirectory = {
+  async resolveEmail(db, address) {
+    return resolveConversationContact(db, "email", normalizeEmailAddress(address))
+  },
+  async resolvePhone(db, address) {
+    return resolveConversationContact(db, "phone", normalizeE164(address))
+  },
+  async resolvePersonContactPoint(db, input) {
+    const kind = input.channel === "sms" ? "phone" : "email"
+    const rows = await (db as PostgresJsDatabase)
+      .select()
+      .from(identityContactPoints)
+      .where(
+        and(
+          eq(identityContactPoints.id, input.contactPointRef),
+          eq(identityContactPoints.entityType, "person"),
+          eq(identityContactPoints.entityId, input.personRef),
+          eq(identityContactPoints.kind, kind),
+        ),
+      )
+      .limit(1)
+    const point = rows[0]
+    if (!point) return null
+    return {
+      address: kind === "phone" ? normalizeE164(point.value) : normalizeEmailAddress(point.value),
+    }
+  },
+}
+
+async function resolveConversationContact(
+  db: unknown,
+  kind: "email" | "phone",
+  normalizedAddress: string,
+) {
+  const rows = await (db as PostgresJsDatabase)
+    .select()
+    .from(identityContactPoints)
+    .where(
+      and(
+        eq(identityContactPoints.entityType, "person"),
+        eq(identityContactPoints.kind, kind),
+        eq(identityContactPoints.normalizedValue, normalizedAddress),
+      ),
+    )
+    .limit(2)
+  if (rows.length === 0) return { kind: "none" as const }
+  if (rows.length > 1) return { kind: "ambiguous" as const }
+  const point = rows[0]!
+  return {
+    kind: "unique" as const,
+    personRef: point.entityId,
+    contactPointRef: point.id,
+    address: normalizedAddress,
+  }
 }
 
 const relationshipCustomFieldValueOperations: CustomFieldValueOperationsRuntime = {
@@ -217,6 +277,7 @@ export function createRelationshipsRuntimePortContribution(
     },
   }
   return {
+    [conversationsPersonDirectoryPort.id]: conversationsPersonDirectory,
     [publicApiIntakeRuntimePortReference.id]: createPublicApiIntakePersistence(),
     [customFieldValueReaderRuntimePort.id]: customFields,
     [customFieldValueLifecycleRuntimePort.id]: relationshipCustomFieldValues,

--- a/packages/relationships/src/voyant.ts
+++ b/packages/relationships/src/voyant.ts
@@ -3,6 +3,7 @@ import {
   bookingsCrmSnapshotRuntimePort,
   bookingsRelationshipsRuntimePort,
 } from "@voyant-travel/bookings/runtime-port"
+import { conversationsPersonDirectoryPort } from "@voyant-travel/conversations/runtime-port"
 import { defineModule, providePort, requirePort } from "@voyant-travel/core/project"
 import {
   customFieldsRuntimePort,
@@ -95,6 +96,7 @@ export const relationshipsVoyantModule = defineModule({
       providePort(customFieldValueLifecycleRuntimePort),
       providePort(customFieldValueOperationsRuntimePort),
       providePort(relationshipsBookingEnrichmentDatabaseRuntimePort),
+      providePort(conversationsPersonDirectoryPort),
     ],
   },
   runtimePorts: [

--- a/packages/relationships/tests/unit/voyant-manifest.test.ts
+++ b/packages/relationships/tests/unit/voyant-manifest.test.ts
@@ -32,6 +32,7 @@ describe("relationships deployment manifest", () => {
           { id: customFieldValueLifecycleRuntimePort.id },
           { id: customFieldValueOperationsRuntimePort.id },
           { id: "relationships.booking-enrichment-database" },
+          { id: "conversations.person-directory" },
         ],
       },
       runtimePorts: [

--- a/packages/schema-kit/src/typeid/typeid-prefixes.ts
+++ b/packages/schema-kit/src/typeid/typeid-prefixes.ts
@@ -56,6 +56,8 @@ export const PREFIXES = {
   notification_channel_accounts: "ncha",
   notification_delivery_events: "ndev",
   notification_send_operations: "nsop",
+  sms_transport_policies: "smsp",
+  sms_transport_policy_events: "smse",
   contract_document_operations: "lcdo",
   notification_reminder_rules: "ntrl",
   notification_reminder_runs: "ntrn",

--- a/packages/schema-kit/src/typeid/typeid-schemas.ts
+++ b/packages/schema-kit/src/typeid/typeid-schemas.ts
@@ -12,6 +12,8 @@ export const typeIdSchemas = {
   notificationDelivery: typeIdSchema("notification_deliveries"),
   notificationChannelAccount: typeIdSchema("notification_channel_accounts"),
   notificationDeliveryEvent: typeIdSchema("notification_delivery_events"),
+  smsTransportPolicy: typeIdSchema("sms_transport_policies"),
+  smsTransportPolicyEvent: typeIdSchema("sms_transport_policy_events"),
   personNote: typeIdSchema("person_notes"),
   organizationNote: typeIdSchema("organization_notes"),
   segment: typeIdSchema("segments"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5572,6 +5572,12 @@ importers:
       '@voyant-travel/bookings':
         specifier: workspace:^
         version: link:../bookings
+      '@voyant-travel/conversations':
+        specifier: workspace:^
+        version: link:../conversations
+      '@voyant-travel/conversations-contracts':
+        specifier: workspace:^
+        version: link:../conversations-contracts
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../core
@@ -13831,28 +13837,28 @@ snapshots:
       '@cloudflare/workers-types': 4.20260702.1
       '@opentelemetry/api': 1.9.0
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
 
-  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
+  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.2
 
-  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0(socks@2.8.7))':
+  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0(socks@2.8.7))':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       mongodb: 7.1.0(socks@2.8.7)
@@ -13867,14 +13873,14 @@ snapshots:
       jose: 6.2.4
       zod: 4.4.3
 
-  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -16976,12 +16982,12 @@ snapshots:
   better-auth@1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3)):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))
-      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
-      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0(socks@2.8.7))
-      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))
+      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0(socks@2.8.7))
+      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0

--- a/scripts/checks/graph/graph-conformance.json
+++ b/scripts/checks/graph/graph-conformance.json
@@ -25,7 +25,9 @@
         "conversations.rendered-message-admission",
         "conversations.person-directory",
         "auth.staff-directory",
-        "conversations.attachments"
+        "conversations.attachments",
+        "conversations.channel-policy",
+        "conversations.delivery-truth"
       ],
       "runtimeExport": "createConversationsRuntimePortContribution"
     },
@@ -41,7 +43,8 @@
         "relationships.route-runtime",
         "relationships.mice.runtime",
         "custom-fields.runtime",
-        "relationships.booking-enrichment-database"
+        "relationships.booking-enrichment-database",
+        "conversations.person-directory"
       ],
       "runtimeExport": "createRelationshipsRuntimePortContribution"
     },


### PR DESCRIPTION
## Summary
- adds provider-neutral two-way SMS envelopes and deterministic account/address threading
- centralizes account-scoped opt-out policy and fail-closed admission in Notifications
- derives sender identity and delivery truth from Channel Account/Notifications authorities
- adds SMS composer health, suppression, capability, migration, and retry coverage

## Stack
Depends on the Inbox foundation, email, collaboration, and secure-content PRs already merged into feat/inbox.

Closes #4829

## Verification
- Conversations typecheck and tests (29 passed; DB tests were separately green before rebase)
- Conversations React typecheck
- Notifications full tests (183 passed)
- Relationships tests (190 passed)
- contracts tests/typecheck
- graph conformance, migration identity, OpenAPI drift, Biome, diff check

The broad Notifications typecheck exhausted a 4 GB Node heap on this host; its package tests are green and the pre-rebase focused typecheck was green. The repository pre-push full suite also hit two unrelated runtime timeout tests; the logical package suites above pass.