### PR TITLE
feat(inbox): add search, queues, bulk operations, and reporting

### DIFF
--- a/.changeset/quiet-inbox-operations.md
+++ b/.changeset/quiet-inbox-operations.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/conversations": minor
+"@voyant-travel/conversations-react": minor
+"@voyant-travel/admin-api-client": minor
+---
+
+Add membership-scoped Inbox search, indexed queues, optimistic bulk lifecycle operations, and content-free operational reporting.

--- a/docs/architecture/inbox-operational-reporting.md
+++ b/docs/architecture/inbox-operational-reporting.md
@@ -1,0 +1,33 @@
+# Inbox operational reporting
+
+Inbox search, queues, and reports execute inside the deployment's tenant database. Customer
+addresses, subjects, and message bodies are not copied into the deployment-wide catalog,
+search plane, telemetry labels, or reporting events. Search only considers authorized Inbox
+memberships and excludes quarantined or redacted Part content.
+
+Queue projections are durable fields on `conversations`, maintained in the same transaction as
+the Part or lifecycle Event that changes them. They are rebuildable from Parts and Events and
+exist to make the operator's day-to-day queues indexable; they are not a second source of truth.
+
+## SLA semantics
+
+The first reporting surface is explicitly **non-authoritative** for contractual SLAs:
+
+- clocks use elapsed wall time, not configured business hours;
+- the clock starts at Conversation creation;
+- snoozing does not pause a clock;
+- reopening clears the previous resolution projection but continues from the original clock;
+- `waiting_on_staff` starts with the latest inbound customer Part, and `waiting_on_customer`
+  starts with the latest outbound staff Part;
+- first response is the first outbound Part at or after the first inbound Part;
+- resolution is the latest transition to closed.
+
+The API returns these semantics with every report. An authoritative SLA display must wait for a
+separate decision and configuration model covering calendars, time zones, holidays, pause rules,
+and reopen policy.
+
+## Content-free observability
+
+Ingress lag uses only operation timestamps. Delivery failure and suppression metrics use status
+counts. Metric dimensions may include channel and coarse lifecycle state, but never addresses,
+subjects, message text, attachment names, Person identifiers, or Conversation identifiers.

--- a/packages/admin-api-client/src/generated/conversations.ts
+++ b/packages/admin-api-client/src/generated/conversations.ts
@@ -17,6 +17,21 @@ export interface paths {
           status?: "open" | "closed" | "snoozed"
           inboxId?: string
           assignedToUserId?: string
+          priority?: "low" | "normal" | "high" | "urgent"
+          unread?: "true" | "false"
+          channel?: string
+          participant?: string
+          q?: string
+          from?: string
+          to?: string
+          queue?:
+            | "unassigned"
+            | "assigned_to_me"
+            | "waiting_on_staff"
+            | "waiting_on_customer"
+            | "snoozed"
+            | "closed"
+          cursor?: string
           limit?: number
         }
         header?: never
