### PR TITLE
feat(relationships): add an exact Person communication timeline

### DIFF
--- a/.changeset/strong-rivers-connect.md
+++ b/.changeset/strong-rivers-connect.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/relationships-contracts": minor
+"@voyant-travel/relationships": minor
+"@voyant-travel/relationships-react": minor
+"@voyant-travel/conversations": minor
+"@voyant-travel/notifications": minor
+---
+
+Add an exact Person communication timeline, read-only People directory integration for Inbox, and a capability-aware Person conversation composer.

--- a/packages/admin-api-client/src/generated/relationships.ts
+++ b/packages/admin-api-client/src/generated/relationships.ts
@@ -310,6 +310,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/v1/admin/relationships/people/{id}/communications/timeline": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** GET /v1/admin/relationships/people/{id}/communications/timeline */
+    get: operations["getAdminRelationshipsPeopleByIdCommunicationsTimeline"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/v1/admin/relationships/segments": {
     parameters: {
       query?: never
@@ -3014,6 +3031,87 @@ export interface operations {
         }
       }
       /** @description invalid_request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+      /** @description Person not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+  getAdminRelationshipsPeopleByIdCommunicationsTimeline: {
+    parameters: {
+      query?: {
+        limit?: number
+        cursor?: string
+        channel?: "email" | "phone" | "whatsapp" | "sms" | "meeting" | "other"
+        direction?: "inbound" | "outbound"
+        dateFrom?: string
+        dateTo?: string
+      }
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Exact chronological Person communication timeline */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              id: string
+              personId: string
+              organizationId: string | null
+              conversationId: string | null
+              /** @enum {string} */
+              channel: "email" | "phone" | "whatsapp" | "sms" | "meeting" | "other"
+              /** @enum {string} */
+              direction: "inbound" | "outbound"
+              subject: string | null
+              content: string | null
+              /** @enum {string|null} */
+              deliveryStatus:
+                | "received"
+                | "pending"
+                | "accepted"
+                | "delivered"
+                | "failed"
+                | "bounced"
+                | "complained"
+                | "suppressed"
+                | "cancelled"
+                | null
+              occurredAt: string
+              createdAt: string
+              /** @enum {string} */
+              source: "logged" | "conversation" | "notification"
+            }[]
+            nextCursor: string | null
+          }
+        }
+      }
+      /** @description Invalid or drifted cursor */
       400: {
         headers: {
           [name: string]: unknown

--- a/packages/conversations/package.json
+++ b/packages/conversations/package.json
@@ -31,6 +31,7 @@
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
     "@voyant-travel/storage": "workspace:^",
+    "@voyant-travel/relationships": "workspace:^",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
     "sanitize-html": "^2.17.5",

--- a/packages/conversations/src/person-timeline-runtime.ts
+++ b/packages/conversations/src/person-timeline-runtime.ts
@@ -1,0 +1,115 @@
+import type {
+  PersonConversationPart,
+  RelationshipsPersonConversationsRuntime,
+} from "@voyant-travel/relationships/runtime-port"
+import { and, desc, eq, gte, inArray, isNotNull, lt, lte, ne, or } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { conversationInboxMemberships, conversationParts, conversations } from "./schema.js"
+
+const sourceRank = { logged: 0, conversation: 1, notification: 2 } as const
+
+export function createPersonTimelineRuntime(): RelationshipsPersonConversationsRuntime {
+  return {
+    async listPersonParts(db, personId, query): Promise<readonly PersonConversationPart[]> {
+      const database = db as PostgresJsDatabase
+      const conditions = [
+        eq(conversations.personRef, personId),
+        inArray(conversations.channel, ["email", "sms"]),
+        eq(conversationInboxMemberships.userId, query.actorUserId),
+        eq(conversationInboxMemberships.active, true),
+        eq(conversationParts.classification, "message"),
+        ne(conversationParts.contentStatus, "quarantined"),
+      ]
+      if (query.channel) conditions.push(eq(conversations.channel, query.channel))
+      if (query.direction) conditions.push(eq(conversationParts.direction, query.direction))
+      if (query.dateFrom)
+        conditions.push(gte(conversationParts.occurredAt, new Date(query.dateFrom)))
+      if (query.dateTo) conditions.push(lte(conversationParts.occurredAt, new Date(query.dateTo)))
+      if (query.boundary) {
+        const at = new Date(query.boundary.occurredAt)
+        const rank = sourceRank.conversation
+        conditions.push(
+          rank > sourceRank[query.boundary.source]
+            ? lte(conversationParts.occurredAt, at)
+            : rank < sourceRank[query.boundary.source]
+              ? lt(conversationParts.occurredAt, at)
+              : or(
+                  lt(conversationParts.occurredAt, at),
+                  and(
+                    eq(conversationParts.occurredAt, at),
+                    lt(conversationParts.id, query.boundary.id),
+                  ),
+                )!,
+        )
+      }
+      const rows = await database
+        .select({
+          id: conversationParts.id,
+          conversationId: conversationParts.conversationId,
+          channel: conversations.channel,
+          direction: conversationParts.direction,
+          subject: conversationParts.subject,
+          body: conversationParts.textBody,
+          contentStatus: conversationParts.contentStatus,
+          classification: conversationParts.classification,
+          notificationDeliveryId: conversationParts.notificationDeliveryId,
+          occurredAt: conversationParts.occurredAt,
+          createdAt: conversationParts.createdAt,
+        })
+        .from(conversationParts)
+        .innerJoin(conversations, eq(conversations.id, conversationParts.conversationId))
+        .innerJoin(
+          conversationInboxMemberships,
+          eq(conversationInboxMemberships.inboxId, conversations.inboxId),
+        )
+        .where(and(...conditions))
+        .orderBy(desc(conversationParts.occurredAt), desc(conversationParts.id))
+        .limit(query.limit)
+      return rows.map((row) => ({
+        ...row,
+        subject: row.contentStatus === "safe" ? row.subject : null,
+        body: row.contentStatus === "safe" ? row.body : null,
+        deliveryStatus: null,
+        channel: row.channel as "email" | "sms",
+        occurredAt: row.occurredAt.toISOString(),
+        createdAt: row.createdAt.toISOString(),
+      }))
+    },
+
+    async findLinkedDeliveryIds(
+      db,
+      personId,
+      deliveryIds,
+      actorUserId,
+    ): Promise<readonly string[]> {
+      if (deliveryIds.length === 0) return []
+      const database = db as PostgresJsDatabase
+      const rows = await database
+        .select({ id: conversationParts.notificationDeliveryId })
+        .from(conversationParts)
+        .innerJoin(conversations, eq(conversations.id, conversationParts.conversationId))
+        .innerJoin(
+          conversationInboxMemberships,
+          eq(conversationInboxMemberships.inboxId, conversations.inboxId),
+        )
+        .where(
+          and(
+            eq(conversations.personRef, personId),
+            eq(conversationInboxMemberships.userId, actorUserId),
+            eq(conversationInboxMemberships.active, true),
+            isNotNull(conversationParts.notificationDeliveryId),
+            inArray(conversationParts.notificationDeliveryId, [...deliveryIds]),
+          ),
+        )
+      return rows.flatMap((row) => (row.id ? [row.id] : []))
+    },
+
+    async mergePersonHistory(db, survivorPersonId, mergedPersonId) {
+      await (db as PostgresJsDatabase)
+        .update(conversations)
+        .set({ personRef: survivorPersonId, updatedAt: new Date() })
+        .where(eq(conversations.personRef, mergedPersonId))
+    },
+  }
+}

--- a/packages/conversations/src/runtime-contributor.ts
+++ b/packages/conversations/src/runtime-contributor.ts
@@ -1,4 +1,6 @@
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import { relationshipsPersonConversationsRuntimePort } from "@voyant-travel/relationships/runtime-port"
+import { createPersonTimelineRuntime } from "./person-timeline-runtime.js"
 import { conversationsDatabaseRuntimePort } from "./runtime-port.js"
 
 /** Supply the package-owned database runtime from standard host primitives. */
@@ -10,5 +12,6 @@ export function createConversationsRuntimePortContribution(host: {
       resolveDb: (bindings?: unknown) =>
         host.primitives.database.resolve(bindings as Record<string, unknown> | undefined),
     },
+    [relationshipsPersonConversationsRuntimePort.id]: createPersonTimelineRuntime(),
   }
 }

--- a/packages/conversations/src/runtime-port.ts
+++ b/packages/conversations/src/runtime-port.ts
@@ -26,7 +26,7 @@ export type PersonEmailResolution =
 /** Read-only People boundary. It deliberately has no create or merge operation. */
 export interface ConversationsPersonDirectory {
   resolveEmail(db: unknown, address: string): Promise<PersonEmailResolution>
-  resolvePhone?(db: unknown, address: string): Promise<PersonEmailResolution>
+  resolvePhone(db: unknown, address: string): Promise<PersonEmailResolution>
   resolvePersonContactPoint(
     db: unknown,
     input: { personRef: string; contactPointRef: string; channel?: "email" | "sms" },
@@ -121,6 +121,7 @@ export const conversationsPersonDirectoryPort = definePort<ConversationsPersonDi
       !provider ||
       typeof provider !== "object" ||
       typeof provider.resolveEmail !== "function" ||
+      typeof provider.resolvePhone !== "function" ||
       typeof provider.resolvePersonContactPoint !== "function"
     ) {
       throw new Error(

--- a/packages/conversations/src/voyant.ts
+++ b/packages/conversations/src/voyant.ts
@@ -1,5 +1,6 @@
 import { staffDirectoryRuntimePort } from "@voyant-travel/auth/staff-directory-runtime-port"
-import { defineModule, requirePort } from "@voyant-travel/core/project"
+import { defineModule, providePort, requirePort } from "@voyant-travel/core/project"
+import { relationshipsPersonConversationsRuntimePort } from "@voyant-travel/relationships/runtime-port"
 import {
   conversationIngressSourcePort,
   conversationsAttachmentRuntimePort,
@@ -45,6 +46,7 @@ export const conversationsVoyantModule = defineModule({
     requirePort(conversationsChannelPolicyPort, { optional: true }),
     requirePort(conversationsDeliveryTruthPort, { optional: true }),
   ],
+  provides: { ports: [providePort(relationshipsPersonConversationsRuntimePort)] },
   api: [
     {
       id: "@voyant-travel/conversations#api.admin",

--- a/packages/conversations/tests/integration/person-timeline-runtime.test.ts
+++ b/packages/conversations/tests/integration/person-timeline-runtime.test.ts
@@ -1,0 +1,91 @@
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { cleanupTestDb, createTestDb } from "@voyant-travel/db/test-utils"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { createPersonTimelineRuntime } from "../../src/person-timeline-runtime.js"
+import {
+  conversationInboxes,
+  conversationInboxMemberships,
+  conversationParts,
+  conversations,
+} from "../../src/schema.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+describe.skipIf(!DB_AVAILABLE)("Person timeline Conversations projection", () => {
+  const db = createTestDb()
+  const runtime = createPersonTimelineRuntime()
+  const personId = "person-survivor"
+  const actorUserId = "staff-authorized"
+
+  beforeAll(async () => cleanupTestDb(db))
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+    const allowedInbox = newId("conversation_inboxes")
+    const deniedInbox = newId("conversation_inboxes")
+    await db.insert(conversationInboxes).values([
+      { id: allowedInbox, name: "Allowed", isDefault: true },
+      { id: deniedInbox, name: "Denied" },
+    ])
+    await db.insert(conversationInboxMemberships).values({
+      inboxId: allowedInbox,
+      userId: actorUserId,
+      active: true,
+    })
+    for (const [index, inboxId] of [allowedInbox, deniedInbox].entries()) {
+      const conversationId = newId("conversations")
+      await db.insert(conversations).values({
+        id: conversationId,
+        inboxId,
+        personRef: personId,
+        replyAlias: `reply-${index}@example.test`,
+        customerAddress: "customer@example.test",
+        lastPartAt: new Date("2026-08-18T10:00:00Z"),
+      })
+      await db.insert(conversationParts).values({
+        conversationId,
+        sequence: 1,
+        direction: "outbound",
+        senderAddress: "reply@example.test",
+        recipientAddresses: ["customer@example.test"],
+        subject: "Private subject",
+        textBody: index === 0 ? "Authorized body" : "Denied body",
+        payloadFingerprint: `part-${index}`,
+        notificationDeliveryId: `delivery-${index}`,
+        admissionStatus: "admitted",
+        occurredAt: new Date("2026-08-18T10:00:00Z"),
+      })
+    }
+  })
+
+  it("requires active Inbox membership for parts and linked-delivery dedupe", async () => {
+    const query = { limit: 20, actorUserId }
+    const parts = await runtime.listPersonParts(db, personId, query)
+    expect(parts).toHaveLength(1)
+    expect(parts[0]).toMatchObject({ body: "Authorized body", deliveryStatus: null })
+    await expect(
+      runtime.findLinkedDeliveryIds(db, personId, ["delivery-0", "delivery-1"], actorUserId),
+    ).resolves.toEqual(["delivery-0"])
+  })
+
+  it("never projects quarantined, redacted, or classified transport content", async () => {
+    const [part] = await db.select().from(conversationParts).limit(1)
+    await db.update(conversationParts).set({ contentStatus: "redacted", textBody: "must-not-leak" })
+    expect(await runtime.listPersonParts(db, personId, { limit: 20, actorUserId })).toEqual([
+      expect.objectContaining({ id: part!.id, subject: null, body: null }),
+    ])
+    await db.update(conversationParts).set({ contentStatus: "quarantined" })
+    expect(await runtime.listPersonParts(db, personId, { limit: 20, actorUserId })).toEqual([])
+    await db
+      .update(conversationParts)
+      .set({ contentStatus: "safe", classification: "automatic_reply" })
+    expect(await runtime.listPersonParts(db, personId, { limit: 20, actorUserId })).toEqual([])
+  })
+
+  it("moves losing Person history through the Conversations-owned merge hook", async () => {
+    await runtime.mergePersonHistory(db, personId, "person-loser")
+    await runtime.mergePersonHistory(db, "person-new-survivor", personId)
+    expect(
+      await runtime.listPersonParts(db, "person-new-survivor", { limit: 20, actorUserId }),
+    ).toHaveLength(1)
+  })
+})

--- a/packages/conversations/tests/integration/sms-conversations.test.ts
+++ b/packages/conversations/tests/integration/sms-conversations.test.ts
@@ -192,6 +192,7 @@ describe.skipIf(!DB_AVAILABLE)("SMS conversation integration", () => {
       { admitRenderedServiceMessage: admit },
       {
         resolveEmail: async () => ({ kind: "none" }),
+        resolvePhone: async () => ({ kind: "none" }),
         resolvePersonContactPoint: async () => ({ address: "+12025550123" }),
       },
       {

--- a/packages/conversations/tests/unit/runtime-port.test.ts
+++ b/packages/conversations/tests/unit/runtime-port.test.ts
@@ -8,6 +8,7 @@ describe("Conversations-owned consumer ports", () => {
   it("keeps People resolution read-only", () => {
     const provider = {
       resolveEmail: async () => ({ kind: "none" as const }),
+      resolvePhone: async () => ({ kind: "none" as const }),
       resolvePersonContactPoint: async () => null,
     }
     expect(() => conversationsPersonDirectoryPort.test?.(provider)).not.toThrow()

--- a/packages/notifications/src/person-communications-runtime.ts
+++ b/packages/notifications/src/person-communications-runtime.ts
@@ -3,7 +3,7 @@ import type {
   PersonNotificationDeliveryQuery,
   RelationshipsPersonNotificationsRuntime,
 } from "@voyant-travel/relationships/runtime-port"
-import { and, desc, eq, gte, inArray, isNotNull, lte } from "drizzle-orm"
+import { and, desc, eq, gte, inArray, lt, lte, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { notificationDeliveries } from "./schema.js"
@@ -11,10 +11,8 @@ import { notificationDeliveries } from "./schema.js"
 /**
  * Expose delivered customer messages to the CRM Communications tab.
  *
- * Only `delivered` rows: adapter acceptance does not prove that the customer
- * received anything. Delivery status
- * lives here and stays here — CRM reads this rather than holding a copy that
- * could not follow a later bounce.
+ * Delivery status stays authoritative here. The timeline includes unsuccessful
+ * attempts too, explicitly labelled with their current lifecycle truth.
  */
 export function createPersonCommunicationsRuntime(): RelationshipsPersonNotificationsRuntime {
   return {
@@ -26,15 +24,34 @@ export function createPersonCommunicationsRuntime(): RelationshipsPersonNotifica
       const database = db as PostgresJsDatabase
       const conditions = [
         eq(notificationDeliveries.personId, personId),
-        eq(notificationDeliveries.status, "delivered"),
         inArray(notificationDeliveries.channel, ["email", "sms"]),
-        isNotNull(notificationDeliveries.deliveredAt),
       ]
+      if (!query.includeAllStatuses) {
+        conditions.push(eq(notificationDeliveries.status, "delivered"))
+      }
+      if (query.channel === "email" || query.channel === "sms") {
+        conditions.push(eq(notificationDeliveries.channel, query.channel))
+      }
       if (query.dateFrom) {
         conditions.push(gte(notificationDeliveries.createdAt, new Date(query.dateFrom)))
       }
       if (query.dateTo) {
         conditions.push(lte(notificationDeliveries.createdAt, new Date(query.dateTo)))
+      }
+      if (query.boundary) {
+        const at = new Date(query.boundary.occurredAt)
+        // Notifications sort after the other two sources at an equal instant.
+        conditions.push(
+          query.boundary.source === "notification"
+            ? or(
+                lt(notificationDeliveries.createdAt, at),
+                and(
+                  eq(notificationDeliveries.createdAt, at),
+                  lt(notificationDeliveries.id, query.boundary.id),
+                ),
+              )!
+            : lte(notificationDeliveries.createdAt, at),
+        )
       }
 
       const rows = await database
@@ -43,23 +60,35 @@ export function createPersonCommunicationsRuntime(): RelationshipsPersonNotifica
           channel: notificationDeliveries.channel,
           subject: notificationDeliveries.subject,
           textBody: notificationDeliveries.textBody,
-          sentAt: notificationDeliveries.deliveredAt,
+          status: notificationDeliveries.status,
+          deliveredAt: notificationDeliveries.deliveredAt,
           createdAt: notificationDeliveries.createdAt,
         })
         .from(notificationDeliveries)
         .where(and(...conditions))
         .orderBy(desc(notificationDeliveries.createdAt))
         .limit(query.limit)
-        .offset(query.offset)
 
       return rows.map((row) => ({
         id: row.id,
         channel: row.channel === "sms" ? "sms" : "email",
         subject: row.subject ?? null,
         body: row.textBody ?? null,
-        sentAt: row.sentAt?.toISOString() ?? null,
+        status: row.status,
+        occurredAt: (!query.includeAllStatuses && row.deliveredAt
+          ? row.deliveredAt
+          : row.createdAt
+        ).toISOString(),
         createdAt: row.createdAt.toISOString(),
       }))
+    },
+    async getDeliveryTruth(db, deliveryIds) {
+      if (deliveryIds.length === 0) return {}
+      const rows = await (db as PostgresJsDatabase)
+        .select({ id: notificationDeliveries.id, status: notificationDeliveries.status })
+        .from(notificationDeliveries)
+        .where(inArray(notificationDeliveries.id, [...deliveryIds]))
+      return Object.fromEntries(rows.map((row) => [row.id, row.status]))
     },
   }
 }

--- a/packages/relationships-contracts/src/validation.ts
+++ b/packages/relationships-contracts/src/validation.ts
@@ -36,6 +36,7 @@ export {
 export {
   communicationListQuerySchema,
   insertCommunicationLogSchema,
+  personTimelineQuerySchema,
 } from "./validation/communication-log.js"
 export type {
   CustomerSignalInput,

--- a/packages/relationships-contracts/src/validation/communication-log.ts
+++ b/packages/relationships-contracts/src/validation/communication-log.ts
@@ -23,3 +23,13 @@ export const communicationListQuerySchema = paginationSchema.extend({
   dateFrom: z.string().optional(),
   dateTo: z.string().optional(),
 })
+
+/** Stable keyset pagination for the cross-authority Person timeline. */
+export const personTimelineQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(100).default(50),
+  cursor: z.string().min(1).optional(),
+  channel: communicationChannelSchema.optional(),
+  direction: communicationDirectionSchema.optional(),
+  dateFrom: z.string().datetime({ offset: true }).optional(),
+  dateTo: z.string().datetime({ offset: true }).optional(),
+})

--- a/packages/relationships-react/package.json
+++ b/packages/relationships-react/package.json
@@ -34,6 +34,7 @@
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
     "@voyant-travel/admin": "workspace:^",
+    "@voyant-travel/admin-react": "workspace:^",
     "@voyant-travel/identity-react": "workspace:^",
     "@voyant-travel/relationships": "workspace:^",
     "@voyant-travel/ui": "workspace:^",

--- a/packages/relationships-react/src/admin/conversation-capability.test.ts
+++ b/packages/relationships-react/src/admin/conversation-capability.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { canStartPersonConversation } from "./conversation-capability.js"
+
+const allowed = {
+  modules: ["@voyant-travel/conversations"],
+  operations: [
+    {
+      method: "POST",
+      pathTemplate: "/v1/admin/conversations",
+      scopes: ["conversations:write"],
+    },
+  ],
+  scopes: ["conversations:write"],
+}
+
+describe("Person conversation capability", () => {
+  it("fails closed while discovery is unknown or write permission is denied", () => {
+    expect(canStartPersonConversation(undefined)).toBe(false)
+    expect(canStartPersonConversation({ ...allowed, scopes: ["conversations:read"] })).toBe(false)
+    expect(canStartPersonConversation({ ...allowed, operations: [] })).toBe(false)
+    expect(canStartPersonConversation({ ...allowed, modules: [] })).toBe(false)
+  })
+
+  it("requires the selected module and exact write operation", () => {
+    expect(canStartPersonConversation(allowed)).toBe(true)
+  })
+})

--- a/packages/relationships-react/src/admin/conversation-capability.ts
+++ b/packages/relationships-react/src/admin/conversation-capability.ts
@@ -1,0 +1,25 @@
+export interface ConversationDeploymentCapabilities {
+  modules: readonly string[]
+  operations: readonly { method: string; pathTemplate: string; scopes: readonly string[] }[]
+  scopes?: readonly string[]
+}
+
+/** Fail-closed gate for the cross-module Person composer. */
+export function canStartPersonConversation(
+  capabilities: ConversationDeploymentCapabilities | undefined,
+): boolean {
+  if (!capabilities) return false
+  const moduleActive = capabilities.modules.some(
+    (moduleId) => moduleId === "conversations" || moduleId === "@voyant-travel/conversations",
+  )
+  if (!moduleActive) return false
+  const operation = capabilities.operations.find(
+    ({ method, pathTemplate }) =>
+      method.toUpperCase() === "POST" && pathTemplate === "/v1/admin/conversations",
+  )
+  if (!operation?.scopes.includes("conversations:write")) return false
+  if (capabilities.scopes) {
+    return capabilities.scopes.includes("*") || capabilities.scopes.includes("conversations:write")
+  }
+  return true
+}

--- a/packages/relationships-react/src/admin/person-detail-host.tsx
+++ b/packages/relationships-react/src/admin/person-detail-host.tsx
@@ -9,9 +9,11 @@ import {
   useAdminNavigate,
   useOperatorAdminMessages,
 } from "@voyant-travel/admin"
+import { useCapabilities } from "@voyant-travel/admin-react"
 
 import { PersonDetailPage } from "../components/person-detail-page.js"
 import { usePerson } from "../index.js"
+import { canStartPersonConversation } from "./conversation-capability.js"
 import { type PersonDetailBookingsTabContext, personDetailBookingsTabSlot } from "./slots.js"
 
 export interface PersonDetailHostProps {
@@ -31,6 +33,8 @@ export interface PersonDetailHostProps {
  *     card travels the widget seam, not an import).
  */
 export function PersonDetailHost({ id }: PersonDetailHostProps) {
+  const capabilities = useCapabilities()
+  const canWriteConversations = canStartPersonConversation(capabilities.data)
   const messages = useOperatorAdminMessages().crm.personDetail
   const navigateTo = useAdminNavigate()
   const resolveHref = useAdminHref()
@@ -56,6 +60,7 @@ export function PersonDetailHost({ id }: PersonDetailHostProps) {
   return (
     <PersonDetailPage
       id={id}
+      canWriteConversations={canWriteConversations}
       onBack={() => navigateTo("person.list", {})}
       onDeleted={() => navigateTo("person.list", {})}
       onOrganizationOpen={(organizationId) => navigateTo("organization.detail", { organizationId })}

--- a/packages/relationships-react/src/components/person-detail-page.tsx
+++ b/packages/relationships-react/src/components/person-detail-page.tsx
@@ -70,6 +70,7 @@ export type {
 
 export function PersonDetailPage({
   id,
+  canWriteConversations = false,
   className,
   onBack,
   onDeleted,
@@ -200,6 +201,7 @@ export function PersonDetailPage({
           documentsPending={documentsQuery.isPending}
           paymentMethodsPending={paymentMethodsQuery.isPending}
           communicationsPending={communicationsQuery.isPending}
+          canWriteConversations={canWriteConversations}
           onUpdateField={updateField}
           onPersonOpen={onPersonOpen}
           slots={slots}
@@ -326,6 +328,7 @@ export interface PersonMainProps {
   documentsPending: boolean
   paymentMethodsPending: boolean
   communicationsPending: boolean
+  canWriteConversations: boolean
   onUpdateField: (patch: UpdatePersonInput) => Promise<void>
   onPersonOpen?: (personId: string) => void
   slots?: PersonDetailPageSlots
@@ -346,6 +349,7 @@ export function PersonMain({
   documentsPending,
   paymentMethodsPending,
   communicationsPending,
+  canWriteConversations,
   onUpdateField,
   onPersonOpen,
   slots,
@@ -489,6 +493,7 @@ export function PersonMain({
                 personId={person.id}
                 communications={communications}
                 communicationsPending={communicationsPending}
+                canWriteConversations={canWriteConversations}
               />
             </CardContent>
           </Card>

--- a/packages/relationships-react/src/components/person-detail-panels.tsx
+++ b/packages/relationships-react/src/components/person-detail-panels.tsx
@@ -38,6 +38,7 @@ import type {
 import {
   usePerson,
   usePersonCommunicationMutation,
+  usePersonConversationComposer,
   usePersonDocumentMutation,
   usePersonPaymentMethodMutation,
   useRevealPersonDocument,
@@ -548,18 +549,24 @@ export interface PersonCommunicationsPanelProps {
   communications: PersonCommunication[]
   communicationsPending: boolean
   personId: string
+  canWriteConversations: boolean
 }
 
 export function PersonCommunicationsPanel({
   communications,
   communicationsPending,
   personId,
+  canWriteConversations,
 }: PersonCommunicationsPanelProps) {
   const i18n = useCrmUiI18nOrDefault()
   const messages = useCrmUiMessagesOrDefault()
   const labels = messages.personDetail.communications
   const mutation = usePersonCommunicationMutation(personId)
+  const composer = usePersonConversationComposer(personId, canWriteConversations)
   const [isCreating, setIsCreating] = useState(false)
+  const [composeOption, setComposeOption] = useState("")
+  const [composeSubject, setComposeSubject] = useState("")
+  const [composeText, setComposeText] = useState("")
   const [form, setForm] = useState<CommunicationFormState>(() => emptyCommunicationFormState())
 
   const set = <K extends keyof CommunicationFormState>(key: K, value: CommunicationFormState[K]) =>
@@ -584,6 +591,61 @@ export function PersonCommunicationsPanel({
 
   return (
     <section className="flex flex-col gap-3">
+      {(composer.data?.length ?? 0) > 0 ? (
+        <form
+          className="grid gap-2 rounded-md border p-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+          onSubmit={async (event) => {
+            event.preventDefault()
+            const option = composer.data?.find(
+              (candidate) => `${candidate.account.id}:${candidate.contact.id}` === composeOption,
+            )
+            if (!option || !composeText.trim()) return
+            await composer.start.mutateAsync({
+              option,
+              subject: composeSubject.trim() || null,
+              text: composeText.trim(),
+            })
+            setComposeSubject("")
+            setComposeText("")
+          }}
+        >
+          <Select value={composeOption} onValueChange={(value) => setComposeOption(value ?? "")}>
+            <SelectTrigger aria-label="Conversation sender and recipient">
+              <SelectValue placeholder="Send from…" />
+            </SelectTrigger>
+            <SelectContent>
+              {composer.data?.map((option) => (
+                <SelectItem
+                  key={`${option.account.id}:${option.contact.id}`}
+                  value={`${option.account.id}:${option.contact.id}`}
+                >
+                  {option.account.displayName} → {option.contact.value}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            aria-label="Conversation subject"
+            placeholder="Subject"
+            value={composeSubject}
+            onChange={(event) => setComposeSubject(event.target.value)}
+          />
+          <Button
+            type="submit"
+            disabled={!composeOption || !composeText.trim() || composer.start.isPending}
+          >
+            Send
+          </Button>
+          <Textarea
+            className="sm:col-span-3"
+            aria-label="Conversation message"
+            placeholder="Write a message…"
+            value={composeText}
+            onChange={(event) => setComposeText(event.target.value)}
+            rows={2}
+          />
+        </form>
+      ) : null}
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-medium text-foreground">{labels.title}</h3>
         {!isCreating ? (
@@ -684,7 +746,7 @@ export function PersonCommunicationsPanel({
                   </p>
                 ) : null}
                 <p className="text-xs text-muted-foreground">
-                  {formatCrmRelative(i18n, communication.sentAt ?? communication.createdAt)}
+                  {formatCrmRelative(i18n, communication.occurredAt)}
                 </p>
               </div>
               <div className="flex flex-col items-end gap-1">
@@ -692,6 +754,17 @@ export function PersonCommunicationsPanel({
                 <Badge variant="secondary">{labels.directionLabels[communication.direction]}</Badge>
                 {communication.source === "notification" ? (
                   <Badge variant="outline">{labels.automaticBadge}</Badge>
+                ) : null}
+                {communication.deliveryStatus ? (
+                  <Badge variant="outline">{communication.deliveryStatus}</Badge>
+                ) : null}
+                {communication.conversationId ? (
+                  <a
+                    className="text-xs text-primary underline-offset-4 hover:underline"
+                    href={`/inbox?conversation=${encodeURIComponent(communication.conversationId)}`}
+                  >
+                    Inbox
+                  </a>
                 ) : null}
               </div>
             </li>

--- a/packages/relationships-react/src/components/person-detail-types.ts
+++ b/packages/relationships-react/src/components/person-detail-types.ts
@@ -1,12 +1,12 @@
 import type { ReactNode } from "react"
 import type {
   ActivityRecord,
-  CommunicationLogRecord,
   OrganizationRecord,
   PersonDocumentRecord,
   PersonPaymentMethodRecord,
   PersonRecord,
   PersonRelationshipRecord,
+  PersonTimelineRecord,
   PersonTravelSnapshotRecord,
 } from "../index.js"
 
@@ -95,16 +95,18 @@ export type PersonPaymentMethod = Pick<
 >
 
 export type PersonCommunication = Pick<
-  CommunicationLogRecord,
+  PersonTimelineRecord,
   | "channel"
   | "content"
   | "createdAt"
   | "direction"
   | "id"
   | "personId"
-  | "sentAt"
+  | "occurredAt"
   | "source"
   | "subject"
+  | "conversationId"
+  | "deliveryStatus"
 >
 
 export type PersonTravelSnapshot = PersonTravelSnapshotRecord
@@ -136,6 +138,7 @@ export interface PersonDetailPageSlots {
 
 export interface PersonDetailPageProps {
   id: string
+  canWriteConversations?: boolean
   className?: string
   onBack?: () => void
   onDeleted?: () => void

--- a/packages/relationships-react/src/hooks/index.ts
+++ b/packages/relationships-react/src/hooks/index.ts
@@ -32,6 +32,13 @@ export {
   usePersonCommunications,
 } from "./use-person-communications.js"
 export {
+  type PersonComposerChannelAccount,
+  type PersonComposerContact,
+  type PersonComposerOption,
+  selectConversationComposerOptions,
+  usePersonConversationComposer,
+} from "./use-person-conversation-composer.js"
+export {
   type CreatePersonDocumentFromPlaintextInput,
   type CreatePersonDocumentInput,
   type UpdatePersonDocumentFromPlaintextInput,

--- a/packages/relationships-react/src/hooks/use-person-communications.ts
+++ b/packages/relationships-react/src/hooks/use-person-communications.ts
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query"
 import { fetchWithValidation } from "../client.js"
 import { useVoyantContext } from "../provider.js"
 import { type PersonCommunicationsListFilters, relationshipsQueryKeys } from "../query-keys.js"
-import { communicationLogListResponse } from "../schemas.js"
+import { personTimelinePageResponse } from "../schemas.js"
 
 export interface UsePersonCommunicationsOptions extends PersonCommunicationsListFilters {
   enabled?: boolean
@@ -28,11 +28,11 @@ export function usePersonCommunications(
       if (filters.dateFrom) params.set("dateFrom", filters.dateFrom)
       if (filters.dateTo) params.set("dateTo", filters.dateTo)
       if (filters.limit !== undefined) params.set("limit", String(filters.limit))
-      if (filters.offset !== undefined) params.set("offset", String(filters.offset))
+      if (filters.cursor !== undefined) params.set("cursor", filters.cursor)
       const qs = params.toString()
       return fetchWithValidation(
-        `/v1/admin/relationships/people/${personId}/communications${qs ? `?${qs}` : ""}`,
-        communicationLogListResponse,
+        `/v1/admin/relationships/people/${personId}/communications/timeline${qs ? `?${qs}` : ""}`,
+        personTimelinePageResponse,
         { baseUrl, fetcher },
       )
     },

--- a/packages/relationships-react/src/hooks/use-person-conversation-composer.test.ts
+++ b/packages/relationships-react/src/hooks/use-person-conversation-composer.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildPersonConversationStartRequest,
+  selectConversationComposerOptions,
+} from "./use-person-conversation-composer.js"
+
+const contact = { id: "contact_1", kind: "email", value: "guest@example.test", isPrimary: true }
+const account = {
+  id: "account_1",
+  channel: "email",
+  displayAddress: "hello@example.test",
+  displayName: "Hello",
+  lifecycle: "active",
+  health: "healthy",
+  outboundCapable: true,
+}
+const inboxes = [{ id: "inbox_1", isDefault: true }]
+
+describe("Person conversation composer capability selection", () => {
+  it("offers only active healthy outbound-capable account/contact pairs", () => {
+    expect(selectConversationComposerOptions([account], [contact], inboxes)).toHaveLength(1)
+    expect(
+      selectConversationComposerOptions(
+        [
+          { ...account, id: "disabled", lifecycle: "disabled" },
+          { ...account, id: "unavailable", health: "unavailable" },
+          { ...account, id: "inbound", outboundCapable: false },
+        ],
+        [contact],
+        inboxes,
+      ),
+    ).toEqual([])
+  })
+
+  it("offers SMS with exact channel semantics when an Inbox is writable", () => {
+    const smsAccount = { ...account, channel: "sms", displayAddress: "+12025550100" }
+    const phone = { ...contact, kind: "mobile", value: "+12025550101" }
+    expect(selectConversationComposerOptions([smsAccount], [phone], [])).toEqual([])
+    expect(selectConversationComposerOptions([smsAccount], [phone], inboxes)).toEqual([
+      expect.objectContaining({
+        channel: "sms",
+        contact: phone,
+        account: smsAccount,
+        inboxId: "inbox_1",
+      }),
+    ])
+  })
+
+  it("builds exact discriminated email and SMS start requests", () => {
+    const [email] = selectConversationComposerOptions([account], [contact], inboxes)
+    expect(
+      buildPersonConversationStartRequest(
+        "person_1",
+        { option: email!, subject: "Hello", text: "Email body" },
+        "email-key",
+      ),
+    ).toMatchObject({
+      channel: "email",
+      inboxId: "inbox_1",
+      fromAddress: "hello@example.test",
+      subject: "Hello",
+    })
+    const [sms] = selectConversationComposerOptions(
+      [{ ...account, channel: "sms", displayAddress: "+12025550100" }],
+      [{ ...contact, kind: "mobile", value: "+12025550101" }],
+      inboxes,
+    )
+    const request = buildPersonConversationStartRequest(
+      "person_1",
+      { option: sms!, subject: "ignored", text: "SMS body" },
+      "sms-key",
+    )
+    expect(request).toMatchObject({ channel: "sms", inboxId: "inbox_1", subject: null })
+    expect(request).not.toHaveProperty("fromAddress")
+  })
+})

--- a/packages/relationships-react/src/hooks/use-person-conversation-composer.ts
+++ b/packages/relationships-react/src/hooks/use-person-conversation-composer.ts
@@ -1,0 +1,152 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { z } from "zod"
+
+import { fetchWithValidation } from "../client.js"
+import { useVoyantContext } from "../provider.js"
+import { relationshipsQueryKeys } from "../query-keys.js"
+
+const contactPoint = z.object({
+  id: z.string(),
+  kind: z.string(),
+  value: z.string(),
+  isPrimary: z.boolean(),
+})
+const channelAccount = z.object({
+  id: z.string(),
+  channel: z.string(),
+  displayAddress: z.string(),
+  displayName: z.string(),
+  lifecycle: z.string(),
+  health: z.string(),
+  outboundCapable: z.boolean(),
+})
+const contactsResponse = z.object({ data: z.array(contactPoint) })
+const accountsResponse = z.object({ data: z.array(channelAccount) })
+const inboxesResponse = z.object({
+  data: z.array(z.object({ id: z.string(), isDefault: z.boolean() })),
+})
+const startedConversationResponse = z.object({
+  data: z.object({ conversation: z.object({ id: z.string() }) }),
+})
+
+export type PersonComposerContact = z.infer<typeof contactPoint>
+export type PersonComposerChannelAccount = z.infer<typeof channelAccount>
+
+export interface PersonComposerOption {
+  channel: "email" | "sms"
+  contact: PersonComposerContact
+  account: PersonComposerChannelAccount
+  inboxId: string
+}
+
+/** Pure capability gate, exported so unavailable combinations stay regression-tested. */
+export function selectConversationComposerOptions(
+  accounts: readonly PersonComposerChannelAccount[],
+  contacts: readonly PersonComposerContact[],
+  inboxes: readonly { id: string; isDefault: boolean }[],
+  supportedChannels: readonly ("email" | "sms")[] = ["email", "sms"],
+): PersonComposerOption[] {
+  const inboxId = inboxes.find((inbox) => inbox.isDefault)?.id ?? inboxes[0]?.id
+  if (!inboxId) return []
+  const supported = new Set(supportedChannels)
+  const usableAccounts = accounts.filter(
+    (account) =>
+      (account.channel === "email" || account.channel === "sms") &&
+      supported.has(account.channel) &&
+      account.lifecycle === "active" &&
+      account.health !== "unavailable" &&
+      account.outboundCapable,
+  )
+  return usableAccounts.flatMap((account) => {
+    const channel = account.channel as "email" | "sms"
+    const allowedKinds = channel === "email" ? ["email"] : ["phone", "mobile", "sms"]
+    return contacts
+      .filter((contact) => allowedKinds.includes(contact.kind) && contact.value.trim().length > 0)
+      .sort((left, right) => Number(right.isPrimary) - Number(left.isPrimary))
+      .map((contact) => ({ channel, contact, account, inboxId }))
+  })
+}
+
+export function buildPersonConversationStartRequest(
+  personId: string,
+  input: { option: PersonComposerOption; subject: string | null; text: string },
+  idempotencyKey: string,
+) {
+  const base = {
+    inboxId: input.option.inboxId,
+    personRef: personId,
+    contactPointRef: input.option.contact.id,
+    channelAccountId: input.option.account.id,
+    channel: input.option.channel,
+    text: input.text,
+    idempotencyKey,
+  }
+  return input.option.channel === "email"
+    ? {
+        ...base,
+        channel: "email" as const,
+        fromAddress: input.option.account.displayAddress,
+        subject: input.subject,
+      }
+    : { ...base, channel: "sms" as const, subject: null }
+}
+
+export function usePersonConversationComposer(personId: string | undefined, canWrite: boolean) {
+  const { baseUrl, fetcher } = useVoyantContext()
+  const queryClient = useQueryClient()
+  const query = useQuery({
+    queryKey: [...relationshipsQueryKeys.person(personId ?? ""), "conversation-composer"],
+    enabled: Boolean(personId) && canWrite,
+    queryFn: async () => {
+      if (!personId) throw new Error("usePersonConversationComposer requires a personId")
+      const [contacts, accounts, inboxes] = await Promise.all([
+        fetchWithValidation(
+          `/v1/admin/relationships/people/${personId}/contact-methods`,
+          contactsResponse,
+          { baseUrl, fetcher },
+        ),
+        fetchWithValidation("/v1/admin/notifications/channel-accounts", accountsResponse, {
+          baseUrl,
+          fetcher,
+        }),
+        fetchWithValidation("/v1/admin/conversation-inboxes", inboxesResponse, {
+          baseUrl,
+          fetcher,
+        }),
+      ])
+      return selectConversationComposerOptions(accounts.data, contacts.data, inboxes.data)
+    },
+  })
+  const start = useMutation({
+    mutationFn: async (input: {
+      option: PersonComposerOption
+      subject: string | null
+      text: string
+    }) => {
+      if (!personId) throw new Error("usePersonConversationComposer requires a personId")
+      return fetchWithValidation(
+        "/v1/admin/conversations",
+        startedConversationResponse,
+        {
+          baseUrl,
+          fetcher,
+        },
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            buildPersonConversationStartRequest(personId, input, crypto.randomUUID()),
+          ),
+        },
+      )
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: [...relationshipsQueryKeys.person(personId ?? ""), "communications"],
+      })
+    },
+  })
+  return { ...query, start }
+}

--- a/packages/relationships-react/src/index.ts
+++ b/packages/relationships-react/src/index.ts
@@ -60,6 +60,13 @@ export {
   usePersonCommunications,
 } from "./hooks/use-person-communications.js"
 export {
+  type PersonComposerChannelAccount,
+  type PersonComposerContact,
+  type PersonComposerOption,
+  selectConversationComposerOptions,
+  usePersonConversationComposer,
+} from "./hooks/use-person-conversation-composer.js"
+export {
   type CreatePersonDocumentFromPlaintextInput,
   type CreatePersonDocumentInput,
   type UpdatePersonDocumentFromPlaintextInput,
@@ -165,6 +172,7 @@ export {
   type PersonRecord,
   type PersonRelationshipKind,
   type PersonRelationshipRecord,
+  type PersonTimelineRecord,
   type PersonTravelSnapshotRecord,
   personDocumentRecordSchema,
   personDocumentTypeSchema,
@@ -176,5 +184,7 @@ export {
   personRecordSchema,
   personRelationshipKindSchema,
   personRelationshipRecordSchema,
+  personTimelinePageResponse,
+  personTimelineRecordSchema,
   personTravelSnapshotSchema,
 } from "./schemas.js"

--- a/packages/relationships-react/src/query-keys.ts
+++ b/packages/relationships-react/src/query-keys.ts
@@ -76,7 +76,7 @@ export interface PersonCommunicationsListFilters {
   dateFrom?: string | undefined
   dateTo?: string | undefined
   limit?: number | undefined
-  offset?: number | undefined
+  cursor?: string | undefined
 }
 
 export const relationshipsQueryKeys = {

--- a/packages/relationships-react/src/schemas.ts
+++ b/packages/relationships-react/src/schemas.ts
@@ -243,6 +243,38 @@ export type CommunicationLogRecord = z.infer<typeof communicationLogRecordSchema
 export const communicationLogListResponse = listEnvelope(communicationLogRecordSchema)
 export const communicationLogSingleResponse = singleEnvelope(communicationLogRecordSchema)
 
+export const personTimelineRecordSchema = z.object({
+  id: z.string(),
+  personId: z.string(),
+  organizationId: z.string().nullable(),
+  conversationId: z.string().nullable(),
+  channel: communicationChannelSchema,
+  direction: communicationDirectionSchema,
+  subject: z.string().nullable(),
+  content: z.string().nullable(),
+  deliveryStatus: z
+    .enum([
+      "received",
+      "pending",
+      "accepted",
+      "delivered",
+      "failed",
+      "bounced",
+      "complained",
+      "suppressed",
+      "cancelled",
+    ])
+    .nullable(),
+  occurredAt: z.string(),
+  createdAt: z.string(),
+  source: z.enum(["logged", "conversation", "notification"]),
+})
+export type PersonTimelineRecord = z.infer<typeof personTimelineRecordSchema>
+export const personTimelinePageResponse = z.object({
+  data: z.array(personTimelineRecordSchema),
+  nextCursor: z.string().nullable(),
+})
+
 export const customerSignalKindSchema = z.enum([
   "wishlist",
   "notify",

--- a/packages/relationships/openapi/admin/relationships.json
+++ b/packages/relationships/openapi/admin/relationships.json
@@ -5247,6 +5247,207 @@
         "x-voyant-package-name": "@voyant-travel/relationships"
       }
     },
+    "/v1/admin/relationships/people/{id}/communications/timeline": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 100,
+              "default": 50
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false,
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["email", "phone", "whatsapp", "sms", "meeting", "other"]
+            },
+            "required": false,
+            "name": "channel",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["inbound", "outbound"]
+            },
+            "required": false,
+            "name": "direction",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "required": false,
+            "name": "dateFrom",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "required": false,
+            "name": "dateTo",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Exact chronological Person communication timeline",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "personId": {
+                            "type": "string"
+                          },
+                          "organizationId": {
+                            "type": ["string", "null"]
+                          },
+                          "conversationId": {
+                            "type": ["string", "null"]
+                          },
+                          "channel": {
+                            "type": "string",
+                            "enum": ["email", "phone", "whatsapp", "sms", "meeting", "other"]
+                          },
+                          "direction": {
+                            "type": "string",
+                            "enum": ["inbound", "outbound"]
+                          },
+                          "subject": {
+                            "type": ["string", "null"]
+                          },
+                          "content": {
+                            "type": ["string", "null"]
+                          },
+                          "deliveryStatus": {
+                            "type": ["string", "null"],
+                            "enum": [
+                              "received",
+                              "pending",
+                              "accepted",
+                              "delivered",
+                              "failed",
+                              "bounced",
+                              "complained",
+                              "suppressed",
+                              "cancelled",
+                              null
+                            ]
+                          },
+                          "occurredAt": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string",
+                            "enum": ["logged", "conversation", "notification"]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "personId",
+                          "organizationId",
+                          "conversationId",
+                          "channel",
+                          "direction",
+                          "subject",
+                          "content",
+                          "deliveryStatus",
+                          "occurredAt",
+                          "createdAt",
+                          "source"
+                        ]
+                      }
+                    },
+                    "nextCursor": {
+                      "type": ["string", "null"]
+                    }
+                  },
+                  "required": ["data", "nextCursor"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or drifted cursor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Person not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminRelationshipsPeopleByIdCommunicationsTimeline",
+        "summary": "GET /v1/admin/relationships/people/{id}/communications/timeline",
+        "tags": ["relationships"],
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/relationships#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/relationships",
+        "x-voyant-package-name": "@voyant-travel/relationships"
+      }
+    },
     "/v1/admin/relationships/segments": {
       "get": {
         "responses": {

--- a/packages/relationships/package.json
+++ b/packages/relationships/package.json
@@ -34,7 +34,6 @@
     "@voyant-travel/bookings": "workspace:^",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/custom-fields": "workspace:^",
-    "@voyant-travel/conversations": "workspace:^",
     "@voyant-travel/conversations-contracts": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/finance": "workspace:^",

--- a/packages/relationships/src/route-runtime.ts
+++ b/packages/relationships/src/route-runtime.ts
@@ -1,7 +1,10 @@
 import type { CustomFieldRegistryResolver } from "@voyant-travel/core/custom-fields"
 import { createKmsProviderFromEnv, type KmsProvider } from "@voyant-travel/utils"
 
-import type { RelationshipsPersonNotificationsRuntime } from "./runtime-port.js"
+import type {
+  RelationshipsPersonConversationsRuntime,
+  RelationshipsPersonNotificationsRuntime,
+} from "./runtime-port.js"
 
 export const RELATIONSHIPS_ROUTE_RUNTIME_CONTAINER_KEY = "runtime.relationships.routes"
 
@@ -32,6 +35,7 @@ export interface RelationshipsRouteRuntime {
    * what staff recorded, which is what it did before.
    */
   personNotifications?: RelationshipsPersonNotificationsRuntime
+  personConversations?: RelationshipsPersonConversationsRuntime
 }
 
 export interface RelationshipsRouteRuntimeOptions {
@@ -39,6 +43,7 @@ export interface RelationshipsRouteRuntimeOptions {
   customFields?: CustomFieldRegistryResolver
   customFieldsForWrite?: (db: unknown, entity: string) => ReturnType<CustomFieldRegistryResolver>
   personNotifications?: RelationshipsPersonNotificationsRuntime
+  personConversations?: RelationshipsPersonConversationsRuntime
 }
 
 function buildRuntimeEnv(bindings: Record<string, unknown>): Record<string, string | undefined> {
@@ -78,5 +83,6 @@ export function buildRelationshipsRouteRuntime(
     customFields: options.customFields,
     customFieldsForWrite: options.customFieldsForWrite,
     personNotifications: options.personNotifications,
+    personConversations: options.personConversations,
   }
 }

--- a/packages/relationships/src/routes/accounts-openapi-schemas.ts
+++ b/packages/relationships/src/routes/accounts-openapi-schemas.ts
@@ -164,6 +164,38 @@ export const communicationLogEntrySchema = z.object({
   source: z.enum(["logged", "notification"]).default("logged"),
 })
 
+export const personTimelineEntrySchema = z.object({
+  id: idSchema,
+  personId: z.string(),
+  organizationId: z.string().nullable(),
+  conversationId: z.string().nullable(),
+  channel: communicationChannelSchema,
+  direction: communicationDirectionSchema,
+  subject: z.string().nullable(),
+  content: z.string().nullable(),
+  deliveryStatus: z
+    .enum([
+      "received",
+      "pending",
+      "accepted",
+      "delivered",
+      "failed",
+      "bounced",
+      "complained",
+      "suppressed",
+      "cancelled",
+    ])
+    .nullable(),
+  occurredAt: isoTimestamp,
+  createdAt: isoTimestamp,
+  source: z.enum(["logged", "conversation", "notification"]),
+})
+
+export const personTimelinePageSchema = z.object({
+  data: z.array(personTimelineEntrySchema),
+  nextCursor: z.string().nullable(),
+})
+
 // --- segments ---------------------------------------------------------------
 
 export const segmentSchema = z.object({

--- a/packages/relationships/src/routes/accounts.ts
+++ b/packages/relationships/src/routes/accounts.ts
@@ -52,7 +52,10 @@ import {
 } from "../route-runtime.js"
 import { RelationshipsMergeError } from "../service/accounts-merge.js"
 import { relationshipsService } from "../service/index.js"
-import { mergePersonCommunications } from "../service/person-communications.js"
+import {
+  InvalidPersonTimelineCursorError,
+  listPersonTimeline,
+} from "../service/person-communications.js"
 import {
   communicationListQuerySchema,
   insertCommunicationLogSchema,
@@ -66,6 +69,7 @@ import {
   mergePersonSchema,
   organizationListQuerySchema,
   personListQuerySchema,
+  personTimelineQuerySchema,
   updateOrganizationNoteSchema,
   updateOrganizationSchema,
   updatePersonNoteSchema,
@@ -85,6 +89,7 @@ import {
   personNoteSchema,
   personPaymentMethodSchema,
   personSchema,
+  personTimelinePageSchema,
   segmentIdParamSchema,
   segmentSchema,
   successResponseSchema,
@@ -762,6 +767,20 @@ const listCommunicationsRoute = createRoute({
   },
 })
 
+const listPersonTimelineRoute = createRoute({
+  method: "get",
+  path: "/people/{id}/communications/timeline",
+  request: { params: idParamSchema, query: personTimelineQuerySchema },
+  responses: {
+    200: {
+      description: "Exact chronological Person communication timeline",
+      ...jsonContent(personTimelinePageSchema),
+    },
+    400: { description: "Invalid or drifted cursor", ...jsonContent(errorResponseSchema) },
+    404: { description: "Person not found", ...jsonContent(errorResponseSchema) },
+  },
+})
+
 const createCommunicationRoute = createRoute({
   method: "post",
   path: "/people/{id}/communications",
@@ -833,10 +852,14 @@ peopleRoutes
   .openapi(mergePersonRoute, async (c) => {
     try {
       const body = c.req.valid("json")
+      const runtime = c.get("container")?.resolve(RELATIONSHIPS_ROUTE_RUNTIME_CONTAINER_KEY) as
+        | RelationshipsRouteRuntime
+        | undefined
       const row = await relationshipsService.mergePerson(
         c.get("db"),
         c.req.valid("param").id,
         body.mergeId,
+        runtime?.personConversations,
       )
       // The service always returns the hydrated survivor (email/phone/website);
       // the `?? row` fallback in the service only widens the static type.
@@ -979,7 +1002,57 @@ peopleRoutes
         ? Promise.resolve([])
         : runtime.personNotifications.listPersonDeliveries(c.get("db"), personId, query),
     ])
-    return c.json({ data: mergePersonCommunications(personId, logged, delivered, query) }, 200)
+    return c.json(
+      {
+        data: [
+          ...logged.map((row) => ({ ...row, source: "logged" as const })),
+          ...delivered.map((row) => ({
+            id: row.id,
+            personId,
+            organizationId: null,
+            channel: row.channel,
+            direction: "outbound" as const,
+            subject: row.subject,
+            content: row.body,
+            sentAt: new Date(row.occurredAt),
+            createdAt: new Date(row.createdAt),
+            source: "notification" as const,
+          })),
+        ]
+          .sort(
+            (left, right) =>
+              (right.sentAt ?? right.createdAt).getTime() -
+              (left.sentAt ?? left.createdAt).getTime(),
+          )
+          .slice(0, query.limit),
+      },
+      200,
+    )
+  })
+  .openapi(listPersonTimelineRoute, async (c) => {
+    const personId = c.req.valid("param").id
+    const query = c.req.valid("query")
+    const actorUserId = requireUserId(c)
+    if (!(await relationshipsService.getPersonById(c.get("db"), personId))) {
+      return c.json({ error: "Person not found" }, 404)
+    }
+    const runtime = c.get("container")?.resolve(RELATIONSHIPS_ROUTE_RUNTIME_CONTAINER_KEY) as
+      | RelationshipsRouteRuntime
+      | undefined
+    try {
+      return c.json(
+        await listPersonTimeline(c.get("db"), personId, query, actorUserId, {
+          notifications: runtime?.personNotifications,
+          conversations: runtime?.personConversations,
+        }),
+        200,
+      )
+    } catch (error) {
+      if (error instanceof InvalidPersonTimelineCursorError) {
+        return c.json({ error: error.code }, 400)
+      }
+      throw error
+    }
   })
   .openapi(createCommunicationRoute, async (c) => {
     const row = await relationshipsService.createCommunication(

--- a/packages/relationships/src/runtime-contributor.ts
+++ b/packages/relationships/src/runtime-contributor.ts
@@ -2,8 +2,6 @@ import {
   type BookingsRelationshipsRuntime,
   bookingsRelationshipsRuntimePort,
 } from "@voyant-travel/bookings/runtime-port"
-import type { ConversationsPersonDirectory } from "@voyant-travel/conversations/runtime-port"
-import { conversationsPersonDirectoryPort } from "@voyant-travel/conversations/runtime-port"
 import { normalizeE164, normalizeEmailAddress } from "@voyant-travel/conversations-contracts"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import {
@@ -26,24 +24,36 @@ import {
   financeStoredInstrumentRuntimePort,
 } from "@voyant-travel/finance/runtime-port"
 import { identityContactPoints } from "@voyant-travel/identity/schema"
-import { and, eq, sql } from "drizzle-orm"
+import { and, eq, inArray, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { createPublicApiIntakePersistence } from "./public-api-intake-runtime.js"
 import type { RelationshipsRouteRuntimeOptions } from "./route-runtime.js"
 import {
   type RelationshipsBookingEnrichmentDatabaseRuntime,
   type RelationshipsMiceRuntime,
+  type RelationshipsPersonConversationsRuntime,
   type RelationshipsPersonNotificationsRuntime,
   relationshipsBookingEnrichmentDatabaseRuntimePort,
   relationshipsMiceRuntimePort,
+  relationshipsPersonConversationsRuntimePort,
   relationshipsPersonNotificationsRuntimePort,
   relationshipsRouteRuntimePort,
 } from "./runtime-port.js"
 import { relationshipsService } from "./service/index.js"
 
+interface ConversationsPersonDirectory {
+  resolveEmail(db: unknown, address: string): Promise<DirectoryResolution>
+  resolvePhone(db: unknown, address: string): Promise<DirectoryResolution>
+  resolvePersonContactPoint(
+    db: unknown,
+    input: { personRef: string; contactPointRef: string; channel?: "email" | "sms" },
+  ): Promise<{ address: string } | null>
+}
+
 const publicApiIntakeRuntimePortReference = {
   id: "public-api.intake.runtime",
 } as const
+const conversationsPersonDirectoryPortReference = { id: "conversations.person-directory" } as const
 
 const relationshipCustomFieldTables = {
   person: "people",
@@ -90,62 +100,6 @@ const relationshipCustomFieldValues: CustomFieldValueLifecycleRuntime = {
           WHERE custom_fields -> ${definition.namespace} ? ${definition.key}`,
     )
   },
-}
-
-const conversationsPersonDirectory: ConversationsPersonDirectory = {
-  async resolveEmail(db, address) {
-    return resolveConversationContact(db, "email", normalizeEmailAddress(address))
-  },
-  async resolvePhone(db, address) {
-    return resolveConversationContact(db, "phone", normalizeE164(address))
-  },
-  async resolvePersonContactPoint(db, input) {
-    const kind = input.channel === "sms" ? "phone" : "email"
-    const rows = await (db as PostgresJsDatabase)
-      .select()
-      .from(identityContactPoints)
-      .where(
-        and(
-          eq(identityContactPoints.id, input.contactPointRef),
-          eq(identityContactPoints.entityType, "person"),
-          eq(identityContactPoints.entityId, input.personRef),
-          eq(identityContactPoints.kind, kind),
-        ),
-      )
-      .limit(1)
-    const point = rows[0]
-    if (!point) return null
-    return {
-      address: kind === "phone" ? normalizeE164(point.value) : normalizeEmailAddress(point.value),
-    }
-  },
-}
-
-async function resolveConversationContact(
-  db: unknown,
-  kind: "email" | "phone",
-  normalizedAddress: string,
-) {
-  const rows = await (db as PostgresJsDatabase)
-    .select()
-    .from(identityContactPoints)
-    .where(
-      and(
-        eq(identityContactPoints.entityType, "person"),
-        eq(identityContactPoints.kind, kind),
-        eq(identityContactPoints.normalizedValue, normalizedAddress),
-      ),
-    )
-    .limit(2)
-  if (rows.length === 0) return { kind: "none" as const }
-  if (rows.length > 1) return { kind: "ambiguous" as const }
-  const point = rows[0]!
-  return {
-    kind: "unique" as const,
-    personRef: point.entityId,
-    contactPointRef: point.id,
-    address: normalizedAddress,
-  }
 }
 
 const relationshipCustomFieldValueOperations: CustomFieldValueOperationsRuntime = {
@@ -239,6 +193,78 @@ async function resolvePersonNotifications(
   }
 }
 
+async function resolvePersonConversations(
+  host: RelationshipsRuntimeContributorHost,
+): Promise<RelationshipsPersonConversationsRuntime | undefined> {
+  if (host.hasRuntimePort?.(relationshipsPersonConversationsRuntimePort) === false) return undefined
+  try {
+    return await host.getRuntimePort(relationshipsPersonConversationsRuntimePort)
+  } catch {
+    return undefined
+  }
+}
+
+type DirectoryResolution =
+  | { kind: "none" }
+  | { kind: "ambiguous" }
+  | {
+      kind: "unique"
+      personRef: string
+      contactPointRef: string
+      address: string
+      channel: "email" | "sms"
+    }
+
+function normalizeDirectoryAddress(channel: "email" | "sms", value: string): string {
+  return channel === "email" ? normalizeEmailAddress(value) : normalizeE164(value)
+}
+
+export function classifyDirectoryRows(
+  rows: readonly { id: string; personRef: string; address: string }[],
+  channel: "email" | "sms",
+): DirectoryResolution {
+  const people = new Set(rows.map((row) => row.personRef))
+  if (people.size === 0) return { kind: "none" }
+  if (people.size > 1 || rows.length > 1) return { kind: "ambiguous" }
+  const row = rows[0]!
+  return {
+    kind: "unique",
+    personRef: row.personRef,
+    contactPointRef: row.id,
+    address: normalizeDirectoryAddress(channel, row.address),
+    channel,
+  }
+}
+
+async function resolveDirectoryAddress(
+  db: unknown,
+  channel: "email" | "sms",
+  address: string,
+): Promise<DirectoryResolution> {
+  const database = db as PostgresJsDatabase
+  const normalized = normalizeDirectoryAddress(channel, address)
+  const kinds = channel === "email" ? (["email"] as const) : (["phone", "mobile", "sms"] as const)
+  const rows = await database
+    .select({
+      id: identityContactPoints.id,
+      personRef: identityContactPoints.entityId,
+      address: identityContactPoints.value,
+    })
+    .from(identityContactPoints)
+    .where(
+      and(
+        eq(identityContactPoints.entityType, "person"),
+        inArray(identityContactPoints.kind, kinds),
+        or(
+          eq(identityContactPoints.normalizedValue, normalized),
+          sql`lower(${identityContactPoints.value}) = ${normalized.toLowerCase()}`,
+        ),
+      ),
+    )
+    .limit(3)
+  return classifyDirectoryRows(rows, channel)
+}
+
 /** Package-owned registration map for Relationships deployment adapters. */
 export function createRelationshipsRuntimePortContribution(
   host: RelationshipsRuntimeContributorHost,
@@ -247,6 +273,7 @@ export function createRelationshipsRuntimePortContribution(
     host.getRuntimePort<CustomFieldsRuntime>(customFieldsRuntimePort),
   )
   const personNotifications = resolvePersonNotifications(host)
+  const personConversations = resolvePersonConversations(host)
   const customFields: CustomFieldValueReaderRuntime = {
     async resolveVisibleValues(db, entity, entityId, channel) {
       const database = db as PostgresJsDatabase
@@ -277,7 +304,6 @@ export function createRelationshipsRuntimePortContribution(
     },
   }
   return {
-    [conversationsPersonDirectoryPort.id]: conversationsPersonDirectory,
     [publicApiIntakeRuntimePortReference.id]: createPublicApiIntakePersistence(),
     [customFieldValueReaderRuntimePort.id]: customFields,
     [customFieldValueLifecycleRuntimePort.id]: relationshipCustomFieldValues,
@@ -294,12 +320,57 @@ export function createRelationshipsRuntimePortContribution(
       personNotifications: {
         listPersonDeliveries: async (db, personId, query) =>
           (await personNotifications)?.listPersonDeliveries(db, personId, query) ?? [],
+        getDeliveryTruth: async (db, deliveryIds) =>
+          (await personNotifications)?.getDeliveryTruth(db, deliveryIds) ?? {},
+      },
+      personConversations: {
+        listPersonParts: async (db, personId, query) =>
+          (await personConversations)?.listPersonParts(db, personId, query) ?? [],
+        findLinkedDeliveryIds: async (db, personId, deliveryIds, actorUserId) =>
+          (await personConversations)?.findLinkedDeliveryIds(
+            db,
+            personId,
+            deliveryIds,
+            actorUserId,
+          ) ?? [],
+        mergePersonHistory: async (db, survivorPersonId, mergedPersonId) =>
+          (await personConversations)?.mergePersonHistory(db, survivorPersonId, mergedPersonId),
       },
     } satisfies RelationshipsRouteRuntimeOptions,
     [relationshipsMiceRuntimePort.id]: {
       personExists: async (db, personId) =>
         (await relationshipsService.getPersonById(db as never, personId)) != null,
     } satisfies RelationshipsMiceRuntime,
+    [conversationsPersonDirectoryPortReference.id]: {
+      resolveEmail: (db: unknown, address: string) => resolveDirectoryAddress(db, "email", address),
+      resolvePhone: (db: unknown, address: string) => resolveDirectoryAddress(db, "sms", address),
+      async resolvePersonContactPoint(
+        db: unknown,
+        input: { personRef: string; contactPointRef: string; channel?: "email" | "sms" },
+      ) {
+        const database = db as PostgresJsDatabase
+        const channel = input.channel ?? "email"
+        const kinds =
+          channel === "email" ? (["email"] as const) : (["phone", "mobile", "sms"] as const)
+        const [row] = await database
+          .select({ address: identityContactPoints.value })
+          .from(identityContactPoints)
+          .where(
+            and(
+              eq(identityContactPoints.id, input.contactPointRef),
+              eq(identityContactPoints.entityType, "person"),
+              eq(identityContactPoints.entityId, input.personRef),
+              inArray(identityContactPoints.kind, kinds),
+            ),
+          )
+          .limit(1)
+        if (!row) return null
+        return {
+          address:
+            channel === "sms" ? normalizeE164(row.address) : normalizeEmailAddress(row.address),
+        }
+      },
+    } satisfies ConversationsPersonDirectory,
     [relationshipsBookingEnrichmentDatabaseRuntimePort.id]: {
       withDb: <T>(bindings: unknown, operation: (db: AnyDrizzleDb) => Promise<T>) =>
         host.primitives.database.transaction(bindings, (database) =>

--- a/packages/relationships/src/runtime-port.ts
+++ b/packages/relationships/src/runtime-port.ts
@@ -13,20 +13,44 @@ export interface RelationshipsBookingEnrichmentDatabaseRuntime {
 }
 
 /** One message a deployment actually delivered to a person. */
+export type PersonCommunicationChannel = "email" | "sms"
+export type PersonCommunicationDirection = "inbound" | "outbound"
+export type PersonCommunicationDeliveryStatus =
+  | "received"
+  | "pending"
+  | "accepted"
+  | "delivered"
+  | "failed"
+  | "bounced"
+  | "complained"
+  | "suppressed"
+  | "cancelled"
+
+export interface PersonTimelineBoundary {
+  occurredAt: string
+  source: "logged" | "conversation" | "notification"
+  id: string
+}
+
 export interface PersonNotificationDelivery {
   id: string
-  channel: "email" | "sms"
+  channel: PersonCommunicationChannel
   subject: string | null
   body: string | null
-  sentAt: string | null
+  status: PersonCommunicationDeliveryStatus
+  occurredAt: string
   createdAt: string
 }
 
 export interface PersonNotificationDeliveryQuery {
   limit: number
-  offset: number
+  actorUserId: string
+  boundary?: PersonTimelineBoundary
   dateFrom?: string
   dateTo?: string
+  channel?: string
+  direction?: PersonCommunicationDirection
+  includeAllStatuses?: boolean
 }
 
 /**
@@ -43,6 +67,39 @@ export interface RelationshipsPersonNotificationsRuntime {
     personId: string,
     query: PersonNotificationDeliveryQuery,
   ): Promise<readonly PersonNotificationDelivery[]>
+  getDeliveryTruth(
+    db: unknown,
+    deliveryIds: readonly string[],
+  ): Promise<Readonly<Record<string, PersonCommunicationDeliveryStatus>>>
+}
+
+/** A customer-visible part, projected without exposing message transport internals. */
+export interface PersonConversationPart {
+  id: string
+  conversationId: string
+  channel: PersonCommunicationChannel
+  direction: PersonCommunicationDirection
+  subject: string | null
+  body: string | null
+  deliveryStatus: PersonCommunicationDeliveryStatus | null
+  notificationDeliveryId: string | null
+  occurredAt: string
+  createdAt: string
+}
+
+export interface RelationshipsPersonConversationsRuntime {
+  listPersonParts(
+    db: unknown,
+    personId: string,
+    query: PersonNotificationDeliveryQuery,
+  ): Promise<readonly PersonConversationPart[]>
+  findLinkedDeliveryIds(
+    db: unknown,
+    personId: string,
+    deliveryIds: readonly string[],
+    actorUserId: string,
+  ): Promise<readonly string[]>
+  mergePersonHistory(db: unknown, survivorPersonId: string, mergedPersonId: string): Promise<void>
 }
 
 /** Deployment contract consumed by the package-owned Relationships graph runtime. */
@@ -93,6 +150,24 @@ export const relationshipsPersonNotificationsRuntimePort =
       ) {
         throw new Error(
           "relationships.person-notifications provider must implement listPersonDeliveries().",
+        )
+      }
+    },
+  })
+
+export const relationshipsPersonConversationsRuntimePort =
+  definePort<RelationshipsPersonConversationsRuntime>({
+    id: "relationships.person-conversations",
+    test(provider) {
+      if (
+        provider === null ||
+        typeof provider !== "object" ||
+        typeof provider.listPersonParts !== "function" ||
+        typeof provider.findLinkedDeliveryIds !== "function" ||
+        typeof provider.mergePersonHistory !== "function"
+      ) {
+        throw new Error(
+          "relationships.person-conversations provider must implement timeline methods.",
         )
       }
     },

--- a/packages/relationships/src/service/accounts-merge.ts
+++ b/packages/relationships/src/service/accounts-merge.ts
@@ -353,7 +353,18 @@ async function dedupePersonJoinTables(db: PostgresJsDatabase, keepId: string, me
 }
 
 export const accountMergeService = {
-  async mergePerson(db: PostgresJsDatabase, keepId: string, mergeId: string) {
+  async mergePerson(
+    db: PostgresJsDatabase,
+    keepId: string,
+    mergeId: string,
+    conversations?: {
+      mergePersonHistory(
+        db: unknown,
+        survivorPersonId: string,
+        mergedPersonId: string,
+      ): Promise<void>
+    },
+  ) {
     if (keepId === mergeId) {
       throw new RelationshipsMergeError("Cannot merge a person into itself", 400)
     }
@@ -495,6 +506,8 @@ export const accountMergeService = {
         keepId,
         mergeId,
       )
+
+      await conversations?.mergePersonHistory(tx, keepId, mergeId)
 
       await tx.delete(people).where(eq(people.id, mergeId))
 

--- a/packages/relationships/src/service/person-communications.ts
+++ b/packages/relationships/src/service/person-communications.ts
@@ -1,83 +1,358 @@
-import type { PersonNotificationDelivery } from "../runtime-port.js"
-import type { CommunicationLogEntry } from "../schema.js"
+import { and, desc, eq, gte, lt, lte, or, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-/**
- * A communication as the Communications tab sees it.
- *
- * `source` is the field the UI needs: a `logged` entry is a row staff wrote and
- * may edit, a `notification` entry is a message the deployment sent and is
- * read-only. Without it the tab would offer to edit a delivery record that has
- * no edit route behind it.
- */
+import type {
+  PersonCommunicationDeliveryStatus,
+  PersonConversationPart,
+  PersonNotificationDelivery,
+  PersonTimelineBoundary,
+  RelationshipsPersonConversationsRuntime,
+  RelationshipsPersonNotificationsRuntime,
+} from "../runtime-port.js"
+import { communicationLog } from "../schema.js"
+
+export type PersonCommunicationSource = "logged" | "conversation" | "notification"
+
 export interface PersonCommunicationEntry {
   id: string
   personId: string
   organizationId: string | null
-  channel: CommunicationLogEntry["channel"]
-  direction: CommunicationLogEntry["direction"]
+  conversationId: string | null
+  channel: "email" | "phone" | "whatsapp" | "sms" | "meeting" | "other"
+  direction: "inbound" | "outbound"
   subject: string | null
   content: string | null
-  sentAt: Date | null
+  deliveryStatus: PersonCommunicationDeliveryStatus | null
+  occurredAt: Date
   createdAt: Date
-  source: "logged" | "notification"
+  source: PersonCommunicationSource
 }
 
-interface MergeQuery {
+export interface PersonTimelineQuery {
   limit: number
-  offset: number
-  channel?: CommunicationLogEntry["channel"]
-  direction?: CommunicationLogEntry["direction"]
+  cursor?: string
+  channel?: PersonCommunicationEntry["channel"]
+  direction?: PersonCommunicationEntry["direction"]
+  dateFrom?: string
+  dateTo?: string
 }
 
-function orderedAt(entry: PersonCommunicationEntry): number {
-  return (entry.sentAt ?? entry.createdAt).getTime()
+export interface PersonTimelinePage {
+  data: PersonCommunicationEntry[]
+  nextCursor: string | null
 }
 
-/**
- * Interleave hand-logged entries with delivered notifications, newest first.
- *
- * Both inputs arrive already paged by their own source, so the merge is exact
- * for the first page and approximate beyond it — a deep page can miss an entry
- * that sorted into the other source's earlier page. The tab reads one page of
- * 50, and the alternative is a cross-module SQL union that would put Bookings'
- * and Notifications' tables inside a CRM query.
- */
-export function mergePersonCommunications(
+interface CursorPayload {
+  v: 1
+  personId: string
+  filters: string
+  boundary: PersonTimelineBoundary
+}
+
+const sourceRank: Record<PersonCommunicationSource, number> = {
+  logged: 0,
+  conversation: 1,
+  notification: 2,
+}
+
+export class InvalidPersonTimelineCursorError extends Error {
+  readonly code = "invalid_person_timeline_cursor"
+}
+
+function base64UrlEncode(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url")
+}
+
+function base64UrlDecode(value: string): string {
+  return Buffer.from(value, "base64url").toString("utf8")
+}
+
+function filterIdentity(query: PersonTimelineQuery): string {
+  return JSON.stringify({
+    channel: query.channel ?? null,
+    direction: query.direction ?? null,
+    dateFrom: query.dateFrom ?? null,
+    dateTo: query.dateTo ?? null,
+  })
+}
+
+export function encodePersonTimelineCursor(
   personId: string,
-  logged: readonly CommunicationLogEntry[],
-  delivered: readonly PersonNotificationDelivery[],
-  query: MergeQuery,
-): PersonCommunicationEntry[] {
-  const entries: PersonCommunicationEntry[] = logged.map((row) => ({
+  query: PersonTimelineQuery,
+  boundary: PersonTimelineBoundary,
+): string {
+  return base64UrlEncode(
+    JSON.stringify({ v: 1, personId, filters: filterIdentity(query), boundary }),
+  )
+}
+
+export function decodePersonTimelineCursor(
+  cursor: string | undefined,
+  personId: string,
+  query: PersonTimelineQuery,
+): PersonTimelineBoundary | undefined {
+  if (!cursor) return undefined
+  try {
+    const parsed = JSON.parse(base64UrlDecode(cursor)) as Partial<CursorPayload>
+    if (
+      parsed.v !== 1 ||
+      parsed.personId !== personId ||
+      parsed.filters !== filterIdentity(query) ||
+      !parsed.boundary ||
+      !["logged", "conversation", "notification"].includes(parsed.boundary.source) ||
+      typeof parsed.boundary.id !== "string" ||
+      Number.isNaN(new Date(parsed.boundary.occurredAt).getTime())
+    ) {
+      throw new InvalidPersonTimelineCursorError()
+    }
+    return parsed.boundary
+  } catch (error) {
+    if (error instanceof InvalidPersonTimelineCursorError) throw error
+    throw new InvalidPersonTimelineCursorError()
+  }
+}
+
+function comesAfterBoundary(
+  source: PersonCommunicationSource,
+  id: string,
+  occurredAt: Date,
+  boundary: PersonTimelineBoundary,
+): boolean {
+  const timestamp = occurredAt.getTime()
+  const boundaryTimestamp = new Date(boundary.occurredAt).getTime()
+  if (timestamp !== boundaryTimestamp) return timestamp < boundaryTimestamp
+  if (sourceRank[source] !== sourceRank[boundary.source]) {
+    return sourceRank[source] > sourceRank[boundary.source]
+  }
+  return id < boundary.id
+}
+
+function compareTimeline(left: PersonCommunicationEntry, right: PersonCommunicationEntry): number {
+  const timestamp = right.occurredAt.getTime() - left.occurredAt.getTime()
+  if (timestamp !== 0) return timestamp
+  const source = sourceRank[left.source] - sourceRank[right.source]
+  if (source !== 0) return source
+  return right.id.localeCompare(left.id)
+}
+
+async function listLogged(
+  db: PostgresJsDatabase,
+  personId: string,
+  query: PersonTimelineQuery,
+  boundary: PersonTimelineBoundary | undefined,
+): Promise<PersonCommunicationEntry[]> {
+  const orderedAt = sql<Date>`coalesce(${communicationLog.sentAt}, ${communicationLog.createdAt})`
+  const conditions = [eq(communicationLog.personId, personId)]
+  if (query.channel) conditions.push(eq(communicationLog.channel, query.channel))
+  if (query.direction) conditions.push(eq(communicationLog.direction, query.direction))
+  if (query.dateFrom) conditions.push(gte(orderedAt, new Date(query.dateFrom)))
+  if (query.dateTo) conditions.push(lte(orderedAt, new Date(query.dateTo)))
+  if (boundary) {
+    const at = new Date(boundary.occurredAt)
+    const rank = sourceRank.logged
+    conditions.push(
+      rank > sourceRank[boundary.source]
+        ? lte(orderedAt, at)
+        : rank < sourceRank[boundary.source]
+          ? lt(orderedAt, at)
+          : or(lt(orderedAt, at), and(eq(orderedAt, at), lt(communicationLog.id, boundary.id)))!,
+    )
+  }
+  const rows = await db
+    .select()
+    .from(communicationLog)
+    .where(and(...conditions))
+    .orderBy(desc(orderedAt), desc(communicationLog.id))
+    .limit(query.limit + 1)
+  return rows.map((row) => ({
     id: row.id,
     personId: row.personId,
     organizationId: row.organizationId,
+    conversationId: null,
     channel: row.channel,
     direction: row.direction,
     subject: row.subject,
     content: row.content,
-    sentAt: row.sentAt,
+    deliveryStatus: null,
+    occurredAt: row.sentAt ?? row.createdAt,
     createdAt: row.createdAt,
     source: "logged",
   }))
+}
 
-  for (const delivery of delivered) {
-    // The delivery channel enum is a subset of the communication one, but a
-    // caller filtering on `phone` or `meeting` must not see email deliveries.
-    if (query.channel && query.channel !== delivery.channel) continue
-    entries.push({
-      id: delivery.id,
-      personId,
-      organizationId: null,
-      channel: delivery.channel,
-      direction: "outbound",
-      subject: delivery.subject,
-      content: delivery.body,
-      sentAt: delivery.sentAt ? new Date(delivery.sentAt) : null,
-      createdAt: new Date(delivery.createdAt),
-      source: "notification",
-    })
+function conversationEntry(
+  personId: string,
+  part: PersonConversationPart,
+): PersonCommunicationEntry {
+  return {
+    id: part.id,
+    personId,
+    organizationId: null,
+    conversationId: part.conversationId,
+    channel: part.channel,
+    direction: part.direction,
+    subject: part.subject,
+    content: part.body,
+    deliveryStatus: part.deliveryStatus,
+    occurredAt: new Date(part.occurredAt),
+    createdAt: new Date(part.createdAt),
+    source: "conversation",
+  }
+}
+
+function notificationEntry(
+  personId: string,
+  delivery: PersonNotificationDelivery,
+): PersonCommunicationEntry {
+  return {
+    id: delivery.id,
+    personId,
+    organizationId: null,
+    conversationId: null,
+    channel: delivery.channel,
+    direction: "outbound",
+    subject: delivery.subject,
+    content: delivery.body,
+    deliveryStatus: delivery.status,
+    occurredAt: new Date(delivery.occurredAt),
+    createdAt: new Date(delivery.createdAt),
+    source: "notification",
+  }
+}
+
+/** Exact keyset merge. Each authority is queried at the same global boundary. */
+export async function listPersonTimeline(
+  db: PostgresJsDatabase,
+  personId: string,
+  query: PersonTimelineQuery,
+  actorUserId: string,
+  runtimes: {
+    notifications?: RelationshipsPersonNotificationsRuntime
+    conversations?: RelationshipsPersonConversationsRuntime
+  },
+): Promise<PersonTimelinePage> {
+  const boundary = decodePersonTimelineCursor(query.cursor, personId, query)
+  const runtimeQuery = {
+    limit: query.limit + 1,
+    boundary,
+    dateFrom: query.dateFrom,
+    dateTo: query.dateTo,
+    channel: query.channel,
+    direction: query.direction,
+    includeAllStatuses: true,
+    actorUserId,
+  }
+  const [logged, conversationParts] = await Promise.all([
+    listLogged(db, personId, query, boundary),
+    runtimes.conversations &&
+    (!query.direction || query.direction === "inbound" || query.direction === "outbound")
+      ? runtimes.conversations.listPersonParts(db, personId, runtimeQuery)
+      : Promise.resolve([]),
+  ])
+
+  const channelParts = conversationParts.filter(
+    (part) =>
+      (!query.channel || part.channel === query.channel) &&
+      (!query.direction || part.direction === query.direction),
+  )
+  const deliveries: PersonNotificationDelivery[] = []
+  const linked = new Set<string>()
+  if (runtimes.notifications && query.direction !== "inbound") {
+    let notificationBoundary = boundary
+    while (deliveries.length - linked.size <= query.limit) {
+      const batch = await runtimes.notifications.listPersonDeliveries(db, personId, {
+        ...runtimeQuery,
+        boundary: notificationBoundary,
+      })
+      if (batch.length === 0) break
+      deliveries.push(...batch)
+      if (runtimes.conversations) {
+        for (const id of await runtimes.conversations.findLinkedDeliveryIds(
+          db,
+          personId,
+          batch.map((delivery) => delivery.id),
+          actorUserId,
+        )) {
+          linked.add(id)
+        }
+      }
+      if (batch.length < runtimeQuery.limit) break
+      const last = batch.at(-1)!
+      notificationBoundary = {
+        occurredAt: last.occurredAt,
+        source: "notification",
+        id: last.id,
+      }
+    }
   }
 
-  return entries.sort((left, right) => orderedAt(right) - orderedAt(left)).slice(0, query.limit)
+  const truth = runtimes.notifications
+    ? await runtimes.notifications.getDeliveryTruth(
+        db,
+        channelParts.flatMap((part) =>
+          part.notificationDeliveryId ? [part.notificationDeliveryId] : [],
+        ),
+      )
+    : {}
+  const projectedParts = overlayConversationDeliveryTruth(channelParts, truth)
+
+  return mergePersonTimelineCandidates(
+    personId,
+    query,
+    boundary,
+    logged,
+    projectedParts,
+    deliveries,
+    linked,
+  )
+}
+
+export function overlayConversationDeliveryTruth(
+  parts: readonly PersonConversationPart[],
+  truth: Readonly<Record<string, PersonCommunicationDeliveryStatus>>,
+): PersonConversationPart[] {
+  return parts.map((part) => ({
+    ...part,
+    deliveryStatus: part.notificationDeliveryId
+      ? (truth[part.notificationDeliveryId] ?? null)
+      : part.deliveryStatus,
+  }))
+}
+
+/** Pure merge used to prove pagination independently from database adapters. */
+export function mergePersonTimelineCandidates(
+  personId: string,
+  query: PersonTimelineQuery,
+  boundary: PersonTimelineBoundary | undefined,
+  logged: readonly PersonCommunicationEntry[],
+  conversationParts: readonly PersonConversationPart[],
+  deliveries: readonly PersonNotificationDelivery[],
+  linkedDeliveryIds: ReadonlySet<string>,
+): PersonTimelinePage {
+  const merged = [
+    ...logged,
+    ...conversationParts.map((part) => conversationEntry(personId, part)),
+    ...deliveries
+      .filter((delivery) => !linkedDeliveryIds.has(delivery.id))
+      .map((delivery) => notificationEntry(personId, delivery)),
+  ]
+    .filter(
+      (entry) =>
+        !boundary || comesAfterBoundary(entry.source, entry.id, entry.occurredAt, boundary),
+    )
+    .sort(compareTimeline)
+
+  const data = merged.slice(0, query.limit)
+  const last = data.at(-1)
+  return {
+    data,
+    nextCursor:
+      merged.length > query.limit && last
+        ? encodePersonTimelineCursor(personId, query, {
+            occurredAt: last.occurredAt.toISOString(),
+            source: last.source,
+            id: last.id,
+          })
+        : null,
+  }
 }

--- a/packages/relationships/src/validation.ts
+++ b/packages/relationships/src/validation.ts
@@ -60,6 +60,7 @@ export {
   personListSortFieldSchema,
   personRelationshipKindSchema,
   personRelationshipListQuerySchema,
+  personTimelineQuerySchema,
   recordStatusSchema,
   relationTypeSchema,
   resolveCustomerSignalSchema,

--- a/packages/relationships/src/voyant.ts
+++ b/packages/relationships/src/voyant.ts
@@ -3,7 +3,6 @@ import {
   bookingsCrmSnapshotRuntimePort,
   bookingsRelationshipsRuntimePort,
 } from "@voyant-travel/bookings/runtime-port"
-import { conversationsPersonDirectoryPort } from "@voyant-travel/conversations/runtime-port"
 import { defineModule, providePort, requirePort } from "@voyant-travel/core/project"
 import {
   customFieldsRuntimePort,
@@ -30,6 +29,7 @@ const relationshipsAdminRuntime = {
 } as const
 
 const publicApiIntakeRuntimePortReference = { id: "public-api.intake.runtime" } as const
+const conversationsPersonDirectoryPortReference = { id: "conversations.person-directory" } as const
 
 const customerSignalCreatedPayloadSchema = {
   type: "object",
@@ -88,6 +88,7 @@ export const relationshipsVoyantModule = defineModule({
   provides: {
     ports: [
       publicApiIntakeRuntimePortReference,
+      conversationsPersonDirectoryPortReference,
       providePort(relationshipsMiceRuntimePort),
       providePort(bookingsRelationshipsRuntimePort),
       providePort(financeStoredInstrumentRuntimePort),
@@ -96,7 +97,6 @@ export const relationshipsVoyantModule = defineModule({
       providePort(customFieldValueLifecycleRuntimePort),
       providePort(customFieldValueOperationsRuntimePort),
       providePort(relationshipsBookingEnrichmentDatabaseRuntimePort),
-      providePort(conversationsPersonDirectoryPort),
     ],
   },
   runtimePorts: [

--- a/packages/relationships/tests/unit/conversations-person-directory.test.ts
+++ b/packages/relationships/tests/unit/conversations-person-directory.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+
+import { classifyDirectoryRows } from "../../src/runtime-contributor.js"
+
+describe("Conversations Person directory", () => {
+  it("returns none, unique, and exact ambiguity without choosing a Person", () => {
+    expect(classifyDirectoryRows([], "email")).toEqual({ kind: "none" })
+    expect(
+      classifyDirectoryRows(
+        [{ id: "contact_1", personRef: "person_1", address: "guest@example.test" }],
+        "email",
+      ),
+    ).toEqual({
+      kind: "unique",
+      personRef: "person_1",
+      contactPointRef: "contact_1",
+      address: "guest@example.test",
+      channel: "email",
+    })
+    expect(
+      classifyDirectoryRows(
+        [
+          { id: "contact_1", personRef: "person_1", address: "+12025550100" },
+          { id: "contact_2", personRef: "person_2", address: "+12025550100" },
+        ],
+        "sms",
+      ),
+    ).toEqual({ kind: "ambiguous" })
+  })
+
+  it("treats duplicate matching contact points on one Person as ambiguous", () => {
+    expect(
+      classifyDirectoryRows(
+        [
+          { id: "contact_1", personRef: "person_1", address: "guest@example.test" },
+          { id: "contact_2", personRef: "person_1", address: "guest@example.test" },
+        ],
+        "email",
+      ),
+    ).toEqual({ kind: "ambiguous" })
+  })
+
+  it("rejects non-E.164 phone values instead of inventing a normalized identity", () => {
+    expect(() =>
+      classifyDirectoryRows(
+        [{ id: "contact_1", personRef: "person_1", address: "+1 (202) 555-0100" }],
+        "sms",
+      ),
+    ).toThrow(/normalized E\.164/)
+  })
+})

--- a/packages/relationships/tests/unit/person-communications.test.ts
+++ b/packages/relationships/tests/unit/person-communications.test.ts
@@ -1,101 +1,166 @@
 import { describe, expect, it } from "vitest"
 
-import type { PersonNotificationDelivery } from "../../src/runtime-port.js"
-import type { CommunicationLogEntry } from "../../src/schema.js"
-import { mergePersonCommunications } from "../../src/service/person-communications.js"
+import type { PersonConversationPart, PersonNotificationDelivery } from "../../src/runtime-port.js"
+import {
+  decodePersonTimelineCursor,
+  InvalidPersonTimelineCursorError,
+  mergePersonTimelineCandidates,
+  overlayConversationDeliveryTruth,
+  type PersonCommunicationEntry,
+  type PersonTimelineQuery,
+} from "../../src/service/person-communications.js"
 
 const PERSON_ID = "person_01"
+const QUERY: PersonTimelineQuery = { limit: 2 }
 
-function logged(overrides: Partial<CommunicationLogEntry> = {}): CommunicationLogEntry {
+function logged(id: string, occurredAt: string): PersonCommunicationEntry {
   return {
-    id: "communication_log_01",
+    id,
     personId: PERSON_ID,
     organizationId: null,
+    conversationId: null,
     channel: "phone",
     direction: "inbound",
-    subject: "Called about the itinerary",
+    subject: "Manual call",
     content: null,
-    sentAt: new Date("2026-08-02T10:00:00Z"),
-    createdAt: new Date("2026-08-02T10:00:00Z"),
-    ...overrides,
+    deliveryStatus: null,
+    occurredAt: new Date(occurredAt),
+    createdAt: new Date(occurredAt),
+    source: "logged",
   }
 }
 
-function delivery(overrides: Partial<PersonNotificationDelivery> = {}): PersonNotificationDelivery {
+function part(
+  id: string,
+  occurredAt: string,
+  notificationDeliveryId: string | null = null,
+): PersonConversationPart {
   return {
-    id: "notification_deliveries_01",
+    id,
+    conversationId: `conversation_${id}`,
     channel: "email",
-    subject: "Your booking is confirmed",
-    body: "Thanks for booking with us.",
-    sentAt: "2026-08-03T09:00:00.000Z",
-    createdAt: "2026-08-03T08:59:00.000Z",
-    ...overrides,
+    direction: "outbound",
+    subject: "Reply",
+    body: "Hello",
+    deliveryStatus: "accepted",
+    notificationDeliveryId,
+    occurredAt,
+    createdAt: occurredAt,
   }
 }
 
-const QUERY = { limit: 50, offset: 0 }
+function delivery(id: string, occurredAt: string): PersonNotificationDelivery {
+  return {
+    id,
+    channel: "email",
+    subject: "Notice",
+    body: "Hello",
+    status: "bounced",
+    occurredAt,
+    createdAt: occurredAt,
+  }
+}
 
-describe("mergePersonCommunications", () => {
-  it("interleaves both sources newest first", () => {
-    const merged = mergePersonCommunications(PERSON_ID, [logged()], [delivery()], QUERY)
+function page(
+  query: PersonTimelineQuery,
+  loggedRows: PersonCommunicationEntry[],
+  parts: PersonConversationPart[],
+  deliveries: PersonNotificationDelivery[],
+  linked = new Set<string>(),
+) {
+  const boundary = decodePersonTimelineCursor(query.cursor, PERSON_ID, query)
+  return mergePersonTimelineCandidates(
+    PERSON_ID,
+    query,
+    boundary,
+    loggedRows,
+    parts,
+    deliveries,
+    linked,
+  )
+}
 
-    expect(merged.map((entry) => entry.id)).toEqual([
-      "notification_deliveries_01",
-      "communication_log_01",
-    ])
-  })
-
-  it("tags each entry with where it came from", () => {
-    const merged = mergePersonCommunications(PERSON_ID, [logged()], [delivery()], QUERY)
-
-    expect(merged.map((entry) => entry.source)).toEqual(["notification", "logged"])
-  })
-
-  it("presents a delivery as an outbound message attributed to the person", () => {
-    const [entry] = mergePersonCommunications(PERSON_ID, [], [delivery()], QUERY)
-
-    expect(entry).toMatchObject({
-      personId: PERSON_ID,
-      direction: "outbound",
-      channel: "email",
-      subject: "Your booking is confirmed",
-      content: "Thanks for booking with us.",
-      source: "notification",
-    })
-    expect(entry?.sentAt).toEqual(new Date("2026-08-03T09:00:00.000Z"))
-  })
-
-  it("drops deliveries whose channel the caller filtered out", () => {
-    const merged = mergePersonCommunications(PERSON_ID, [logged()], [delivery()], {
-      ...QUERY,
-      channel: "phone",
-    })
-
-    expect(merged.map((entry) => entry.id)).toEqual(["communication_log_01"])
-  })
-
-  it("orders by createdAt when a delivery has no sent timestamp", () => {
-    const merged = mergePersonCommunications(
-      PERSON_ID,
-      [logged({ sentAt: null, createdAt: new Date("2026-08-05T00:00:00Z") })],
-      [delivery({ sentAt: null })],
-      QUERY,
+describe("Person communication timeline", () => {
+  it("uses a total stable order for equal timestamps", () => {
+    const at = "2026-08-03T09:00:00.000Z"
+    const result = page(
+      { limit: 10 },
+      [logged("log_b", at), logged("log_a", at)],
+      [part("part_a", at)],
+      [delivery("delivery_a", at)],
     )
 
-    expect(merged.map((entry) => entry.id)).toEqual([
-      "communication_log_01",
-      "notification_deliveries_01",
-    ])
+    expect(result.data.map((item) => item.id)).toEqual(["log_b", "log_a", "part_a", "delivery_a"])
   })
 
-  it("never returns more than the requested page", () => {
-    const merged = mergePersonCommunications(
-      PERSON_ID,
-      [logged(), logged({ id: "communication_log_02" })],
-      [delivery(), delivery({ id: "notification_deliveries_02" })],
-      { ...QUERY, limit: 3 },
+  it("paginates deeply without gaps or duplicates as sources exhaust", () => {
+    const logs = [logged("log_3", "2026-08-06T00:00:00Z")]
+    const parts = [
+      part("part_3", "2026-08-05T00:00:00Z"),
+      part("part_2", "2026-08-03T00:00:00Z"),
+      part("part_1", "2026-08-01T00:00:00Z"),
+    ]
+    const deliveries = [
+      delivery("delivery_2", "2026-08-04T00:00:00Z"),
+      delivery("delivery_1", "2026-08-02T00:00:00Z"),
+    ]
+    const seen: string[] = []
+    let cursor: string | undefined
+    do {
+      const result = page({ ...QUERY, cursor }, logs, parts, deliveries)
+      seen.push(...result.data.map((item) => item.id))
+      cursor = result.nextCursor ?? undefined
+    } while (cursor)
+
+    expect(seen).toEqual(["log_3", "part_3", "delivery_2", "part_2", "delivery_1", "part_1"])
+    expect(new Set(seen).size).toBe(seen.length)
+  })
+
+  it("deduplicates a delivery linked to a Conversation Part and keeps delivery truth", () => {
+    const at = "2026-08-03T09:00:00.000Z"
+    const result = page(
+      { limit: 10 },
+      [],
+      [part("part_1", at, "delivery_1")],
+      [delivery("delivery_1", at), delivery("delivery_2", at)],
+      new Set(["delivery_1"]),
     )
 
-    expect(merged).toHaveLength(3)
+    expect(result.data.map((item) => item.id)).toEqual(["part_1", "delivery_2"])
+    expect(result.data[0]).toMatchObject({
+      source: "conversation",
+      conversationId: "conversation_part_1",
+      deliveryStatus: "accepted",
+    })
+    expect(result.data[1]).toMatchObject({ source: "notification", deliveryStatus: "bounced" })
+  })
+
+  it("overlays current delivery truth before linked-delivery dedupe", () => {
+    const projected = overlayConversationDeliveryTruth(
+      [part("part_1", "2026-08-03T09:00:00Z", "delivery_1")],
+      { delivery_1: "bounced" },
+    )
+    expect(projected[0]?.deliveryStatus).toBe("bounced")
+  })
+
+  it("rejects malformed, cross-person, and filter-drifted cursors", () => {
+    const first = page({ limit: 1 }, [logged("log_1", "2026-08-01T00:00:00Z")], [], [])
+    expect(first.nextCursor).toBeNull()
+    const source = page(
+      { limit: 1 },
+      [logged("log_2", "2026-08-02T00:00:00Z"), logged("log_1", "2026-08-01T00:00:00Z")],
+      [],
+      [],
+    )
+    expect(source.nextCursor).not.toBeNull()
+    expect(() => decodePersonTimelineCursor("not-base64", PERSON_ID, QUERY)).toThrow(
+      InvalidPersonTimelineCursorError,
+    )
+    expect(() => decodePersonTimelineCursor(source.nextCursor!, "person_02", { limit: 1 })).toThrow(
+      InvalidPersonTimelineCursorError,
+    )
+    expect(() =>
+      decodePersonTimelineCursor(source.nextCursor!, PERSON_ID, { limit: 1, channel: "email" }),
+    ).toThrow(InvalidPersonTimelineCursorError)
   })
 })

--- a/packages/relationships/tests/unit/voyant-manifest.test.ts
+++ b/packages/relationships/tests/unit/voyant-manifest.test.ts
@@ -24,6 +24,7 @@ describe("relationships deployment manifest", () => {
       provides: {
         ports: [
           { id: "public-api.intake.runtime" },
+          { id: "conversations.person-directory" },
           { id: relationshipsMiceRuntimePort.id },
           { id: bookingsRelationshipsRuntimePort.id },
           { id: financeStoredInstrumentRuntimePort.id },
@@ -32,7 +33,6 @@ describe("relationships deployment manifest", () => {
           { id: customFieldValueLifecycleRuntimePort.id },
           { id: customFieldValueOperationsRuntimePort.id },
           { id: "relationships.booking-enrichment-database" },
-          { id: "conversations.person-directory" },
         ],
       },
       runtimePorts: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2183,6 +2183,9 @@ importers:
       '@voyant-travel/storage':
         specifier: workspace:^
         version: link:../storage
+      '@voyant-travel/relationships':
+        specifier: workspace:^
+        version: link:../relationships
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -5572,9 +5575,6 @@ importers:
       '@voyant-travel/bookings':
         specifier: workspace:^
         version: link:../bookings
-      '@voyant-travel/conversations':
-        specifier: workspace:^
-        version: link:../conversations
       '@voyant-travel/conversations-contracts':
         specifier: workspace:^
         version: link:../conversations-contracts
@@ -5624,6 +5624,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -5649,6 +5652,9 @@ importers:
 
   packages/relationships-react:
     dependencies:
+      '@voyant-travel/admin-react':
+        specifier: workspace:^
+        version: link:../admin-react
       '@voyant-travel/i18n':
         specifier: workspace:^
         version: link:../i18n


### PR DESCRIPTION
## Summary
- merges logged communication, Notification lifecycle truth, and authorized Conversation parts with an opaque exact keyset cursor
- enforces Inbox membership and secure/redacted content projection before exposing message bodies on a Person
- preserves history across Person merges and resolves exact email/phone contacts without creating or merging People
- adds an email/SMS composer gated by the exact Conversations write capability

## Stack
Depends on the Inbox foundation, secure content, SMS, and operations slices already merged into feat/inbox.

Closes #4830

## Verification
- Relationships timeline/directory/manifest: 11 tests
- React composer/capability: 5 tests
- Conversations focused suite compiled; 2 passed and 10 database-gated skipped locally
- Conversations typecheck and Relationships React typecheck
- focused Biome
- Relationships OpenAPI/client generation
- diff check and proprietary-name scan