### PR TITLE
Pin @better-auth/core so a fresh install cannot take 1.7.0

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -298,6 +298,7 @@
   },
   "dependencies": {
     "@better-auth/api-key": "1.6.23",
+    "@better-auth/core": "1.6.23",
     "@better-auth/oauth-provider": "1.6.23",
     "@hono/zod-openapi": "catalog:",
     "@voyant-travel/action-ledger": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1413,6 +1413,9 @@ importers:
       '@better-auth/api-key':
         specifier: 1.6.23
         version: 1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)
+      '@better-auth/core':
+        specifier: 1.6.23
+        version: 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/oauth-provider':
         specifier: 1.6.23
         version: 1.6.23(bf36fc26337f4673d4d3fc1d92c2f490)


### PR DESCRIPTION
## What broke

`@better-auth/core@1.7.0` was published **2026-08-18T00:10Z** and removed `getIp`
entirely. `@better-auth/api-key@1.6.23` imports it:

```
import { getIp } from "@better-auth/core/utils/ip";
```

and declares the peer as `^1.6.23`, which 1.7.0 satisfies. A breaking change
shipped in a minor.

## Why CI only started failing now

This repository's own installs were never affected — the lockfile already
resolved `@better-auth/core@1.6.23`, and CI installs `--frozen-lockfile`.

The **packaged starter acceptance test** is not covered by that: it installs into
a fresh project outside this lockfile, so it resolved 1.7.0 and the runtime
failed to load before serving a request.

```
SyntaxError: The requested module '@better-auth/core/utils/ip'
  does not provide an export named 'getIp'
    at loadProjectRuntime (@voyant-travel/cli/dist/commands/start.js:103:20)
```

Both `voyant start` and `voyant develop` fail. Main was green at 2026-08-17
20:09, before the publish; every run after it fails, on any branch that reaches
this job — it is not specific to the branch that first surfaced it.

## The fix

`@better-auth/core` was never declared here. It arrived only as a transitive
peer, which is exactly why nothing pinned it while its three siblings —
`better-auth`, `@better-auth/api-key`, `@better-auth/oauth-provider` — were all
pinned to an exact `1.6.23`. Declaring it makes the version an explicit fact of
the package instead of a resolution outcome, so any fresh install of
`@voyant-travel/auth` gets the version its siblings were built against.

## Verification

Checked against the published tarballs rather than inferred from the error:

| | `dist/utils/ip.mjs` | `getIp` |
|---|---|---|
| `@better-auth/core@1.6.23` | present | present |
| `@better-auth/core@1.7.0` | present | **absent from the whole dist** |

The lockfile diff is the pin and nothing else (3 lines). `@voyant-travel/auth` is
private, so no changeset applies.

## Not done here

Moving the better-auth family to 1.7.0 is the forward fix and wants its own
change — 1.7.0 carries a breaking change in a minor, so it needs testing rather
than a version bump.