@@ -25,7 +40,7 @@ export interface paths {
       }
       requestBody?: never
       responses: {
-        /** @description Membership-scoped Inbox */
+        /** @description Membership-scoped operational Inbox page */
         200: {
           headers: {
             [name: string]: unknown
@@ -53,8 +68,18 @@ export interface paths {
                 unreadCount: number
                 /** Format: date-time */
                 snoozedUntil: string | null
+                /** @enum {string|null} */
+                waitingOn: "staff" | "customer" | null
+                /** Format: date-time */
+                firstResponseAt: string | null
+                /** Format: date-time */
+                resolvedAt: string | null
                 /** Format: date-time */
                 closedAt: string | null
+                /** Format: date-time */
+                lastInboundAt: string | null
+                /** Format: date-time */
+                lastOutboundAt: string | null
                 /** Format: date-time */
                 lastPartAt: string
                 /** Format: date-time */
@@ -62,6 +87,9 @@ export interface paths {
                 /** Format: date-time */
                 updatedAt: string
               }[]
+              page: {
+                nextCursor: string | null
+              }
             }
           }
         }
@@ -189,8 +217,18 @@ export interface paths {
                   unreadCount: number
                   /** Format: date-time */
                   snoozedUntil: string | null
+                  /** @enum {string|null} */
+                  waitingOn: "staff" | "customer" | null
+                  /** Format: date-time */
+                  firstResponseAt: string | null
+                  /** Format: date-time */
+                  resolvedAt: string | null
                   /** Format: date-time */
                   closedAt: string | null
+                  /** Format: date-time */
+                  lastInboundAt: string | null
+                  /** Format: date-time */
+                  lastOutboundAt: string | null
                   /** Format: date-time */
                   lastPartAt: string
                   /** Format: date-time */
@@ -443,6 +481,289 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/v1/admin/conversations/bulk": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post: {
+      parameters: {
+        query?: never
+        header?: never
+        path?: never
+        cookie?: never
+      }
+      requestBody: {
+        content: {
+          "application/json": {
+            items: {
+              id: string
+              revision: number
+            }[]
+            changes: {
+              assignedToUserId?: string | null
+              /** @enum {string} */
+              status?: "open" | "closed" | "snoozed"
+              /** Format: date-time */
+              snoozedUntil?: string | null
+            }
+          }
+        }
+      }
+      responses: {
+        /** @description Audited optimistic bulk update */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              data: {
+                id: string
+                channel: string
+                inboxId: string
+                assignedToUserId: string | null
+                /** @enum {string} */
+                priority: "low" | "normal" | "high" | "urgent"
+                revision: number
+                /** @enum {string} */
+                status: "open" | "closed" | "snoozed"
+                subject: string | null
+                suggestedSubject: string | null
+                replyAlias: string | null
+                channelAccountId: string | null
+                localAddress: string | null
+                customerAddress: string
+                personRef: string | null
+                contactPointRef: string | null
+                unreadCount: number
+                /** Format: date-time */
+                snoozedUntil: string | null
+                /** @enum {string|null} */
+                waitingOn: "staff" | "customer" | null
+                /** Format: date-time */
+                firstResponseAt: string | null
+                /** Format: date-time */
+                resolvedAt: string | null
+                /** Format: date-time */
+                closedAt: string | null
+                /** Format: date-time */
+                lastInboundAt: string | null
+                /** Format: date-time */
+                lastOutboundAt: string | null
+                /** Format: date-time */
+                lastPartAt: string
+                /** Format: date-time */
+                createdAt: string
+                /** Format: date-time */
+                updatedAt: string
+              }[]
+            }
+          }
+        }
+        /** @description Invalid conversation operation */
+        400: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Authenticated staff required */
+        401: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Inbox membership required */
+        403: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Conversation resource not found */
+        404: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Revision or idempotency conflict */
+        409: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+      }
+    }
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/v1/admin/conversations/reporting": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get: {
+      parameters: {
+        query: {
+          from: string
+          to: string
+          inboxId?: string
+        }
+        header?: never
+        path?: never
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Content-free operational reporting with non-authoritative SLA semantics */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              data: {
+                period: {
+                  /** Format: date-time */
+                  from: string
+                  /** Format: date-time */
+                  to: string
+                }
+                volumes: {
+                  new: number
+                  opened: number
+                  closed: number
+                }
+                backlog: number
+                averagesMs: {
+                  firstResponse: number | null
+                  resolution: number | null
+                  customerWaiting: number | null
+                }
+                delivery: {
+                  failed: number
+                  suppressed: number
+                }
+                ingress: {
+                  averageLagMs: number | null
+                  failedOrDrifted: number
+                }
+                sla: {
+                  /** @enum {boolean} */
+                  authoritative: false
+                  /** @enum {string} */
+                  clock: "elapsed"
+                  /** @enum {string} */
+                  startsAt: "conversation_created"
+                  /** @enum {string} */
+                  pauses: "none"
+                  /** @enum {string} */
+                  reopen: "original_clock_continues"
+                  /** @enum {string} */
+                  businessHours: "not_configured"
+                }
+              }
+            }
+          }
+        }
+        /** @description Invalid conversation operation */
+        400: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Authenticated staff required */
+        401: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Inbox membership required */
+        403: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Conversation resource not found */
+        404: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+        /** @description Revision or idempotency conflict */
+        409: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            "application/json": {
+              error: string
+            }
+          }
+        }
+      }
+    }
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/v1/admin/conversations/{id}": {
     parameters: {
       query?: never
@@ -490,8 +811,18 @@ export interface paths {
                   unreadCount: number
                   /** Format: date-time */
                   snoozedUntil: string | null
+                  /** @enum {string|null} */
+                  waitingOn: "staff" | "customer" | null
+                  /** Format: date-time */
+                  firstResponseAt: string | null
+                  /** Format: date-time */
+                  resolvedAt: string | null
                   /** Format: date-time */
                   closedAt: string | null
+                  /** Format: date-time */
+                  lastInboundAt: string | null
+                  /** Format: date-time */
+                  lastOutboundAt: string | null
                   /** Format: date-time */
                   lastPartAt: string
                   /** Format: date-time */
@@ -796,8 +1127,18 @@ export interface paths {
                 unreadCount: number
                 /** Format: date-time */
                 snoozedUntil: string | null
+                /** @enum {string|null} */
+                waitingOn: "staff" | "customer" | null
+                /** Format: date-time */
+                firstResponseAt: string | null
+                /** Format: date-time */
+                resolvedAt: string | null
                 /** Format: date-time */
                 closedAt: string | null
+                /** Format: date-time */
+                lastInboundAt: string | null
+                /** Format: date-time */
+                lastOutboundAt: string | null
                 /** Format: date-time */
                 lastPartAt: string
                 /** Format: date-time */
@@ -1084,8 +1425,18 @@ export interface paths {
                 unreadCount: number
                 /** Format: date-time */
                 snoozedUntil: string | null
+                /** @enum {string|null} */
+                waitingOn: "staff" | "customer" | null
+                /** Format: date-time */
+                firstResponseAt: string | null
+                /** Format: date-time */
+                resolvedAt: string | null
                 /** Format: date-time */
                 closedAt: string | null
+                /** Format: date-time */
+                lastInboundAt: string | null
+                /** Format: date-time */
+                lastOutboundAt: string | null
                 /** Format: date-time */
                 lastPartAt: string
                 /** Format: date-time */

--- a/packages/conversations-react/src/admin/inbox-page.tsx
+++ b/packages/conversations-react/src/admin/inbox-page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useAdminHref } from "@voyant-travel/admin"
 import { useVoyantReactContext } from "@voyant-travel/react"
 import { type FormEvent, useState } from "react"
@@ -9,46 +9,204 @@ import type { InboxConversation } from "../types.js"
 
 export function InboxPage() {
   const { baseUrl, fetcher } = useVoyantReactContext()
+  const queryClient = useQueryClient()
+  const [filters, setFilters] = useState<Record<string, string | boolean | undefined>>({})
+  const [selected, setSelected] = useState<string[]>([])
   const conversations = useQuery({
-    queryKey: ["voyant", "conversations", "list"],
-    queryFn: () => conversationsApi.list(fetcher, baseUrl),
+    queryKey: ["voyant", "conversations", "list", filters],
+    queryFn: () => conversationsApi.list(fetcher, baseUrl, filters),
   })
-  const items = conversations.data ?? []
+  const items = conversations.data?.data ?? []
+  const report = useQuery({
+    queryKey: ["voyant", "conversations", "reporting"],
+    queryFn: () => {
+      const to = new Date()
+      const from = new Date(to.getTime() - 7 * 24 * 60 * 60 * 1_000)
+      return conversationsApi.reporting(fetcher, baseUrl, from.toISOString(), to.toISOString())
+    },
+  })
+  const bulk = useMutation({
+    mutationFn: (changes: {
+      assignedToUserId?: string | null
+      status?: InboxConversation["status"]
+    }) =>
+      conversationsApi.bulk(fetcher, baseUrl, {
+        items: items
+          .filter(({ id }) => selected.includes(id))
+          .map(({ id, revision }) => ({ id, revision })),
+        changes,
+      }),
+    onSuccess: async () => {
+      setSelected([])
+      await queryClient.invalidateQueries({ queryKey: ["voyant", "conversations"] })
+    },
+  })
   const error = conversations.error ? String(conversations.error) : null
+  function submitFilters(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = new FormData(event.currentTarget)
+    setFilters({
+      queue: String(form.get("queue") ?? ""),
+      q: String(form.get("q") ?? ""),
+      priority: String(form.get("priority") ?? ""),
+      unread: form.get("unread") === "on" ? true : undefined,
+    })
+    setSelected([])
+  }
+  function submitBulk(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = new FormData(event.currentTarget)
+    const status = String(form.get("status") ?? "") as InboxConversation["status"] | ""
+    const assignee = String(form.get("assignedToUserId") ?? "")
+    bulk.mutate({
+      ...(status ? { status } : {}),
+      ...(assignee ? { assignedToUserId: assignee } : {}),
+    })
+  }
   return (
     <main className="space-y-6 p-6">
       <header>
         <h1 className="text-2xl font-semibold">Inbox</h1>
-        <p className="text-sm text-muted-foreground">Customer email conversations</p>
+        <p className="text-sm text-muted-foreground">Customer conversations</p>
       </header>
+      <form className="flex flex-wrap gap-2" onSubmit={submitFilters} aria-label="Inbox filters">
+        <select name="queue" className="rounded border p-2" defaultValue="">
+          <option value="">All queues</option>
+          <option value="unassigned">Unassigned</option>
+          <option value="assigned_to_me">Assigned to me</option>
+          <option value="waiting_on_staff">Waiting on staff</option>
+          <option value="waiting_on_customer">Waiting on customer</option>
+          <option value="snoozed">Snoozed</option>
+          <option value="closed">Closed</option>
+        </select>
+        <input
+          name="q"
+          minLength={2}
+          maxLength={100}
+          placeholder="Search Inbox"
+          className="rounded border p-2"
+        />
+        <select name="priority" className="rounded border p-2" defaultValue="">
+          <option value="">Any priority</option>
+          <option value="low">Low</option>
+          <option value="normal">Normal</option>
+          <option value="high">High</option>
+          <option value="urgent">Urgent</option>
+        </select>
+        <label className="flex items-center gap-2">
+          <input type="checkbox" name="unread" />
+          Unread
+        </label>
+        <button className="rounded border px-3" type="submit">
+          Apply
+        </button>
+      </form>
+      {report.data ? (
+        <section className="grid gap-2 sm:grid-cols-4" aria-label="Seven-day Inbox report">
+          <Metric label="New" value={report.data.volumes.new} />
+          <Metric label="Closed" value={report.data.volumes.closed} />
+          <Metric label="Backlog" value={report.data.backlog} />
+          <Metric label="Delivery failures" value={report.data.delivery.failed} />
+          <p className="sm:col-span-4 text-xs text-muted-foreground">
+            Elapsed-time operational indicators; business-hour SLA rules are not configured.
+          </p>
+        </section>
+      ) : null}
       {error ? <p role="alert">{error}</p> : null}
+      {selected.length > 0 ? (
+        <form
+          className="flex flex-wrap gap-2 rounded border p-3"
+          onSubmit={submitBulk}
+          aria-label="Bulk lifecycle update"
+        >
+          <span>{selected.length} selected</span>
+          <input
+            name="assignedToUserId"
+            placeholder="Assign to staff ID"
+            className="rounded border px-2"
+          />
+          <select name="status" defaultValue="" className="rounded border px-2">
+            <option value="">Keep lifecycle</option>
+            <option value="open">Open</option>
+            <option value="closed">Closed</option>
+          </select>
+          <button type="submit" className="rounded border px-3">
+            Apply audited update
+          </button>
+        </form>
+      ) : null}
       <section className="divide-y rounded-md border" aria-label="Conversations">
         {items.map((item) => (
-          <ConversationRow key={item.id} item={item} />
+          <ConversationRow
+            key={item.id}
+            item={item}
+            selected={selected.includes(item.id)}
+            onSelected={(checked) =>
+              setSelected((current) =>
+                checked ? [...current, item.id] : current.filter((id) => id !== item.id),
+              )
+            }
+          />
         ))}
         {items.length === 0 && !error ? (
           <p className="p-6 text-sm text-muted-foreground">No conversations yet.</p>
         ) : null}
       </section>
+      {conversations.data?.page.nextCursor ? (
+        <button
+          className="rounded border px-3 py-2"
+          type="button"
+          onClick={() =>
+            setFilters((current) => ({ ...current, cursor: conversations.data!.page.nextCursor! }))
+          }
+        >
+          Next page
+        </button>
+      ) : null}
       <StartConversation />
     </main>
   )
 }
 
-function ConversationRow({ item }: { item: InboxConversation }) {
+function ConversationRow({
+  item,
+  selected,
+  onSelected,
+}: {
+  item: InboxConversation
+  selected: boolean
+  onSelected(checked: boolean): void
+}) {
   const resolveHref = useAdminHref()
   const href = resolveHref("conversation.detail", { id: item.id })
   return (
-    <a className="block p-4 hover:bg-muted/50" href={href}>
-      <div className="flex justify-between gap-4">
-        <strong>{item.subject ?? item.suggestedSubject ?? "No subject"}</strong>
-        <time className="text-xs">{new Date(item.lastPartAt).toLocaleString()}</time>
-      </div>
-      <div className="flex justify-between text-sm text-muted-foreground">
-        <span>{item.customerAddress}</span>
-        <span>{item.unreadCount > 0 ? `${item.unreadCount} unread` : item.status}</span>
-      </div>
-    </a>
+    <div className="flex items-start gap-3 p-4 hover:bg-muted/50">
+      <input
+        type="checkbox"
+        checked={selected}
+        onChange={(event) => onSelected(event.target.checked)}
+        aria-label={`Select ${item.subject ?? item.id}`}
+      />
+      <a className="block min-w-0 flex-1" href={href}>
+        <div className="flex justify-between gap-4">
+          <strong>{item.subject ?? item.suggestedSubject ?? "No subject"}</strong>
+          <time className="text-xs">{new Date(item.lastPartAt).toLocaleString()}</time>
+        </div>
+        <div className="flex justify-between text-sm text-muted-foreground">
+          <span>{item.customerAddress}</span>
+          <span>{item.unreadCount > 0 ? `${item.unreadCount} unread` : item.status}</span>
+        </div>
+      </a>
+    </div>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded border p-3">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <strong>{value}</strong>
+    </div>
   )
 }
 

--- a/packages/conversations-react/src/api.ts
+++ b/packages/conversations-react/src/api.ts
@@ -4,7 +4,9 @@ import type {
   ConversationInbox,
   InboxConversation,
   InboxConversationDetail,
+  InboxConversationPage,
   InboxNote,
+  InboxOperationalReport,
   InboxPart,
 } from "./types.js"
 
@@ -17,9 +19,40 @@ async function request<T>(fetcher: VoyantFetcher, url: string, init?: RequestIni
 }
 
 export const conversationsApi = {
-  list(fetcher: VoyantFetcher, baseUrl: string, filters: { inboxId?: string } = {}) {
-    const query = filters.inboxId ? `?inboxId=${encodeURIComponent(filters.inboxId)}` : ""
-    return request<InboxConversation[]>(fetcher, `${baseUrl}/v1/admin/conversations${query}`)
+  async list(
+    fetcher: VoyantFetcher,
+    baseUrl: string,
+    filters: Record<string, string | boolean | undefined> = {},
+  ): Promise<InboxConversationPage> {
+    const query = new URLSearchParams()
+    for (const [key, value] of Object.entries(filters)) {
+      if (value !== undefined && value !== "") query.set(key, String(value))
+    }
+    const response = await fetcher(`${baseUrl}/v1/admin/conversations?${query}`)
+    const payload = (await response.json()) as InboxConversationPage & { error?: string }
+    if (!response.ok) throw new Error(payload.error ?? `Request failed (${response.status})`)
+    return payload
+  },
+  bulk(
+    fetcher: VoyantFetcher,
+    baseUrl: string,
+    input: {
+      items: Array<{ id: string; revision: number }>
+      changes: { assignedToUserId?: string | null; status?: InboxConversation["status"] }
+    },
+  ) {
+    return request<InboxConversation[]>(fetcher, `${baseUrl}/v1/admin/conversations/bulk`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(input),
+    })
+  },
+  reporting(fetcher: VoyantFetcher, baseUrl: string, from: string, to: string) {
+    const query = new URLSearchParams({ from, to })
+    return request<InboxOperationalReport>(
+      fetcher,
+      `${baseUrl}/v1/admin/conversations/reporting?${query}`,
+    )
   },
   get(fetcher: VoyantFetcher, baseUrl: string, id: string) {
     return request<InboxConversationDetail>(

--- a/packages/conversations-react/src/types.ts
+++ b/packages/conversations-react/src/types.ts
@@ -10,7 +10,28 @@ export interface InboxConversation {
   customerAddress: string
   personRef: string | null
   unreadCount: number
+  channel: string
+  waitingOn: "staff" | "customer" | null
   lastPartAt: string
+}
+
+export interface InboxConversationPage {
+  data: InboxConversation[]
+  page: { nextCursor: string | null }
+}
+
+export interface InboxOperationalReport {
+  period: { from: string; to: string }
+  volumes: { new: number; opened: number; closed: number }
+  backlog: number
+  averagesMs: {
+    firstResponse: number | null
+    resolution: number | null
+    customerWaiting: number | null
+  }
+  delivery: { failed: number; suppressed: number }
+  ingress: { averageLagMs: number | null; failedOrDrifted: number }
+  sla: { authoritative: false; businessHours: "not_configured" }
 }
 
 export interface InboxPart {

--- a/packages/conversations/migrations/0004_operational_inbox.sql
+++ b/packages/conversations/migrations/0004_operational_inbox.sql
@@ -1,0 +1,47 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."conversation_waiting_on" AS ENUM('staff', 'customer');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+ALTER TABLE "conversations" ADD COLUMN "waiting_on" "conversation_waiting_on";--> statement-breakpoint
+ALTER TABLE "conversations" ADD COLUMN "first_response_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "conversations" ADD COLUMN "resolved_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "conversations" ADD COLUMN "last_inbound_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "conversations" ADD COLUMN "last_outbound_at" timestamp with time zone;--> statement-breakpoint
+UPDATE "conversations" c
+SET
+  "last_inbound_at" = (
+    SELECT max(p."occurred_at") FROM "conversation_parts" p
+    WHERE p."conversation_id" = c."id" AND p."direction" = 'inbound'
+  ),
+  "last_outbound_at" = (
+    SELECT max(p."occurred_at") FROM "conversation_parts" p
+    WHERE p."conversation_id" = c."id" AND p."direction" = 'outbound'
+  ),
+  "first_response_at" = (
+    SELECT min(outbound."occurred_at") FROM "conversation_parts" outbound
+    WHERE outbound."conversation_id" = c."id"
+      AND outbound."direction" = 'outbound'
+      AND outbound."occurred_at" >= coalesce((
+        SELECT min(inbound."occurred_at") FROM "conversation_parts" inbound
+        WHERE inbound."conversation_id" = c."id" AND inbound."direction" = 'inbound'
+      ), c."created_at")
+  ),
+  "waiting_on" = CASE
+    WHEN c."status" <> 'open' THEN NULL
+    WHEN (
+      SELECT p."direction" FROM "conversation_parts" p
+      WHERE p."conversation_id" = c."id"
+      ORDER BY p."sequence" DESC LIMIT 1
+    ) = 'inbound' THEN 'staff'::"conversation_waiting_on"
+    WHEN (
+      SELECT p."direction" FROM "conversation_parts" p
+      WHERE p."conversation_id" = c."id"
+      ORDER BY p."sequence" DESC LIMIT 1
+    ) = 'outbound' THEN 'customer'::"conversation_waiting_on"
+    ELSE NULL
+  END,
+  "resolved_at" = CASE WHEN c."status" = 'closed' THEN c."updated_at" ELSE NULL END;--> statement-breakpoint
+CREATE INDEX "idx_conversations_queue_cursor" ON "conversations" USING btree ("inbox_id","status","waiting_on","last_part_at","id");--> statement-breakpoint
+CREATE INDEX "idx_conversations_assignee_cursor" ON "conversations" USING btree ("inbox_id","assigned_to_user_id","last_part_at","id");--> statement-breakpoint
+CREATE INDEX "idx_conversations_priority_cursor" ON "conversations" USING btree ("inbox_id","priority","last_part_at","id");--> statement-breakpoint
+CREATE INDEX "idx_conversations_channel_cursor" ON "conversations" USING btree ("inbox_id","channel","last_part_at","id");

--- a/packages/conversations/migrations/meta/0004_snapshot.json
+++ b/packages/conversations/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1793 @@
+{
+  "id": "56f8588f-eae9-4ec0-ab7e-2dafe692d73a",
+  "prevId": "fa4e103b-8610-48b2-9423-7ff40667f5ab",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.conversation_attachments": {
+      "name": "conversation_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_id": {
+          "name": "part_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_handle": {
+          "name": "private_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'attachment'"
+        },
+        "inline_content_id": {
+          "name": "inline_content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scan_status": {
+          "name": "scan_status",
+          "type": "conversation_attachment_scan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "availability": {
+          "name": "availability",
+          "type": "conversation_attachment_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'quarantined'"
+        },
+        "retention_until": {
+          "name": "retention_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redacted_at": {
+          "name": "redacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_attachment_handle": {
+          "name": "uidx_conversation_attachment_handle",
+          "columns": [
+            {
+              "expression": "private_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_attachment_external": {
+          "name": "uidx_conversation_attachment_external",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversation_attachments_conversation": {
+          "name": "idx_conversation_attachments_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversation_attachments_part": {
+          "name": "idx_conversation_attachments_part",
+          "columns": [
+            {
+              "expression": "part_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversation_attachments_retention": {
+          "name": "idx_conversation_attachments_retention",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retention_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_attachments_conversation_id_conversations_id_fk": {
+          "name": "conversation_attachments_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_attachments",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_attachments_part_id_conversation_parts_id_fk": {
+          "name": "conversation_attachments_part_id_conversation_parts_id_fk",
+          "tableFrom": "conversation_attachments",
+          "tableTo": "conversation_parts",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_events": {
+      "name": "conversation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_conversation_events_conversation": {
+          "name": "idx_conversation_events_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_events_conversation_id_conversations_id_fk": {
+          "name": "conversation_events_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_events",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_inbox_memberships": {
+      "name": "conversation_inbox_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "conversation_inbox_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_inbox_membership": {
+          "name": "uidx_conversation_inbox_membership",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_inbox_memberships_inbox_id_conversation_inboxes_id_fk": {
+          "name": "conversation_inbox_memberships_inbox_id_conversation_inboxes_id_fk",
+          "tableFrom": "conversation_inbox_memberships",
+          "tableTo": "conversation_inboxes",
+          "columnsFrom": [
+            "inbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_inboxes": {
+      "name": "conversation_inboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_inboxes_name": {
+          "name": "uidx_conversation_inboxes_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_inboxes_single_default": {
+          "name": "uidx_conversation_inboxes_single_default",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_inboxes\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_ingress_operations": {
+      "name": "conversation_ingress_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_envelope_id": {
+          "name": "external_envelope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint": {
+          "name": "payload_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_part_id": {
+          "name": "conversation_part_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "conversation_ingress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'committed'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_ingress_envelope": {
+          "name": "uidx_conversation_ingress_envelope",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_envelope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_ingress_message": {
+          "name": "uidx_conversation_ingress_message",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_ingress_operations_conversation_part_id_conversation_parts_id_fk": {
+          "name": "conversation_ingress_operations_conversation_part_id_conversation_parts_id_fk",
+          "tableFrom": "conversation_ingress_operations",
+          "tableTo": "conversation_parts",
+          "columnsFrom": [
+            "conversation_part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_notes": {
+      "name": "conversation_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_conversation_notes_conversation": {
+          "name": "idx_conversation_notes_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_notes_conversation_id_conversations_id_fk": {
+          "name": "conversation_notes_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_notes",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "conversation_participant_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_ref": {
+          "name": "person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_point_ref": {
+          "name": "contact_point_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_participant_address": {
+          "name": "uidx_conversation_participant_address",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_parts": {
+      "name": "conversation_parts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "conversation_part_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_address": {
+          "name": "sender_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_addresses": {
+          "name": "recipient_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_status": {
+          "name": "content_status",
+          "type": "conversation_part_content_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        },
+        "legacy_attachment_count": {
+          "name": "legacy_attachment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification": {
+          "name": "classification",
+          "type": "conversation_part_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'message'"
+        },
+        "replyable": {
+          "name": "replyable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "payload_fingerprint": {
+          "name": "payload_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_delivery_id": {
+          "name": "notification_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admission_status": {
+          "name": "admission_status",
+          "type": "conversation_part_admission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_parts_external_message": {
+          "name": "uidx_conversation_parts_external_message",
+          "columns": [
+            {
+              "expression": "external_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_parts_message_id": {
+          "name": "uidx_conversation_parts_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_parts_idempotency": {
+          "name": "uidx_conversation_parts_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversation_parts_conversation_occurred": {
+          "name": "idx_conversation_parts_conversation_occurred",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversation_parts_sequence": {
+          "name": "uidx_conversation_parts_sequence",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_parts_conversation_id_conversations_id_fk": {
+          "name": "conversation_parts_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_parts",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_read_cursors": {
+      "name": "conversation_read_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_sequence": {
+          "name": "last_read_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversation_read_cursor": {
+          "name": "uidx_conversation_read_cursor",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_read_cursors_conversation_id_conversations_id_fk": {
+          "name": "conversation_read_cursors_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_read_cursors",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to_user_id": {
+          "name": "assigned_to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "conversation_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_part_sequence": {
+          "name": "next_part_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_subject": {
+          "name": "suggested_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_alias": {
+          "name": "reply_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_account_id": {
+          "name": "channel_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_address": {
+          "name": "local_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_address": {
+          "name": "customer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_ref": {
+          "name": "person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_point_ref": {
+          "name": "contact_point_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_idempotency_key": {
+          "name": "start_idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_payload_fingerprint": {
+          "name": "start_payload_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waiting_on": {
+          "name": "waiting_on",
+          "type": "conversation_waiting_on",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_response_at": {
+          "name": "first_response_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inbound_at": {
+          "name": "last_inbound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_outbound_at": {
+          "name": "last_outbound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_part_at": {
+          "name": "last_part_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_conversations_reply_alias": {
+          "name": "uidx_conversations_reply_alias",
+          "columns": [
+            {
+              "expression": "reply_alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversations_active_sms_pair": {
+          "name": "uidx_conversations_active_sms_pair",
+          "columns": [
+            {
+              "expression": "channel_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "customer_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversations\".\"channel\" = 'sms' AND \"conversations\".\"status\" IN ('open', 'snoozed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uidx_conversations_start_idempotency": {
+          "name": "uidx_conversations_start_idempotency",
+          "columns": [
+            {
+              "expression": "start_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_last_part": {
+          "name": "idx_conversations_last_part",
+          "columns": [
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_person": {
+          "name": "idx_conversations_person",
+          "columns": [
+            {
+              "expression": "person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_inbox_status": {
+          "name": "idx_conversations_inbox_status",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_assignee": {
+          "name": "idx_conversations_assignee",
+          "columns": [
+            {
+              "expression": "assigned_to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_queue_cursor": {
+          "name": "idx_conversations_queue_cursor",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "waiting_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_assignee_cursor": {
+          "name": "idx_conversations_assignee_cursor",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_priority_cursor": {
+          "name": "idx_conversations_priority_cursor",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_channel_cursor": {
+          "name": "idx_conversations_channel_cursor",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_part_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_inbox_id_conversation_inboxes_id_fk": {
+          "name": "conversations_inbox_id_conversation_inboxes_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "conversation_inboxes",
+          "columnsFrom": [
+            "inbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.conversation_attachment_availability": {
+      "name": "conversation_attachment_availability",
+      "schema": "public",
+      "values": [
+        "active",
+        "quarantined",
+        "redaction_pending",
+        "redacted"
+      ]
+    },
+    "public.conversation_attachment_scan_status": {
+      "name": "conversation_attachment_scan_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "clean",
+        "blocked",
+        "failed"
+      ]
+    },
+    "public.conversation_inbox_membership_role": {
+      "name": "conversation_inbox_membership_role",
+      "schema": "public",
+      "values": [
+        "member",
+        "manager"
+      ]
+    },
+    "public.conversation_ingress_status": {
+      "name": "conversation_ingress_status",
+      "schema": "public",
+      "values": [
+        "committed",
+        "drifted"
+      ]
+    },
+    "public.conversation_part_admission_status": {
+      "name": "conversation_part_admission_status",
+      "schema": "public",
+      "values": [
+        "received",
+        "pending",
+        "admitted",
+        "suppressed"
+      ]
+    },
+    "public.conversation_part_classification": {
+      "name": "conversation_part_classification",
+      "schema": "public",
+      "values": [
+        "message",
+        "automatic_reply",
+        "delivery_status",
+        "complaint",
+        "suspicious"
+      ]
+    },
+    "public.conversation_part_content_status": {
+      "name": "conversation_part_content_status",
+      "schema": "public",
+      "values": [
+        "safe",
+        "quarantined",
+        "redacted"
+      ]
+    },
+    "public.conversation_part_direction": {
+      "name": "conversation_part_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.conversation_participant_role": {
+      "name": "conversation_participant_role",
+      "schema": "public",
+      "values": [
+        "customer",
+        "staff"
+      ]
+    },
+    "public.conversation_priority": {
+      "name": "conversation_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.conversation_status": {
+      "name": "conversation_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed",
+        "snoozed"
+      ]
+    },
+    "public.conversation_waiting_on": {
+      "name": "conversation_waiting_on",
+      "schema": "public",
+      "values": [
+        "staff",
+        "customer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/conversations/migrations/meta/_journal.json
+++ b/packages/conversations/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1787017255414,
       "tag": "0003_sms_conversations",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1787019880702,
+      "tag": "0004_operational_inbox",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/conversations/openapi/admin/conversations.json
+++ b/packages/conversations/openapi/admin/conversations.json
@@ -41,6 +41,98 @@
           },
           {
             "schema": {
+              "type": "string",
+              "enum": ["low", "normal", "high", "urgent"]
+            },
+            "required": false,
+            "name": "priority",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            "required": false,
+            "name": "unread",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 32
+            },
+            "required": false,
+            "name": "channel",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            },
+            "required": false,
+            "name": "participant",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            },
+            "required": false,
+            "name": "q",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "required": false,
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "required": false,
+            "name": "to",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "unassigned",
+                "assigned_to_me",
+                "waiting_on_staff",
+                "waiting_on_customer",
+                "snoozed",
+                "closed"
+              ]
+            },
+            "required": false,
+            "name": "queue",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 1024
+            },
+            "required": false,
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
               "type": "integer",
               "exclusiveMinimum": 0,
               "maximum": 100
@@ -52,7 +144,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Membership-scoped Inbox",
+            "description": "Membership-scoped operational Inbox page",
             "content": {
               "application/json": {
                 "schema": {
@@ -119,7 +211,27 @@
                             "type": ["string", "null"],
                             "format": "date-time"
                           },
+                          "waitingOn": {
+                            "type": ["string", "null"],
+                            "enum": ["staff", "customer", null]
+                          },
+                          "firstResponseAt": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "resolvedAt": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
                           "closedAt": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "lastInboundAt": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "lastOutboundAt": {
                             "type": ["string", "null"],
                             "format": "date-time"
                           },
@@ -154,15 +266,29 @@
                           "contactPointRef",
                           "unreadCount",
                           "snoozedUntil",
+                          "waitingOn",
+                          "firstResponseAt",
+                          "resolvedAt",
                           "closedAt",
+                          "lastInboundAt",
+                          "lastOutboundAt",
                           "lastPartAt",
                           "createdAt",
                           "updatedAt"
                         ]
                       }
+                    },
+                    "page": {
+                      "type": "object",
+                      "properties": {
+                        "nextCursor": {
+                          "type": ["string", "null"]
+                        }
+                      },
+                      "required": ["nextCursor"]
                     }
                   },
-                  "required": ["data"]
+                  "required": ["data", "page"]
                 }
               }
             }
@@ -427,7 +553,27 @@
                               "type": ["string", "null"],
                               "format": "date-time"
                             },
+                            "waitingOn": {
+                              "type": ["string", "null"],
+                              "enum": ["staff", "customer", null]
+                            },
+                            "firstResponseAt": {
+                              "type": ["string", "null"],
+                              "format": "date-time"
+                            },
+                            "resolvedAt": {
+                              "type": ["string", "null"],
+                              "format": "date-time"
+                            },
                             "closedAt": {
+                              "type": ["string", "null"],
+                              "format": "date-time"
+                            },
+                            "lastInboundAt": {
+                              "type": ["string", "null"],
+                              "format": "date-time"
+                            },
+                            "lastOutboundAt": {
                               "type": ["string", "null"],
                               "format": "date-time"
                             },
@@ -462,7 +608,12 @@
                             "contactPointRef",
                             "unreadCount",
                             "snoozedUntil",
+                            "waitingOn",
+                            "firstResponseAt",
+                            "resolvedAt",
                             "closedAt",
+                            "lastInboundAt",
+                            "lastOutboundAt",
                             "lastPartAt",
                             "createdAt",
                             "updatedAt"
@@ -1108,6 +1259,530 @@
         }
       }
     },
+    "/v1/admin/conversations/bulk": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "revision": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        }
+                      },
+                      "required": ["id", "revision"]
+                    },
+                    "minItems": 1,
+                    "maxItems": 100
+                  },
+                  "changes": {
+                    "type": "object",
+                    "properties": {
+                      "assignedToUserId": {
+                        "type": ["string", "null"]
+                      },
+                      "status": {
+                        "type": "string",
+                        "enum": ["open", "closed", "snoozed"]
+                      },
+                      "snoozedUntil": {
+                        "type": ["string", "null"],
+                        "format": "date-time"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "required": ["items", "changes"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Audited optimistic bulk update",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "channel": {
+                            "type": "string"
+                          },
+                          "inboxId": {
+                            "type": "string"
+                          },
+                          "assignedToUserId": {
+                            "type": ["string", "null"]
+                          },
+                          "priority": {
+                            "type": "string",
+                            "enum": ["low", "normal", "high", "urgent"]
+                          },
+                          "revision": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": ["open", "closed", "snoozed"]
+                          },
+                          "subject": {
+                            "type": ["string", "null"]
+                          },
+                          "suggestedSubject": {
+                            "type": ["string", "null"]
+                          },
+                          "replyAlias": {
+                            "type": ["string", "null"]
+                          },
+                          "channelAccountId": {
+                            "type": ["string", "null"]
+                          },
+                          "localAddress": {
+                            "type": ["string", "null"]
+                          },
+                          "customerAddress": {
+                            "type": "string"
+                          },
+                          "personRef": {
+                            "type": ["string", "null"]
+                          },
+                          "contactPointRef": {
+                            "type": ["string", "null"]
+                          },
+                          "unreadCount": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "snoozedUntil": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "waitingOn": {
+                            "type": ["string", "null"],
+                            "enum": ["staff", "customer", null]
+                          },
+                          "firstResponseAt": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "resolvedAt": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "closedAt": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "lastInboundAt": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "lastOutboundAt": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "lastPartAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "channel",
+                          "inboxId",
+                          "assignedToUserId",
+                          "priority",
+                          "revision",
+                          "status",
+                          "subject",
+                          "suggestedSubject",
+                          "replyAlias",
+                          "channelAccountId",
+                          "localAddress",
+                          "customerAddress",
+                          "personRef",
+                          "contactPointRef",
+                          "unreadCount",
+                          "snoozedUntil",
+                          "waitingOn",
+                          "firstResponseAt",
+                          "resolvedAt",
+                          "closedAt",
+                          "lastInboundAt",
+                          "lastOutboundAt",
+                          "lastPartAt",
+                          "createdAt",
+                          "updatedAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid conversation operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authenticated staff required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Inbox membership required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Conversation resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Revision or idempotency conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/conversations/reporting": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "required": true,
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "required": true,
+            "name": "to",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "inboxId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Content-free operational reporting with non-authoritative SLA semantics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "period": {
+                          "type": "object",
+                          "properties": {
+                            "from": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "to": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          },
+                          "required": ["from", "to"]
+                        },
+                        "volumes": {
+                          "type": "object",
+                          "properties": {
+                            "new": {
+                              "type": "number"
+                            },
+                            "opened": {
+                              "type": "number"
+                            },
+                            "closed": {
+                              "type": "number"
+                            }
+                          },
+                          "required": ["new", "opened", "closed"]
+                        },
+                        "backlog": {
+                          "type": "number"
+                        },
+                        "averagesMs": {
+                          "type": "object",
+                          "properties": {
+                            "firstResponse": {
+                              "type": ["number", "null"]
+                            },
+                            "resolution": {
+                              "type": ["number", "null"]
+                            },
+                            "customerWaiting": {
+                              "type": ["number", "null"]
+                            }
+                          },
+                          "required": ["firstResponse", "resolution", "customerWaiting"]
+                        },
+                        "delivery": {
+                          "type": "object",
+                          "properties": {
+                            "failed": {
+                              "type": "number"
+                            },
+                            "suppressed": {
+                              "type": "number"
+                            }
+                          },
+                          "required": ["failed", "suppressed"]
+                        },
+                        "ingress": {
+                          "type": "object",
+                          "properties": {
+                            "averageLagMs": {
+                              "type": ["number", "null"]
+                            },
+                            "failedOrDrifted": {
+                              "type": "number"
+                            }
+                          },
+                          "required": ["averageLagMs", "failedOrDrifted"]
+                        },
+                        "sla": {
+                          "type": "object",
+                          "properties": {
+                            "authoritative": {
+                              "type": "boolean",
+                              "enum": [false]
+                            },
+                            "clock": {
+                              "type": "string",
+                              "enum": ["elapsed"]
+                            },
+                            "startsAt": {
+                              "type": "string",
+                              "enum": ["conversation_created"]
+                            },
+                            "pauses": {
+                              "type": "string",
+                              "enum": ["none"]
+                            },
+                            "reopen": {
+                              "type": "string",
+                              "enum": ["original_clock_continues"]
+                            },
+                            "businessHours": {
+                              "type": "string",
+                              "enum": ["not_configured"]
+                            }
+                          },
+                          "required": [
+                            "authoritative",
+                            "clock",
+                            "startsAt",
+                            "pauses",
+                            "reopen",
+                            "businessHours"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "period",
+                        "volumes",
+                        "backlog",
+                        "averagesMs",
+                        "delivery",
+                        "ingress",
+                        "sla"
+                      ]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid conversation operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authenticated staff required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Inbox membership required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Conversation resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Revision or idempotency conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/admin/conversations/{id}": {
       "get": {
         "parameters": [
@@ -1190,7 +1865,27 @@
                               "type": ["string", "null"],
                               "format": "date-time"
                             },
+                            "waitingOn": {
+                              "type": ["string", "null"],
+                              "enum": ["staff", "customer", null]
+                            },
+                            "firstResponseAt": {
+                              "type": ["string", "null"],
+                              "format": "date-time"
+                            },
+                            "resolvedAt": {
+                              "type": ["string", "null"],
+                              "format": "date-time"
+                            },
                             "closedAt": {
+                              "type": ["string", "null"],
+                              "format": "date-time"
+                            },
+                            "lastInboundAt": {
+                              "type": ["string", "null"],
+                              "format": "date-time"
+                            },
+                            "lastOutboundAt": {
                               "type": ["string", "null"],
                               "format": "date-time"
                             },
@@ -1225,7 +1920,12 @@
                             "contactPointRef",
                             "unreadCount",
                             "snoozedUntil",
+                            "waitingOn",
+                            "firstResponseAt",
+                            "resolvedAt",
                             "closedAt",
+                            "lastInboundAt",
+                            "lastOutboundAt",
                             "lastPartAt",
                             "createdAt",
                             "updatedAt"
@@ -1983,7 +2683,27 @@
                           "type": ["string", "null"],
                           "format": "date-time"
                         },
+                        "waitingOn": {
+                          "type": ["string", "null"],
+                          "enum": ["staff", "customer", null]
+                        },
+                        "firstResponseAt": {
+                          "type": ["string", "null"],
+                          "format": "date-time"
+                        },
+                        "resolvedAt": {
+                          "type": ["string", "null"],
+                          "format": "date-time"
+                        },
                         "closedAt": {
+                          "type": ["string", "null"],
+                          "format": "date-time"
+                        },
+                        "lastInboundAt": {
+                          "type": ["string", "null"],
+                          "format": "date-time"
+                        },
+                        "lastOutboundAt": {
                           "type": ["string", "null"],
                           "format": "date-time"
                         },
@@ -2018,7 +2738,12 @@
                         "contactPointRef",
                         "unreadCount",
                         "snoozedUntil",
+                        "waitingOn",
+                        "firstResponseAt",
+                        "resolvedAt",
                         "closedAt",
+                        "lastInboundAt",
+                        "lastOutboundAt",
                         "lastPartAt",
                         "createdAt",
                         "updatedAt"
@@ -2528,7 +3253,27 @@
                           "type": ["string", "null"],
                           "format": "date-time"
                         },
+                        "waitingOn": {
+                          "type": ["string", "null"],
+                          "enum": ["staff", "customer", null]
+                        },
+                        "firstResponseAt": {
+                          "type": ["string", "null"],
+                          "format": "date-time"
+                        },
+                        "resolvedAt": {
+                          "type": ["string", "null"],
+                          "format": "date-time"
+                        },
                         "closedAt": {
+                          "type": ["string", "null"],
+                          "format": "date-time"
+                        },
+                        "lastInboundAt": {
+                          "type": ["string", "null"],
+                          "format": "date-time"
+                        },
+                        "lastOutboundAt": {
                           "type": ["string", "null"],
                           "format": "date-time"
                         },
@@ -2563,7 +3308,12 @@
                         "contactPointRef",
                         "unreadCount",
                         "snoozedUntil",
+                        "waitingOn",
+                        "firstResponseAt",
+                        "resolvedAt",
                         "closedAt",
+                        "lastInboundAt",
+                        "lastOutboundAt",
                         "lastPartAt",
                         "createdAt",
                         "updatedAt"

--- a/packages/conversations/src/index.ts
+++ b/packages/conversations/src/index.ts
@@ -15,6 +15,7 @@ import { conversationsModule } from "./schema.js"
 
 export * from "./attachment-runtime.js"
 export * from "./content-security.js"
+export * from "./operations-service.js"
 export * from "./runtime-port.js"
 export * from "./schema.js"
 export * from "./service.js"

--- a/packages/conversations/src/operations-service.ts
+++ b/packages/conversations/src/operations-service.ts
@@ -1,0 +1,451 @@
+import { and, desc, eq, gte, isNull, lt, lte, or, type SQL, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type {
+  ConversationsDeliveryTruthReader,
+  ConversationsStaffDirectory,
+} from "./runtime-port.js"
+import {
+  type Conversation,
+  conversationInboxMemberships,
+  conversationParticipants,
+  conversationParts,
+  conversationReadCursors,
+  conversations,
+} from "./schema.js"
+import {
+  type ConversationActor,
+  type ConversationView,
+  updateConversationState,
+} from "./service.js"
+
+export type ConversationQueue =
+  | "unassigned"
+  | "assigned_to_me"
+  | "waiting_on_staff"
+  | "waiting_on_customer"
+  | "snoozed"
+  | "closed"
+
+export interface OperationalConversationQuery {
+  userId: string
+  inboxId?: string
+  assignedToUserId?: string
+  status?: "open" | "closed" | "snoozed"
+  priority?: "low" | "normal" | "high" | "urgent"
+  unread?: boolean
+  channel?: string
+  participant?: string
+  q?: string
+  from?: Date
+  to?: Date
+  queue?: ConversationQueue
+  cursor?: string
+  limit?: number
+}
+
+export interface OperationalConversationPage {
+  data: ConversationView[]
+  page: { nextCursor: string | null }
+}
+
+interface ConversationCursor {
+  version: 1
+  lastPartAt: string
+  id: string
+}
+
+export class ConversationQueryError extends Error {
+  readonly code = "conversation_query_invalid"
+}
+
+function encodeCursor(conversation: Conversation): string {
+  const value: ConversationCursor = {
+    version: 1,
+    lastPartAt: conversation.lastPartAt.toISOString(),
+    id: conversation.id,
+  }
+  return Buffer.from(JSON.stringify(value)).toString("base64url")
+}
+
+function decodeCursor(value: string): { lastPartAt: Date; id: string } {
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(value, "base64url").toString("utf8"),
+    ) as Partial<ConversationCursor>
+    if (
+      parsed.version !== 1 ||
+      typeof parsed.id !== "string" ||
+      typeof parsed.lastPartAt !== "string"
+    ) {
+      throw new Error("invalid cursor shape")
+    }
+    const lastPartAt = new Date(parsed.lastPartAt)
+    if (Number.isNaN(lastPartAt.getTime()) || parsed.id.length === 0)
+      throw new Error("invalid cursor")
+    return { lastPartAt, id: parsed.id }
+  } catch {
+    throw new ConversationQueryError("Conversation cursor is invalid")
+  }
+}
+
+function escapedLike(value: string): string {
+  return `%${value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_")}%`
+}
+
+/**
+ * Tenant-database-only operational search. The correlated body predicate excludes
+ * quarantined/redacted content and never copies message text or addresses into a
+ * deployment-wide catalog or metric label.
+ */
+export async function listOperationalConversations(
+  db: PostgresJsDatabase,
+  input: OperationalConversationQuery,
+): Promise<OperationalConversationPage> {
+  const limit = Math.min(Math.max(input.limit ?? 50, 1), 100)
+  if (input.from && input.to) {
+    const rangeMs = input.to.getTime() - input.from.getTime()
+    if (rangeMs < 0 || rangeMs > 366 * 24 * 60 * 60 * 1_000) {
+      throw new ConversationQueryError("Inbox date range must be between 0 and 366 days")
+    }
+  }
+  const filters: SQL[] = [
+    eq(conversationInboxMemberships.userId, input.userId),
+    eq(conversationInboxMemberships.active, true),
+  ]
+  if (input.inboxId) filters.push(eq(conversations.inboxId, input.inboxId))
+  if (input.assignedToUserId)
+    filters.push(eq(conversations.assignedToUserId, input.assignedToUserId))
+  if (input.status) filters.push(eq(conversations.status, input.status))
+  if (input.priority) filters.push(eq(conversations.priority, input.priority))
+  if (input.channel) filters.push(eq(conversations.channel, input.channel))
+  if (input.from) filters.push(gte(conversations.lastPartAt, input.from))
+  if (input.to) filters.push(lte(conversations.lastPartAt, input.to))
+  if (input.participant) {
+    const participant = escapedLike(input.participant.trim())
+    filters.push(sql`exists (
+      select 1 from ${conversationParticipants} participant
+      where participant.conversation_id = ${conversations.id}
+        and participant.address ilike ${participant} escape '\\'
+    )`)
+  }
+  if (input.q) {
+    const term = input.q.trim()
+    if (term.length < 2 || term.length > 100) {
+      throw new ConversationQueryError("Search must contain between 2 and 100 characters")
+    }
+    const pattern = escapedLike(term)
+    filters.push(sql`(
+      ${conversations.subject} ilike ${pattern} escape '\\'
+      or ${conversations.customerAddress} ilike ${pattern} escape '\\'
+      or ${conversations.personRef} ilike ${pattern} escape '\\'
+      or ${conversations.contactPointRef} ilike ${pattern} escape '\\'
+      or exists (
+        select 1 from ${conversationParticipants} participant
+        where participant.conversation_id = ${conversations.id}
+          and participant.address ilike ${pattern} escape '\\'
+      )
+      or exists (
+        select 1 from ${conversationParts} part
+        where part.conversation_id = ${conversations.id}
+          and part.content_status = 'safe'
+          and part.classification = 'message'
+          and (
+            part.text_body ilike ${pattern} escape '\\'
+            or regexp_replace(coalesce(part.html_body, ''), '<[^>]*>', ' ', 'g') ilike ${pattern} escape '\\'
+          )
+      )
+    )`)
+  }
+  if (input.unread !== undefined) {
+    const unread = sql`exists (
+      select 1 from ${conversationParts} unread_part
+      where unread_part.conversation_id = ${conversations.id}
+        and unread_part.direction = 'inbound'
+        and unread_part.sequence > coalesce((
+          select cursor.last_read_sequence from ${conversationReadCursors} cursor
+          where cursor.conversation_id = ${conversations.id}
+            and cursor.user_id = ${input.userId}
+        ), 0)
+    )`
+    filters.push(input.unread ? unread : sql`not (${unread})`)
+  }
+  switch (input.queue) {
+    case "unassigned":
+      filters.push(isNull(conversations.assignedToUserId), eq(conversations.status, "open"))
+      break
+    case "assigned_to_me":
+      filters.push(
+        eq(conversations.assignedToUserId, input.userId),
+        eq(conversations.status, "open"),
+      )
+      break
+    case "waiting_on_staff":
+      filters.push(eq(conversations.waitingOn, "staff"), eq(conversations.status, "open"))
+      break
+    case "waiting_on_customer":
+      filters.push(eq(conversations.waitingOn, "customer"), eq(conversations.status, "open"))
+      break
+    case "snoozed":
+      filters.push(eq(conversations.status, "snoozed"))
+      break
+    case "closed":
+      filters.push(eq(conversations.status, "closed"))
+      break
+  }
+  if (input.cursor) {
+    const cursor = decodeCursor(input.cursor)
+    filters.push(
+      or(
+        lt(conversations.lastPartAt, cursor.lastPartAt),
+        and(eq(conversations.lastPartAt, cursor.lastPartAt), lt(conversations.id, cursor.id)),
+      )!,
+    )
+  }
+  const unreadCount = sql<number>`(
+    select count(*)::int from ${conversationParts} unread_part
+    where unread_part.conversation_id = ${conversations.id}
+      and unread_part.direction = 'inbound'
+      and unread_part.sequence > coalesce((
+        select cursor.last_read_sequence from ${conversationReadCursors} cursor
+        where cursor.conversation_id = ${conversations.id}
+          and cursor.user_id = ${input.userId}
+      ), 0)
+  )`
+  const rows = await db
+    .select({ conversation: conversations, unreadCount })
+    .from(conversations)
+    .innerJoin(
+      conversationInboxMemberships,
+      eq(conversationInboxMemberships.inboxId, conversations.inboxId),
+    )
+    .where(and(...filters))
+    .orderBy(desc(conversations.lastPartAt), desc(conversations.id))
+    .limit(limit + 1)
+  const pageRows = rows.slice(0, limit)
+  const last = pageRows.at(-1)?.conversation
+  return {
+    data: pageRows.map(({ conversation, unreadCount: count }) => ({
+      ...conversation,
+      unreadCount: count,
+    })),
+    page: { nextCursor: rows.length > limit && last ? encodeCursor(last) : null },
+  }
+}
+
+export async function bulkUpdateConversations(
+  db: PostgresJsDatabase,
+  input: {
+    actor: ConversationActor
+    items: ReadonlyArray<{ id: string; revision: number }>
+    changes: {
+      assignedToUserId?: string | null
+      status?: "open" | "closed" | "snoozed"
+      snoozedUntil?: string | null
+    }
+    staffDirectory: ConversationsStaffDirectory
+    runtimeBindings?: unknown
+  },
+): Promise<Conversation[]> {
+  if (input.items.length === 0 || input.items.length > 100) {
+    throw new ConversationQueryError("Bulk operations require between 1 and 100 conversations")
+  }
+  if (new Set(input.items.map(({ id }) => id)).size !== input.items.length) {
+    throw new ConversationQueryError("Bulk operation contains duplicate conversations")
+  }
+  if (Object.keys(input.changes).length === 0) {
+    throw new ConversationQueryError("Bulk operation has no lifecycle or assignment change")
+  }
+  return db.transaction(async (transaction) => {
+    const tx = transaction as PostgresJsDatabase
+    const updated: Conversation[] = []
+    for (const item of input.items) {
+      updated.push(
+        await updateConversationState(tx, item.id, {
+          actor: input.actor,
+          revision: item.revision,
+          staffDirectory: input.staffDirectory,
+          runtimeBindings: input.runtimeBindings,
+          ...input.changes,
+        }),
+      )
+    }
+    return updated
+  })
+}
+
+export interface InboxOperationalReport {
+  period: { from: string; to: string }
+  volumes: { new: number; opened: number; closed: number }
+  backlog: number
+  averagesMs: {
+    firstResponse: number | null
+    resolution: number | null
+    customerWaiting: number | null
+  }
+  delivery: { failed: number; suppressed: number }
+  ingress: { averageLagMs: number | null; failedOrDrifted: number }
+  sla: {
+    authoritative: false
+    clock: "elapsed"
+    startsAt: "conversation_created"
+    pauses: "none"
+    reopen: "original_clock_continues"
+    businessHours: "not_configured"
+  }
+}
+
+function executedRows<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[]
+  if (result && typeof result === "object" && "rows" in result) {
+    const rows = (result as { rows?: unknown }).rows
+    if (Array.isArray(rows)) return rows as T[]
+  }
+  return []
+}
+
+/** Content-free, membership-scoped operational aggregates over durable tenant rows. */
+export async function getInboxOperationalReport(
+  db: PostgresJsDatabase,
+  input: {
+    userId: string
+    from: Date
+    to: Date
+    inboxId?: string
+    deliveryTruth?: ConversationsDeliveryTruthReader
+  },
+): Promise<InboxOperationalReport> {
+  if (input.to <= input.from) throw new ConversationQueryError("Reporting period is invalid")
+  if (input.to.getTime() - input.from.getTime() > 366 * 24 * 60 * 60 * 1_000) {
+    throw new ConversationQueryError("Reporting period cannot exceed 366 days")
+  }
+  const inboxFilter = input.inboxId ? sql`and c.inbox_id = ${input.inboxId}` : sql``
+  const summaryResult = await db.execute<{
+    newVolume: number
+    openedVolume: number
+    closedVolume: number
+    backlog: number
+    firstResponseMs: number | null
+    resolutionMs: number | null
+    customerWaitingMs: number | null
+  }>(sql`
+    select
+      count(*) filter (where c.created_at >= ${input.from} and c.created_at < ${input.to})::int as "newVolume",
+      count(*) filter (where c.last_inbound_at >= ${input.from} and c.last_inbound_at < ${input.to})::int as "openedVolume",
+      count(*) filter (where c.closed_at >= ${input.from} and c.closed_at < ${input.to})::int as "closedVolume",
+      count(*) filter (where c.status <> 'closed')::int as backlog,
+      avg(extract(epoch from (c.first_response_at - c.created_at)) * 1000)::float8 as "firstResponseMs",
+      avg(extract(epoch from (c.resolved_at - c.created_at)) * 1000)::float8 as "resolutionMs",
+      avg(extract(epoch from (${input.to}::timestamptz - c.last_inbound_at)) * 1000)
+        filter (where c.waiting_on = 'staff' and c.status = 'open')::float8 as "customerWaitingMs"
+    from conversations c
+    where exists (
+      select 1 from conversation_inbox_memberships membership
+      where membership.inbox_id = c.inbox_id
+        and membership.user_id = ${input.userId}
+        and membership.active = true
+    ) ${inboxFilter}
+  `)
+  const [summary] = executedRows<{
+    newVolume: number
+    openedVolume: number
+    closedVolume: number
+    backlog: number
+    firstResponseMs: number | null
+    resolutionMs: number | null
+    customerWaitingMs: number | null
+  }>(summaryResult)
+  const deliveryResult = await db.execute<{
+    notificationDeliveryId: string | null
+    admissionStatus: "received" | "pending" | "admitted" | "suppressed"
+  }>(sql`
+    select
+      part.notification_delivery_id as "notificationDeliveryId",
+      part.admission_status as "admissionStatus"
+    from conversation_parts part
+    join conversations c on c.id = part.conversation_id
+    where part.occurred_at >= ${input.from} and part.occurred_at < ${input.to}
+      and exists (
+        select 1 from conversation_inbox_memberships membership
+        where membership.inbox_id = c.inbox_id
+          and membership.user_id = ${input.userId}
+          and membership.active = true
+      ) ${inboxFilter}
+  `)
+  const deliveryRows = executedRows<{
+    notificationDeliveryId: string | null
+    admissionStatus: "received" | "pending" | "admitted" | "suppressed"
+  }>(deliveryResult)
+  const deliveryTruth: Record<string, import("./runtime-port.js").ConversationDeliveryTruth> = {}
+  const deliveryIds = deliveryRows.flatMap(({ notificationDeliveryId }) =>
+    notificationDeliveryId ? [notificationDeliveryId] : [],
+  )
+  if (input.deliveryTruth) {
+    for (let offset = 0; offset < deliveryIds.length; offset += 100) {
+      Object.assign(
+        deliveryTruth,
+        await input.deliveryTruth.getDeliveryTruth(db, deliveryIds.slice(offset, offset + 100)),
+      )
+    }
+  }
+  let failedDeliveries = 0
+  let suppressedDeliveries = 0
+  for (const row of deliveryRows) {
+    const truth = row.notificationDeliveryId
+      ? deliveryTruth[row.notificationDeliveryId]
+      : undefined
+    if (truth === "failed" || truth === "bounced" || truth === "complained") {
+      failedDeliveries += 1
+    }
+    if (truth === "suppressed" || (!truth && row.admissionStatus === "suppressed")) {
+      suppressedDeliveries += 1
+    }
+  }
+  const ingressResult = await db.execute<{
+    averageLagMs: number | null
+    failedOrDrifted: number
+  }>(sql`
+    select
+      avg(extract(epoch from (operation.committed_at - operation.created_at)) * 1000)::float8 as "averageLagMs",
+      count(*) filter (where operation.status = 'drifted')::int as "failedOrDrifted"
+    from conversation_ingress_operations operation
+    left join conversation_parts part on part.id = operation.conversation_part_id
+    left join conversations c on c.id = part.conversation_id
+    where operation.created_at >= ${input.from} and operation.created_at < ${input.to}
+      and (c.id is null or exists (
+        select 1 from conversation_inbox_memberships membership
+        where membership.inbox_id = c.inbox_id
+          and membership.user_id = ${input.userId}
+          and membership.active = true
+      )) ${inboxFilter}
+  `)
+  const [ingress] = executedRows<{ averageLagMs: number | null; failedOrDrifted: number }>(
+    ingressResult,
+  )
+  return {
+    period: { from: input.from.toISOString(), to: input.to.toISOString() },
+    volumes: {
+      new: summary?.newVolume ?? 0,
+      opened: summary?.openedVolume ?? 0,
+      closed: summary?.closedVolume ?? 0,
+    },
+    backlog: summary?.backlog ?? 0,
+    averagesMs: {
+      firstResponse: summary?.firstResponseMs ?? null,
+      resolution: summary?.resolutionMs ?? null,
+      customerWaiting: summary?.customerWaitingMs ?? null,
+    },
+    delivery: { failed: failedDeliveries, suppressed: suppressedDeliveries },
+    ingress: {
+      averageLagMs: ingress?.averageLagMs ?? null,
+      failedOrDrifted: ingress?.failedOrDrifted ?? 0,
+    },
+    sla: {
+      authoritative: false,
+      clock: "elapsed",
+      startsAt: "conversation_created",
+      pauses: "none",
+      reopen: "original_clock_continues",
+      businessHours: "not_configured",
+    },
+  }
+}

--- a/packages/conversations/src/routes.ts
+++ b/packages/conversations/src/routes.ts
@@ -12,6 +12,12 @@ import {
   requestAttachmentRedaction,
 } from "./attachment-service.js"
 import { ConversationAttachmentPolicyError } from "./content-security.js"
+import {
+  bulkUpdateConversations,
+  ConversationQueryError,
+  getInboxOperationalReport,
+  listOperationalConversations,
+} from "./operations-service.js"
 import type {
   ConversationsChannelPolicy,
   ConversationsDeliveryTruthReader,
@@ -34,7 +40,6 @@ import {
   getConversation,
   listAssignableStaff,
   listConversationInboxes,
-  listConversations,
   markConversationRead,
   replyToConversation,
   setConversationInboxMembership,
@@ -79,7 +84,12 @@ const conversationSchema = z.object({
   contactPointRef: z.string().nullable(),
   unreadCount: z.number().int().nonnegative(),
   snoozedUntil: timestamp.nullable(),
+  waitingOn: z.enum(["staff", "customer"]).nullable(),
+  firstResponseAt: timestamp.nullable(),
+  resolvedAt: timestamp.nullable(),
   closedAt: timestamp.nullable(),
+  lastInboundAt: timestamp.nullable(),
+  lastOutboundAt: timestamp.nullable(),
   lastPartAt: timestamp,
   createdAt: timestamp,
   updatedAt: timestamp,
@@ -212,11 +222,102 @@ const listRoute = createRoute({
       status: z.enum(["open", "closed", "snoozed"]).optional(),
       inboxId: z.string().optional(),
       assignedToUserId: z.string().optional(),
+      priority: priority.optional(),
+      unread: z
+        .enum(["true", "false"])
+        .transform((value) => value === "true")
+        .optional(),
+      channel: z.string().trim().min(1).max(32).optional(),
+      participant: z.string().trim().min(2).max(100).optional(),
+      q: z.string().trim().min(2).max(100).optional(),
+      from: timestamp.optional(),
+      to: timestamp.optional(),
+      queue: z
+        .enum([
+          "unassigned",
+          "assigned_to_me",
+          "waiting_on_staff",
+          "waiting_on_customer",
+          "snoozed",
+          "closed",
+        ])
+        .optional(),
+      cursor: z.string().min(1).max(1024).optional(),
       limit: z.coerce.number().int().positive().max(100).optional(),
     }),
   },
   responses: {
-    200: json(data(z.array(conversationSchema)), "Membership-scoped Inbox"),
+    200: json(
+      z.object({
+        data: z.array(conversationSchema),
+        page: z.object({ nextCursor: z.string().nullable() }),
+      }),
+      "Membership-scoped operational Inbox page",
+    ),
+    ...standardErrors,
+  },
+})
+const bulkRoute = createRoute({
+  method: "post",
+  path: "/v1/admin/conversations/bulk",
+  request: {
+    body: body(
+      z.object({
+        items: z
+          .array(z.object({ id: z.string(), revision: z.number().int().positive() }))
+          .min(1)
+          .max(100),
+        changes: z
+          .object({
+            assignedToUserId: z.string().nullable().optional(),
+            status: z.enum(["open", "closed", "snoozed"]).optional(),
+            snoozedUntil: timestamp.nullable().optional(),
+          })
+          .strict()
+          .refine(
+            (value) => Object.keys(value).length > 0,
+            "A lifecycle or assignment change is required",
+          ),
+      }),
+    ),
+  },
+  responses: {
+    200: json(data(z.array(conversationSchema)), "Audited optimistic bulk update"),
+    ...standardErrors,
+  },
+})
+const reportingRoute = createRoute({
+  method: "get",
+  path: "/v1/admin/conversations/reporting",
+  request: {
+    query: z.object({ from: timestamp, to: timestamp, inboxId: z.string().optional() }),
+  },
+  responses: {
+    200: json(
+      data(
+        z.object({
+          period: z.object({ from: timestamp, to: timestamp }),
+          volumes: z.object({ new: z.number(), opened: z.number(), closed: z.number() }),
+          backlog: z.number(),
+          averagesMs: z.object({
+            firstResponse: z.number().nullable(),
+            resolution: z.number().nullable(),
+            customerWaiting: z.number().nullable(),
+          }),
+          delivery: z.object({ failed: z.number(), suppressed: z.number() }),
+          ingress: z.object({ averageLagMs: z.number().nullable(), failedOrDrifted: z.number() }),
+          sla: z.object({
+            authoritative: z.literal(false),
+            clock: z.literal("elapsed"),
+            startsAt: z.literal("conversation_created"),
+            pauses: z.literal("none"),
+            reopen: z.literal("original_clock_continues"),
+            businessHours: z.literal("not_configured"),
+          }),
+        }),
+      ),
+      "Content-free operational reporting with non-authoritative SLA semantics",
+    ),
     ...standardErrors,
   },
 })
@@ -528,6 +629,7 @@ async function toDetailDto(
 
 function serviceError(error: unknown): { status: 400 | 403 | 404 | 409; error: string } | null {
   if (error instanceof ConversationNotFoundError) return { status: 404, error: error.code }
+  if (error instanceof ConversationQueryError) return { status: 400, error: error.code }
   if (error instanceof ConversationAccessDeniedError) return { status: 403, error: error.code }
   if (error instanceof ConversationInvalidStateError) return { status: 400, error: error.code }
   if (error instanceof ConversationConflictError || error instanceof ConversationIngressDriftError)
@@ -572,11 +674,44 @@ export function createConversationsRoutes(options: ConversationsRoutesOptions) {
   register(listRoute, async (c: RouteContext) => {
     const actor = await actorFor(c)
     if (!actor) return c.json({ error: "active_staff_required" }, 401)
-    const rows = await listConversations(options.resolveDb(c.env), {
-      ...c.req.valid("query"),
+    const query = c.req.valid("query")
+    const page = await listOperationalConversations(options.resolveDb(c.env), {
+      ...query,
       userId: actor.userId,
+      ...(query.from ? { from: new Date(query.from) } : {}),
+      ...(query.to ? { to: new Date(query.to) } : {}),
     })
-    return c.json(response({ data: rows.map(toConversationDto) }), 200)
+    return c.json(response({ data: page.data.map(toConversationDto), page: page.page }), 200)
+  })
+  register(bulkRoute, async (c: RouteContext) => {
+    const actor = await actorFor(c)
+    if (!actor) return c.json({ error: "active_staff_required" }, 401)
+    const result = await handle(() =>
+      bulkUpdateConversations(options.resolveDb(c.env), {
+        actor,
+        staffDirectory: options.staffDirectory,
+        runtimeBindings: c.env,
+        ...c.req.valid("json"),
+      }),
+    )
+    if (result.error) return c.json({ error: result.error.error }, result.error.status)
+    return c.json(response({ data: result.value!.map(toConversationDto) }), 200)
+  })
+  register(reportingRoute, async (c: RouteContext) => {
+    const actor = await actorFor(c)
+    if (!actor) return c.json({ error: "active_staff_required" }, 401)
+    const query = c.req.valid("query")
+    const result = await handle(() =>
+      getInboxOperationalReport(options.resolveDb(c.env), {
+        userId: actor.userId,
+        from: new Date(query.from),
+        to: new Date(query.to),
+        ...(query.inboxId ? { inboxId: query.inboxId } : {}),
+        ...(options.deliveryTruth ? { deliveryTruth: options.deliveryTruth } : {}),
+      }),
+    )
+    if (result.error) return c.json({ error: result.error.error }, result.error.status)
+    return c.json(response({ data: result.value }), 200)
   })
   register(detailRoute, async (c: RouteContext) => {
     const actor = await actorFor(c)

--- a/packages/conversations/src/schema.ts
+++ b/packages/conversations/src/schema.ts
@@ -20,6 +20,7 @@ export const conversationPriorityEnum = pgEnum("conversation_priority", [
   "high",
   "urgent",
 ])
+export const conversationWaitingOnEnum = pgEnum("conversation_waiting_on", ["staff", "customer"])
 export const conversationInboxMembershipRoleEnum = pgEnum("conversation_inbox_membership_role", [
   "member",
   "manager",
@@ -122,7 +123,12 @@ export const conversations = pgTable(
     startIdempotencyKey: text("start_idempotency_key"),
     startPayloadFingerprint: text("start_payload_fingerprint"),
     snoozedUntil: timestamp("snoozed_until", { withTimezone: true }),
+    waitingOn: conversationWaitingOnEnum("waiting_on"),
+    firstResponseAt: timestamp("first_response_at", { withTimezone: true }),
+    resolvedAt: timestamp("resolved_at", { withTimezone: true }),
     closedAt: timestamp("closed_at", { withTimezone: true }),
+    lastInboundAt: timestamp("last_inbound_at", { withTimezone: true }),
+    lastOutboundAt: timestamp("last_outbound_at", { withTimezone: true }),
     lastPartAt: timestamp("last_part_at", { withTimezone: true }).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
@@ -137,6 +143,31 @@ export const conversations = pgTable(
     index("idx_conversations_person").on(table.personRef),
     index("idx_conversations_inbox_status").on(table.inboxId, table.status, table.lastPartAt),
     index("idx_conversations_assignee").on(table.assignedToUserId, table.lastPartAt),
+    index("idx_conversations_queue_cursor").on(
+      table.inboxId,
+      table.status,
+      table.waitingOn,
+      table.lastPartAt,
+      table.id,
+    ),
+    index("idx_conversations_assignee_cursor").on(
+      table.inboxId,
+      table.assignedToUserId,
+      table.lastPartAt,
+      table.id,
+    ),
+    index("idx_conversations_priority_cursor").on(
+      table.inboxId,
+      table.priority,
+      table.lastPartAt,
+      table.id,
+    ),
+    index("idx_conversations_channel_cursor").on(
+      table.inboxId,
+      table.channel,
+      table.lastPartAt,
+      table.id,
+    ),
   ],
 )
 

--- a/packages/conversations/src/service.ts
+++ b/packages/conversations/src/service.ts
@@ -460,6 +460,10 @@ async function ingestEmailEnvelope(
         contactPointRef: person?.contactPointRef ?? null,
         nextPartSequence: 2,
         status: isCustomerMessage ? "open" : "closed",
+        waitingOn: isCustomerMessage ? "staff" : null,
+        lastInboundAt: isCustomerMessage ? occurredAt : null,
+        closedAt: isCustomerMessage ? null : occurredAt,
+        resolvedAt: isCustomerMessage ? null : occurredAt,
         lastPartAt: occurredAt,
       })
       await tx.insert(conversationParticipants).values({
@@ -475,8 +479,11 @@ async function ingestEmailEnvelope(
         .set({
           status: "open",
           snoozedUntil: null,
+          waitingOn: "staff",
+          lastInboundAt: sql`greatest(coalesce(${conversations.lastInboundAt}, ${occurredAt.toISOString()}::timestamptz), ${occurredAt.toISOString()}::timestamptz)`,
           closedAt: null,
-          lastPartAt: sql`GREATEST(${conversations.lastPartAt}, ${occurredAt.toISOString()}::timestamptz)`,
+          resolvedAt: null,
+          lastPartAt: sql`greatest(${conversations.lastPartAt}, ${occurredAt.toISOString()}::timestamptz)`,
           revision: sql`${conversations.revision} + 1`,
           updatedAt: new Date(),
         })
@@ -1101,6 +1108,9 @@ export async function startConversation(
         contactPointRef: input.contactPointRef,
         startIdempotencyKey: input.idempotencyKey,
         startPayloadFingerprint: startFingerprint,
+        waitingOn: "customer",
+        lastOutboundAt: now,
+        firstResponseAt: now,
         lastPartAt: now,
       })
       .onConflictDoNothing()
@@ -1331,6 +1341,9 @@ async function admitReplyWithinTransaction(
     .update(conversations)
     .set({
       lastPartAt: now,
+      waitingOn: "customer",
+      lastOutboundAt: now,
+      firstResponseAt: sql`coalesce(${conversations.firstResponseAt}, ${now})`,
       revision: sql`${conversations.revision} + 1`,
       updatedAt: now,
     })
@@ -1407,6 +1420,7 @@ export async function updateConversationState(
         throw new ConversationInvalidStateError("Assignee is not active staff")
       }
     }
+    const stateChangedAt = new Date()
     const snoozedUntil =
       input.status === "snoozed" && input.snoozedUntil ? new Date(input.snoozedUntil) : null
     if (input.status === "snoozed" && (!snoozedUntil || snoozedUntil <= new Date())) {
@@ -1417,14 +1431,19 @@ export async function updateConversationState(
       .set({
         ...(input.status ? { status: input.status } : {}),
         ...(input.status ? { snoozedUntil } : {}),
-        ...(input.status ? { closedAt: input.status === "closed" ? new Date() : null } : {}),
+        ...(input.status === "closed"
+          ? { closedAt: stateChangedAt, resolvedAt: stateChangedAt }
+          : {}),
+        ...(input.status === "open" && current.status === "closed"
+          ? { closedAt: null, resolvedAt: null }
+          : {}),
         ...(input.priority ? { priority: input.priority } : {}),
         ...(input.assignedToUserId !== undefined
           ? { assignedToUserId: input.assignedToUserId }
           : {}),
         ...(input.inboxId ? { inboxId: input.inboxId } : {}),
         revision: sql`${conversations.revision} + 1`,
-        updatedAt: new Date(),
+        updatedAt: stateChangedAt,
       })
       .where(and(eq(conversations.id, id), eq(conversations.revision, input.revision)))
       .returning()

--- a/packages/conversations/tests/integration/operations.test.ts
+++ b/packages/conversations/tests/integration/operations.test.ts
@@ -1,0 +1,289 @@
+import { readFileSync } from "node:fs"
+import { PGlite } from "@electric-sql/pglite"
+import { drizzle } from "drizzle-orm/pglite"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import {
+  bulkUpdateConversations,
+  getInboxOperationalReport,
+  listOperationalConversations,
+} from "../../src/operations-service.js"
+import {
+  conversationEvents,
+  conversationInboxes,
+  conversationInboxMemberships,
+  conversationParticipants,
+  conversationParts,
+  conversations,
+} from "../../src/schema.js"
+
+const inboxA = "cvin_ops_a"
+const inboxB = "cvin_ops_b"
+const staffA = "staff-a"
+
+describe("operational Inbox persistence", () => {
+  let client: PGlite
+  let db: ReturnType<typeof drizzle>
+
+  beforeAll(async () => {
+    client = new PGlite()
+    db = drizzle(client)
+    for (const migration of [
+      "0000_conversations_baseline.sql",
+      "0001_collaboration.sql",
+      "0002_secure_content.sql",
+      "0003_sms_conversations.sql",
+      "0004_operational_inbox.sql",
+    ]) {
+      await client.exec(readMigration(migration))
+    }
+    await client.exec(`
+      CREATE TABLE event_outbox (
+        id text primary key, event_id text not null unique, name text not null,
+        payload jsonb, metadata jsonb, status text not null default 'pending',
+        attempts integer not null default 0, max_attempts integer not null default 8,
+        next_attempt_at timestamptz not null default now(), last_error text,
+        attempt_errors jsonb, created_at timestamptz not null default now(),
+        delivered_at timestamptz
+      );
+    `)
+  })
+
+  beforeEach(async () => {
+    await client.exec(`
+      TRUNCATE event_outbox, conversation_events, conversation_ingress_operations,
+        conversation_attachments, conversation_read_cursors, conversation_notes,
+        conversation_participants, conversation_parts, conversations,
+        conversation_inbox_memberships, conversation_inboxes CASCADE;
+    `)
+    await db.insert(conversationInboxes).values([
+      { id: inboxA, name: "Operations A", isDefault: true },
+      { id: inboxB, name: "Operations B" },
+    ])
+    await db.insert(conversationInboxMemberships).values({
+      id: "cvim_ops_a",
+      inboxId: inboxA,
+      userId: staffA,
+      role: "manager",
+      active: true,
+    })
+  })
+
+  afterAll(async () => client.close())
+
+  it("keeps deep keyset pages stable when a newer conversation arrives", async () => {
+    const at = new Date("2026-08-18T10:00:00.000Z")
+    for (let index = 0; index < 125; index += 1) {
+      await seedConversation(db, {
+        id: `conv_${String(index).padStart(3, "0")}`,
+        inboxId: inboxA,
+        lastPartAt: new Date(at.getTime() - index * 1_000),
+      })
+    }
+    const first = await listOperationalConversations(db as never, { userId: staffA, limit: 40 })
+    expect(first.data).toHaveLength(40)
+    await seedConversation(db, {
+      id: "conv_newer",
+      inboxId: inboxA,
+      lastPartAt: new Date("2026-08-18T11:00:00.000Z"),
+    })
+    const seen = new Set(first.data.map(({ id }) => id))
+    let cursor = first.page.nextCursor
+    while (cursor) {
+      const page = await listOperationalConversations(db as never, {
+        userId: staffA,
+        cursor,
+        limit: 40,
+      })
+      for (const row of page.data) {
+        expect(seen.has(row.id)).toBe(false)
+        seen.add(row.id)
+      }
+      cursor = page.page.nextCursor
+    }
+    expect(seen).toHaveLength(125)
+    expect(seen.has("conv_newer")).toBe(false)
+  })
+
+  it("enforces membership and searches only safe tenant content", async () => {
+    await seedConversation(db, { id: "allowed", inboxId: inboxA, subject: "Rail itinerary" })
+    await seedPart(db, "allowed", 1, "Visible reservation reference", "safe")
+    await db.insert(conversationParticipants).values({
+      conversationId: "allowed",
+      role: "customer",
+      address: "traveller@example.test",
+    })
+    await seedConversation(db, { id: "forbidden", inboxId: inboxB, subject: "Rail secret" })
+    await seedPart(db, "forbidden", 1, "Visible reservation reference", "safe")
+    await seedConversation(db, { id: "quarantined", inboxId: inboxA })
+    await seedPart(db, "quarantined", 1, "malicious needle", "quarantined")
+
+    const subject = await listOperationalConversations(db as never, { userId: staffA, q: "Rail" })
+    expect(subject.data.map(({ id }) => id)).toEqual(["allowed"])
+    const address = await listOperationalConversations(db as never, {
+      userId: staffA,
+      participant: "traveller@",
+    })
+    expect(address.data.map(({ id }) => id)).toEqual(["allowed"])
+    const unsafe = await listOperationalConversations(db as never, {
+      userId: staffA,
+      q: "malicious",
+    })
+    expect(unsafe.data).toHaveLength(0)
+  })
+
+  it("serves indexed queue projections and per-user unread state", async () => {
+    await seedConversation(db, { id: "unassigned", inboxId: inboxA, waitingOn: "staff" })
+    await seedPart(db, "unassigned", 1, "Need help", "safe")
+    await seedConversation(db, {
+      id: "mine",
+      inboxId: inboxA,
+      assignedToUserId: staffA,
+      waitingOn: "customer",
+    })
+    expect(
+      (
+        await listOperationalConversations(db as never, { userId: staffA, queue: "unassigned" })
+      ).data.map(({ id }) => id),
+    ).toEqual(["unassigned"])
+    expect(
+      (
+        await listOperationalConversations(db as never, {
+          userId: staffA,
+          queue: "assigned_to_me",
+        })
+      ).data.map(({ id }) => id),
+    ).toEqual(["mine"])
+    expect(
+      (await listOperationalConversations(db as never, { userId: staffA, unread: true })).data.map(
+        ({ id }) => id,
+      ),
+    ).toEqual(["unassigned"])
+  })
+
+  it("applies optimistic bulk lifecycle changes with an event and outbox row per item", async () => {
+    await seedConversation(db, { id: "bulk_a", inboxId: inboxA })
+    await seedConversation(db, { id: "bulk_b", inboxId: inboxA })
+    const updated = await bulkUpdateConversations(db as never, {
+      actor: { userId: staffA, correlationId: "bulk-correlation" },
+      items: [
+        { id: "bulk_a", revision: 1 },
+        { id: "bulk_b", revision: 1 },
+      ],
+      changes: { assignedToUserId: staffA, status: "closed" },
+      staffDirectory: { isActiveStaff: async () => true, listActiveStaff: async () => [] },
+    })
+    expect(
+      updated.every(
+        ({ status, assignedToUserId }) => status === "closed" && assignedToUserId === staffA,
+      ),
+    ).toBe(true)
+    const events = await db.select().from(conversationEvents)
+    expect(events).toHaveLength(2)
+    const outbox = await client.query<{ count: number }>(
+      "select count(*)::int as count from event_outbox",
+    )
+    expect(outbox.rows[0]?.count).toBe(2)
+  })
+
+  it("reconstructs content-free reporting and uses a queue cursor index", async () => {
+    const createdAt = new Date("2026-08-18T08:00:00.000Z")
+    await seedConversation(db, {
+      id: "reported",
+      inboxId: inboxA,
+      createdAt,
+      lastPartAt: new Date("2026-08-18T09:00:00.000Z"),
+      lastInboundAt: new Date("2026-08-18T08:10:00.000Z"),
+      firstResponseAt: new Date("2026-08-18T08:20:00.000Z"),
+      waitingOn: "staff",
+    })
+    await seedPart(db, "reported", 1, "private body", "safe", "admitted")
+    const report = await getInboxOperationalReport(db as never, {
+      userId: staffA,
+      from: new Date("2026-08-18T00:00:00.000Z"),
+      to: new Date("2026-08-19T00:00:00.000Z"),
+      deliveryTruth: {
+        async getDeliveryTruth(_database, deliveryIds) {
+          return Object.fromEntries(deliveryIds.map((id) => [id, "failed" as const]))
+        },
+      },
+    })
+    expect(report.volumes.new).toBe(1)
+    expect(report.backlog).toBe(1)
+    expect(report.averagesMs.firstResponse).toBe(20 * 60_000)
+    expect(report.delivery.failed).toBe(1)
+    expect(report.sla.authoritative).toBe(false)
+    expect(JSON.stringify(report)).not.toContain("private body")
+
+    await client.exec("SET enable_seqscan = off")
+    const explained = await client.query<{ "QUERY PLAN": string }>(`
+      EXPLAIN SELECT id FROM conversations
+      WHERE inbox_id = '${inboxA}' AND status = 'open' AND waiting_on = 'staff'
+      ORDER BY last_part_at DESC, id DESC LIMIT 50
+    `)
+    expect(explained.rows.map((row) => row["QUERY PLAN"]).join("\n")).toMatch(
+      /idx_conversations_queue_cursor/,
+    )
+  })
+})
+
+async function seedConversation(
+  db: ReturnType<typeof drizzle>,
+  input: {
+    id: string
+    inboxId: string
+    subject?: string
+    assignedToUserId?: string | null
+    waitingOn?: "staff" | "customer" | null
+    createdAt?: Date
+    lastPartAt?: Date
+    lastInboundAt?: Date | null
+    firstResponseAt?: Date | null
+  },
+) {
+  const lastPartAt = input.lastPartAt ?? new Date("2026-08-18T10:00:00.000Z")
+  await db.insert(conversations).values({
+    id: input.id,
+    inboxId: input.inboxId,
+    assignedToUserId: input.assignedToUserId ?? null,
+    waitingOn: input.waitingOn ?? null,
+    subject: input.subject ?? null,
+    replyAlias: `${input.id}@inbox.example.test`,
+    customerAddress: `${input.id}@customer.example.test`,
+    nextPartSequence: 2,
+    createdAt: input.createdAt ?? lastPartAt,
+    lastPartAt,
+    lastInboundAt: input.lastInboundAt ?? null,
+    firstResponseAt: input.firstResponseAt ?? null,
+  })
+}
+
+async function seedPart(
+  db: ReturnType<typeof drizzle>,
+  conversationId: string,
+  sequence: number,
+  textBody: string,
+  contentStatus: "safe" | "quarantined" | "redacted",
+  admissionStatus: "received" | "admitted" = "received",
+) {
+  await db.insert(conversationParts).values({
+    id: `part_${conversationId}_${sequence}`,
+    conversationId,
+    sequence,
+    direction: "inbound",
+    senderAddress: "customer@example.test",
+    recipientAddresses: ["inbox@example.test"],
+    textBody,
+    contentStatus,
+    payloadFingerprint: `${conversationId}:${sequence}`,
+    notificationDeliveryId: admissionStatus === "admitted" ? `delivery_${conversationId}` : null,
+    admissionStatus,
+    occurredAt: new Date("2026-08-18T10:00:00.000Z"),
+  })
+}
+
+function readMigration(name: string): string {
+  return readFileSync(new URL(`../../migrations/${name}`, import.meta.url), "utf8").replaceAll(
+    "--> statement-breakpoint",
+    "",
+  )
+}


### PR DESCRIPTION
## Summary
- adds tenant-database-only membership-scoped Inbox search, filters, stable keyset pagination, and indexed queues
- adds revision-checked audited bulk assignment/lifecycle operations with no bulk-send surface
- adds content-free operational reporting reconstructed from durable Conversation and Notification truth
- documents explicit non-authoritative elapsed-time SLA semantics

## Stack
Depends on the Inbox foundation, collaboration, secure content, and SMS slices already merged into feat/inbox.

Closes #4832

## Verification
- Conversations and Conversations React typechecks
- Operations PGlite integration tests: 5/5
- graph conformance and operator preparation
- OpenAPI drift: 81 documents
- admin API client generation: 61 documents
- diff check and proprietary-name scan