### PR TITLE
feat: publish the communications adapter contract

### DIFF
--- a/.changeset/quiet-channel-contracts.md
+++ b/.changeset/quiet-channel-contracts.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/channel-adapter-contracts": minor
+---
+
+Add the versioned, provider-neutral custom channel adapter contract, deterministic fixture, and reusable conformance runner.

--- a/.changeset/quiet-channel-contracts.md
+++ b/.changeset/quiet-channel-contracts.md
@@ -1,5 +1,10 @@
 ---
 "@voyant-travel/channel-adapter-contracts": minor
+"@voyant-travel/notifications": minor
+"@voyant-travel/conversations-contracts": minor
+"@voyant-travel/conversations": minor
 ---
 
-Add the versioned, provider-neutral custom channel adapter contract, deterministic fixture, and reusable conformance runner.
+Add the provider-neutral channel adapter contract and graph runtime bridge, with
+durable delivery lifecycle reconciliation, scoped inbound attachments, per-channel
+capability negotiation, and email/SMS conformance fixtures.

--- a/docs/architecture/channel-adapter-contract.md
+++ b/docs/architecture/channel-adapter-contract.md
@@ -17,7 +17,7 @@ owns inbound idempotency, threading, parts, and staff replies.
 ## Protocol and capability negotiation
 
 An adapter declares the `channel-adapter.v1` protocol and an explicit capability
-set. Channel names are open strings so later transports do not require a breaking
+set per channel. Channel names are open strings so later transports do not require a breaking
 contract release. At startup the deployment validates that every declared
 capability exactly matches an implemented method. Channel Account setup then
 negotiates its required channel and capabilities and, where supported, validates
@@ -25,8 +25,13 @@ the opaque account reference before activation.
 
 A capability is a promise, not UI metadata. Claiming inbound support requires
 list, fetch, acknowledge, and authenticity verification. Claiming lifecycle
-support requires normalization to the shared delivery states. Missing or
+support requires durable list/fetch/ack plus normalization to the shared delivery states. Missing or
 contradictory capabilities fail setup closed.
+
+`@voyant-travel/communications-adapter-runtime` is the graph bridge. One selected
+bundle is validated before activation, then fanned into Notifications durable
+delivery and lifecycle ports plus Conversations ingress. Health affects dispatch
+and polling; an unavailable account is never used.
 
 ## Secrets and private content
 
@@ -35,7 +40,7 @@ the public contract. They remain inside deployment-owned adapter wiring. The hos
 stores only an opaque adapter account reference and must not render it as a secret
 configuration viewer.
 
-Attachments use stable private handles and stream byte chunks when resolved.
+Attachments use account/source-scoped ephemeral handles and stream byte chunks when resolved.
 Neither signed URLs, whole buffered payloads, nor credentials are persisted in
 adapter DTOs. The domain runtime resolves a private handle at use time and remains
 responsible for authorization, scanning, retention, and redaction.
@@ -48,7 +53,7 @@ delivered, failed, bounced, complained, or suppressed truth.
 
 Inbound processing is pull-based even when a webhook wakes the worker:
 
-1. reject an unauthentic inbound-message or lifecycle-event request;
+1. atomically reject unauthentic raw bytes before they enter either queue;
 2. list opaque item references;
 3. fetch and validate a normalized envelope;
 4. commit the conversation part and replay identity in one domain transaction;
@@ -65,6 +70,6 @@ capability truthfulness, invalid-authenticity rejection without prescribing a
 signature algorithm, duplicate replay, payload drift, fetch/ack crash safety,
 delivery normalization, private DTO shape, and health transitions.
 
-Channel-specific semantics extend this suite rather than weakening the base
-contract. SMS number normalization, segmentation, opt-out/opt-in behavior, and
-adapter-handled automatic replies are intentionally deferred to an SMS extension.
+SMS extends the same contract with strict E.164 addresses, GSM 03.38/UCS-2
+segmentation, hard-opt-out/opt-in events, adapter-handled policy responses, and
+per-channel multimedia negotiation.

--- a/docs/architecture/channel-adapter-contract.md
+++ b/docs/architecture/channel-adapter-contract.md
@@ -1,0 +1,70 @@
+# Custom channel adapter contract
+
+## Decision
+
+Third-party communications transports integrate through the publishable,
+provider-neutral `@voyant-travel/channel-adapter-contracts` package. A deployment
+selects exactly one adapter bundle for a configured Channel Account. Provider
+implementations are deployment wiring, not part of the Inbox or Notifications
+domain packages.
+
+The contract package is dependency-light and contains no runtime module. It may
+define transport DTOs and adapter conformance tools, but it must not take ownership
+of domain runtime ports. Notifications owns durable outbound admission, delivery
+state, Channel Accounts, suppression, and lifecycle reconciliation. Conversations
+owns inbound idempotency, threading, parts, and staff replies.
+
+## Protocol and capability negotiation
+
+An adapter declares the `channel-adapter.v1` protocol and an explicit capability
+set. Channel names are open strings so later transports do not require a breaking
+contract release. At startup the deployment validates that every declared
+capability exactly matches an implemented method. Channel Account setup then
+negotiates its required channel and capabilities and, where supported, validates
+the opaque account reference before activation.
+
+A capability is a promise, not UI metadata. Claiming inbound support requires
+list, fetch, acknowledge, and authenticity verification. Claiming lifecycle
+support requires normalization to the shared delivery states. Missing or
+contradictory capabilities fail setup closed.
+
+## Secrets and private content
+
+Credentials, endpoints, signing material, and adapter configuration never cross
+the public contract. They remain inside deployment-owned adapter wiring. The host
+stores only an opaque adapter account reference and must not render it as a secret
+configuration viewer.
+
+Attachments use stable private handles and stream byte chunks when resolved.
+Neither signed URLs, whole buffered payloads, nor credentials are persisted in
+adapter DTOs. The domain runtime resolves a private handle at use time and remains
+responsible for authorization, scanning, retention, and redaction.
+
+## Outbound and inbound guarantees
+
+Outbound submission is idempotent by `operationId`. A successful call means the
+external transport accepted responsibility; later lifecycle events establish
+delivered, failed, bounced, complained, or suppressed truth.
+
+Inbound processing is pull-based even when a webhook wakes the worker:
+
+1. reject an unauthentic inbound-message or lifecycle-event request;
+2. list opaque item references;
+3. fetch and validate a normalized envelope;
+4. commit the conversation part and replay identity in one domain transaction;
+5. acknowledge only after commit.
+
+An item remains available after fetch until acknowledgement. Repeating an event
+or envelope identity with the same canonical payload is a harmless duplicate;
+reusing it with different content is payload drift and fails closed.
+
+## Conformance boundary
+
+The base conformance runner is transport-neutral. It covers protocol negotiation,
+capability truthfulness, invalid-authenticity rejection without prescribing a
+signature algorithm, duplicate replay, payload drift, fetch/ack crash safety,
+delivery normalization, private DTO shape, and health transitions.
+
+Channel-specific semantics extend this suite rather than weakening the base
+contract. SMS number normalization, segmentation, opt-out/opt-in behavior, and
+adapter-handled automatic replies are intentionally deferred to an SMS extension.

--- a/packages/channel-adapter-contracts/README.md
+++ b/packages/channel-adapter-contracts/README.md
@@ -15,15 +15,15 @@ translates between those ports and one external transport.
 - Adapter credentials and configuration remain inside the adapter deployment.
 - The host stores only an opaque `adapterAccountRef`.
 - Outbound submission returns `accepted`, never a premature `delivered` result.
-- Inbound ingestion is pull-based: `listInbound`, `fetchInbound`, then `ackInbound`.
+- Inbound and lifecycle ingestion are pull-based: list, fetch, commit, then ack.
   The adapter must retain an item until acknowledgement succeeds.
 - Inbound-message and lifecycle-webhook authenticity are decided by the adapter.
   The contract requires a fail-closed result but intentionally does not prescribe
   an algorithm.
-- Attachments cross the boundary as private handles and are read as byte streams.
+- Attachments cross the boundary as account/source-scoped private handles and are read as byte streams.
   Signed URLs, buffered payload requirements, and raw secrets are not durable
   contract values.
-- Channel identifiers are open strings. Support is negotiated from capabilities.
+- Channel identifiers are open strings. Capabilities, including multimedia, are negotiated per channel.
 
 ## Setup
 
@@ -54,7 +54,5 @@ payload-drift behavior, fetch/ack crash safety, lifecycle normalization, and
 health transitions. `FixtureChannelAdapter` can be used for host integration
 tests without network access.
 
-Channel-specific policy suites may extend the base runner. In particular,
-telephone-number normalization, message segmentation, opt-out keywords, and
-adapter-handled automatic responses belong to a future SMS conformance extension;
-they are not inferred by this channel-neutral contract.
+The SMS surface includes strict E.164 normalization, GSM 03.38/UCS-2 segment
+boundaries, opt-out/opt-in policy events, and adapter-handled response markers.

--- a/packages/channel-adapter-contracts/README.md
+++ b/packages/channel-adapter-contracts/README.md
@@ -1,0 +1,60 @@
+# Channel adapter contracts
+
+`@voyant-travel/channel-adapter-contracts` is the public, provider-neutral seam
+for adding a custom communications transport to a Voyant deployment. It contains
+DTO schemas, the adapter interface, capability negotiation, a reusable
+conformance runner, and a deterministic fixture adapter.
+
+The package does not own Inbox or Notifications runtime ports. Those domain
+packages remain responsible for transactions, durable delivery state, replay
+ledgers, suppression, conversation threading, and authorization. An adapter
+translates between those ports and one external transport.
+
+## Boundary
+
+- Adapter credentials and configuration remain inside the adapter deployment.
+- The host stores only an opaque `adapterAccountRef`.
+- Outbound submission returns `accepted`, never a premature `delivered` result.
+- Inbound ingestion is pull-based: `listInbound`, `fetchInbound`, then `ackInbound`.
+  The adapter must retain an item until acknowledgement succeeds.
+- Inbound-message and lifecycle-webhook authenticity are decided by the adapter.
+  The contract requires a fail-closed result but intentionally does not prescribe
+  an algorithm.
+- Attachments cross the boundary as private handles and are read as byte streams.
+  Signed URLs, buffered payload requirements, and raw secrets are not durable
+  contract values.
+- Channel identifiers are open strings. Support is negotiated from capabilities.
+
+## Setup
+
+Call `validateChannelAdapter` when loading an adapter, then
+`negotiateChannelAdapter` for the channel and capabilities required by a Channel
+Account. If `accountValidation` is available, call `validateAccount` before
+enabling the account. A disabled or incompatible account must remain unavailable
+for admission.
+
+```ts
+import {
+  CHANNEL_ADAPTER_PROTOCOL_VERSION,
+  negotiateChannelAdapter,
+} from "@voyant-travel/channel-adapter-contracts/v1"
+
+negotiateChannelAdapter(adapter, {
+  protocolVersion: CHANNEL_ADAPTER_PROTOCOL_VERSION,
+  channel: "email",
+  capabilities: ["outbound", "inbound", "health"],
+})
+```
+
+## Conformance
+
+Custom adapter repositories should run `runChannelAdapterConformance` in CI.
+The suite verifies capability truthfulness, authenticity rejection, replay and
+payload-drift behavior, fetch/ack crash safety, lifecycle normalization, and
+health transitions. `FixtureChannelAdapter` can be used for host integration
+tests without network access.
+
+Channel-specific policy suites may extend the base runner. In particular,
+telephone-number normalization, message segmentation, opt-out keywords, and
+adapter-handled automatic responses belong to a future SMS conformance extension;
+they are not inferred by this channel-neutral contract.

--- a/packages/channel-adapter-contracts/package.json
+++ b/packages/channel-adapter-contracts/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@voyant-travel/channel-adapter-contracts",
+  "version": "0.1.0",
+  "description": "Versioned, provider-neutral contracts and conformance tools for custom communication channel adapters.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./v1": "./src/v1.ts",
+    "./conformance": "./src/conformance.ts",
+    "./testing": "./src/testing.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "test": "vitest run",
+    "lint": "biome check src/ tests/"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "files": ["dist", "README.md"],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./v1": {
+        "types": "./dist/v1.d.ts",
+        "import": "./dist/v1.js",
+        "default": "./dist/v1.js"
+      },
+      "./conformance": {
+        "types": "./dist/conformance.d.ts",
+        "import": "./dist/conformance.js",
+        "default": "./dist/conformance.js"
+      },
+      "./testing": {
+        "types": "./dist/testing.d.ts",
+        "import": "./dist/testing.js",
+        "default": "./dist/testing.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyant-travel/voyant.git",
+    "directory": "packages/channel-adapter-contracts"
+  }
+}

--- a/packages/channel-adapter-contracts/src/conformance.ts
+++ b/packages/channel-adapter-contracts/src/conformance.ts
@@ -1,0 +1,369 @@
+import {
+  accountValidationResultSchema,
+  adapterHealthSchema,
+  CHANNEL_ADAPTER_PROTOCOL_VERSION,
+  type ChannelAdapterV1,
+  canonicalAdapterPayload,
+  channelAdapterDescriptorSchema,
+  type DeliveryLifecycleEvent,
+  deliveryLifecycleEventSchema,
+  type InboundEnvelope,
+  inboundAuthenticityResultSchema,
+  inboundEnvelopeSchema,
+  negotiateChannelAdapter,
+  outboundAcceptanceSchema,
+  policyEvaluationResultSchema,
+} from "./contracts.js"
+
+export class AdapterPayloadDriftError extends Error {
+  constructor(readonly identity: string) {
+    super(`Adapter replay payload drift detected for ${identity}`)
+    this.name = "AdapterPayloadDriftError"
+  }
+}
+
+/** Minimal host-side ledger model used by the reusable conformance scenarios. */
+export class AdapterReplayLedger {
+  readonly #fingerprints = new Map<string, string>()
+
+  observe(
+    namespace: "inbound" | "lifecycle",
+    identity: string,
+    payload: unknown,
+  ): "new" | "duplicate" {
+    const key = `${namespace}:${identity}`
+    const fingerprint = canonicalAdapterPayload(payload)
+    const existing = this.#fingerprints.get(key)
+    if (existing === undefined) {
+      this.#fingerprints.set(key, fingerprint)
+      return "new"
+    }
+    if (existing !== fingerprint) throw new AdapterPayloadDriftError(identity)
+    return "duplicate"
+  }
+}
+
+export interface ChannelAdapterConformanceControl {
+  readonly adapter: ChannelAdapterV1
+  readonly accountRef: string
+  readonly channel: string
+  enqueueInbound(envelope: InboundEnvelope): void
+  replaceInbound(envelope: InboundEnvelope): void
+  setInboundAuthenticity(authentic: boolean): void
+  setHealth(status: "healthy" | "degraded" | "unavailable"): void
+  setRecipientSuppressed(suppressed: boolean): void
+  putPrivateAttachment(handle: string, bytes: Uint8Array): void
+  lifecycleRequest(events: readonly DeliveryLifecycleEvent[]): {
+    adapterAccountRef: string
+    headers: Record<string, string>
+    body: Uint8Array<ArrayBuffer>
+  }
+}
+
+export interface ChannelAdapterConformanceResult {
+  readonly passed: readonly string[]
+}
+
+function requireValue<T>(value: T | undefined, message: string): T {
+  if (value === undefined) throw new Error(message)
+  return value
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message)
+}
+
+/**
+ * Runs transport-neutral scenarios against a fresh adapter harness. It has no
+ * test-runner dependency, so adapter repositories can call it from any suite.
+ */
+export async function runChannelAdapterConformance(
+  createControl: () => ChannelAdapterConformanceControl,
+): Promise<ChannelAdapterConformanceResult> {
+  const passed: string[] = []
+
+  {
+    const control = createControl()
+    negotiateChannelAdapter(control.adapter, {
+      protocolVersion: CHANNEL_ADAPTER_PROTOCOL_VERSION,
+      channel: control.channel,
+      capabilities: [
+        "outbound",
+        "inbound",
+        "lifecycleEvents",
+        "policyEvaluation",
+        "privateAttachments",
+        "accountValidation",
+        "health",
+      ],
+    })
+    const validateAccount = requireValue(
+      control.adapter.validateAccount,
+      "validateAccount is missing",
+    ).bind(control.adapter)
+    const valid = accountValidationResultSchema.parse(
+      await validateAccount({
+        adapterAccountRef: control.accountRef,
+        requiredChannels: [control.channel],
+        requiredCapabilities: ["outbound", "inbound", "health"],
+      }),
+    )
+    assert(valid.valid, "configured account must validate")
+    const missing = accountValidationResultSchema.parse(
+      await validateAccount({
+        adapterAccountRef: "conformance-missing-account",
+        requiredChannels: [control.channel],
+        requiredCapabilities: [],
+      }),
+    )
+    assert(!missing.valid, "an unknown account reference must fail validation")
+    passed.push("capability truthfulness and negotiation")
+  }
+
+  {
+    const control = createControl()
+    control.setInboundAuthenticity(false)
+    const verify = requireValue(
+      control.adapter.verifyInboundAuthenticity,
+      "inbound authenticity method is missing",
+    ).bind(control.adapter)
+    const result = inboundAuthenticityResultSchema.parse(
+      await verify({
+        adapterAccountRef: control.accountRef,
+        headers: {},
+        body: new Uint8Array([1]),
+      }),
+    )
+    assert(!result.authentic, "an invalid authenticity proof must be rejected")
+    passed.push("invalid authenticity proof rejection")
+  }
+
+  {
+    const control = createControl()
+    control.setInboundAuthenticity(false)
+    const verify = requireValue(
+      control.adapter.verifyLifecycleAuthenticity,
+      "lifecycle authenticity method is missing",
+    ).bind(control.adapter)
+    const result = inboundAuthenticityResultSchema.parse(await verify(control.lifecycleRequest([])))
+    assert(!result.authentic, "an invalid lifecycle authenticity proof must be rejected")
+    passed.push("invalid lifecycle authenticity proof rejection")
+  }
+
+  {
+    const control = createControl()
+    const submit = requireValue(control.adapter.submitOutbound, "submitOutbound is missing").bind(
+      control.adapter,
+    )
+    const message = fixtureOutboundMessage(control)
+    const first = outboundAcceptanceSchema.parse(await submit(message))
+    const duplicate = outboundAcceptanceSchema.parse(await submit({ ...message }))
+    assert(
+      first.externalSubmissionId === duplicate.externalSubmissionId,
+      "an identical operation replay must return the original acceptance",
+    )
+    let rejected = false
+    try {
+      await submit({ ...message, text: "drift" })
+    } catch {
+      rejected = true
+    }
+    assert(rejected, "an outbound operation replay with payload drift must fail closed")
+    passed.push("outbound idempotency and payload drift")
+  }
+
+  {
+    const control = createControl()
+    const envelope = fixtureEnvelope(control)
+    const ledger = new AdapterReplayLedger()
+    control.enqueueInbound(envelope)
+    const list = requireValue(control.adapter.listInbound, "listInbound is missing").bind(
+      control.adapter,
+    )
+    const fetch = requireValue(control.adapter.fetchInbound, "fetchInbound is missing").bind(
+      control.adapter,
+    )
+    const ack = requireValue(control.adapter.ackInbound, "ackInbound is missing").bind(
+      control.adapter,
+    )
+    const beforeFetch = await list({ adapterAccountRef: control.accountRef, limit: 10 })
+    assert(beforeFetch.items.length === 1, "queued inbound item must be listed")
+    const firstPayload = inboundEnvelopeSchema.parse(await fetch(beforeFetch.items[0]!))
+    assert(firstPayload.threadRef === "conformance-thread-1", "thread reference must be preserved")
+    assert(
+      firstPayload.replyToExternalMessageId === "conformance-parent-1",
+      "reply relationship must be preserved",
+    )
+    assert(
+      ledger.observe("inbound", firstPayload.externalEnvelopeId, firstPayload) === "new",
+      "first inbound item must be new",
+    )
+    const afterCrash = await list({ adapterAccountRef: control.accountRef, limit: 10 })
+    assert(afterCrash.items.length === 1, "fetch without ack must leave the item available")
+    const duplicatePayload = inboundEnvelopeSchema.parse(await fetch(afterCrash.items[0]!))
+    assert(
+      ledger.observe("inbound", duplicatePayload.externalEnvelopeId, duplicatePayload) ===
+        "duplicate",
+      "refetched payload must be an identical duplicate",
+    )
+    control.replaceInbound({ ...envelope, text: "drift" })
+    const driftedPayload = inboundEnvelopeSchema.parse(await fetch(afterCrash.items[0]!))
+    let driftRejected = false
+    try {
+      ledger.observe("inbound", driftedPayload.externalEnvelopeId, driftedPayload)
+    } catch (error) {
+      driftRejected = error instanceof AdapterPayloadDriftError
+    }
+    assert(driftRejected, "refetched payload drift must fail closed")
+    await ack(beforeFetch.items[0]!)
+    const afterAck = await list({ adapterAccountRef: control.accountRef, limit: 10 })
+    assert(afterAck.items.length === 0, "acknowledged item must leave the queue")
+    passed.push("fetch and acknowledgement crash safety, replay and payload drift")
+  }
+
+  {
+    const control = createControl()
+    const normalize = requireValue(
+      control.adapter.normalizeLifecycleEvents,
+      "normalizeLifecycleEvents is missing",
+    ).bind(control.adapter)
+    const event = fixtureLifecycleEvent(control)
+    const events = deliveryLifecycleEventSchema
+      .array()
+      .parse(await normalize(control.lifecycleRequest([event])))
+    assert(
+      events.length === 1 && events[0]?.state === "delivered",
+      "lifecycle state must normalize",
+    )
+    const ledger = new AdapterReplayLedger()
+    assert(ledger.observe("lifecycle", event.externalEventId, events[0]) === "new", "first event")
+    assert(
+      ledger.observe("lifecycle", event.externalEventId, events[0]) === "duplicate",
+      "identical lifecycle replay must be accepted as a duplicate",
+    )
+    let rejected = false
+    try {
+      ledger.observe("lifecycle", event.externalEventId, { ...event, state: "failed" })
+    } catch (error) {
+      rejected = error instanceof AdapterPayloadDriftError
+    }
+    assert(rejected, "lifecycle replay payload drift must fail closed")
+    passed.push("delivery normalization, duplicate replay and payload drift")
+  }
+
+  {
+    const control = createControl()
+    const evaluate = requireValue(control.adapter.evaluatePolicy, "evaluatePolicy is missing").bind(
+      control.adapter,
+    )
+    control.setRecipientSuppressed(true)
+    const result = policyEvaluationResultSchema.parse(
+      await evaluate({
+        adapterAccountRef: control.accountRef,
+        channel: control.channel,
+        recipient: "suppressed@example.test",
+        purpose: "conversation",
+      }),
+    )
+    assert(!result.allowed && result.code === "recipient_suppressed", "suppression must block send")
+    passed.push("policy suppression")
+  }
+
+  {
+    const control = createControl()
+    const read = requireValue(
+      control.adapter.readPrivateAttachment,
+      "readPrivateAttachment is missing",
+    ).bind(control.adapter)
+    control.putPrivateAttachment("conformance-attachment-1", new Uint8Array([1, 2, 3]))
+    const stream = await read("conformance-attachment-1")
+    const bytes: number[] = []
+    for await (const chunk of stream) bytes.push(...chunk)
+    assert(bytes.join(",") === "1,2,3", "private attachment bytes must stream without a public URL")
+    passed.push("private attachment streaming")
+  }
+
+  {
+    const control = createControl()
+    const health = requireValue(control.adapter.getHealth, "getHealth is missing").bind(
+      control.adapter,
+    )
+    control.setHealth("healthy")
+    assert(
+      adapterHealthSchema.parse(await health({ adapterAccountRef: control.accountRef })).status ===
+        "healthy",
+      "healthy",
+    )
+    control.setHealth("degraded")
+    assert(
+      adapterHealthSchema.parse(await health({ adapterAccountRef: control.accountRef })).status ===
+        "degraded",
+      "degraded",
+    )
+    control.setHealth("unavailable")
+    assert(
+      adapterHealthSchema.parse(await health({ adapterAccountRef: control.accountRef })).status ===
+        "unavailable",
+      "unavailable",
+    )
+    passed.push("health transitions")
+  }
+
+  {
+    const control = createControl()
+    const descriptor = channelAdapterDescriptorSchema.parse(control.adapter.descriptor)
+    const serialized = canonicalAdapterPayload(descriptor).toLowerCase()
+    assert(!serialized.includes("credential"), "descriptor must not expose credentials")
+    assert(!serialized.includes("secret"), "descriptor must not expose secrets")
+    assert(!serialized.includes("configuration"), "descriptor must not expose configuration")
+    passed.push("credential and configuration non-exposure")
+  }
+
+  return { passed }
+}
+
+function fixtureOutboundMessage(control: ChannelAdapterConformanceControl) {
+  return {
+    operationId: "conformance-operation-1",
+    adapterAccountRef: control.accountRef,
+    channel: control.channel,
+    recipient: "customer@example.test",
+    subject: "Conformance",
+    text: "Hello",
+    sanitizedHtml: null,
+    attachments: [],
+    threadRef: null,
+    metadata: {},
+  }
+}
+
+function fixtureEnvelope(control: ChannelAdapterConformanceControl): InboundEnvelope {
+  return {
+    protocolVersion: CHANNEL_ADAPTER_PROTOCOL_VERSION,
+    adapterAccountRef: control.accountRef,
+    channel: control.channel,
+    externalEnvelopeId: "conformance-envelope-1",
+    externalMessageId: "conformance-message-1",
+    occurredAt: "2026-01-01T00:00:00.000Z",
+    sender: { address: "sender@example.test", displayName: null },
+    recipients: [{ address: "inbox@example.test", displayName: null }],
+    subject: "Conformance",
+    text: "Hello",
+    untrustedHtml: null,
+    attachments: [],
+    threadRef: "conformance-thread-1",
+    replyToExternalMessageId: "conformance-parent-1",
+    classification: "message",
+  }
+}
+
+function fixtureLifecycleEvent(control: ChannelAdapterConformanceControl): DeliveryLifecycleEvent {
+  return {
+    adapterAccountRef: control.accountRef,
+    externalEventId: "conformance-event-1",
+    externalSubmissionId: "conformance-submission-1",
+    occurredAt: "2026-01-01T00:01:00.000Z",
+    state: "delivered",
+    reasonCode: null,
+  }
+}

--- a/packages/channel-adapter-contracts/src/conformance.ts
+++ b/packages/channel-adapter-contracts/src/conformance.ts
@@ -1,4 +1,5 @@
 import {
+  accountProvisioningResultSchema,
   accountValidationResultSchema,
   adapterHealthSchema,
   CHANNEL_ADAPTER_PROTOCOL_VERSION,
@@ -46,6 +47,7 @@ export class AdapterReplayLedger {
 export interface ChannelAdapterConformanceControl {
   readonly adapter: ChannelAdapterV1
   readonly accountRef: string
+  readonly sourceRef: string
   readonly channel: string
   enqueueInbound(envelope: InboundEnvelope): void
   replaceInbound(envelope: InboundEnvelope): void
@@ -53,6 +55,7 @@ export interface ChannelAdapterConformanceControl {
   setHealth(status: "healthy" | "degraded" | "unavailable"): void
   setRecipientSuppressed(suppressed: boolean): void
   putPrivateAttachment(handle: string, bytes: Uint8Array): void
+  enqueueLifecycle(event: DeliveryLifecycleEvent): void
   lifecycleRequest(events: readonly DeliveryLifecycleEvent[]): {
     adapterAccountRef: string
     headers: Record<string, string>
@@ -105,7 +108,13 @@ export async function runChannelAdapterConformance(
       await validateAccount({
         adapterAccountRef: control.accountRef,
         requiredChannels: [control.channel],
-        requiredCapabilities: ["outbound", "inbound", "health"],
+        requiredCapabilities: [
+          "outbound",
+          "inbound",
+          "lifecycleEvents",
+          "policyEvaluation",
+          "health",
+        ],
       }),
     )
     assert(valid.valid, "configured account must validate")
@@ -117,6 +126,40 @@ export async function runChannelAdapterConformance(
       }),
     )
     assert(!missing.valid, "an unknown account reference must fail validation")
+    const provision = requireValue(
+      control.adapter.provisionAccount,
+      "provisionAccount is missing",
+    ).bind(control.adapter)
+    const provisionInput = {
+      operationId: "conformance-provision-1",
+      channel: control.channel,
+      address: control.channel === "sms" ? "+12025550100" : "inbox@example.test",
+      displayName: "Inbox",
+      inbound: true,
+      outbound: true,
+    }
+    const firstProvision = accountProvisioningResultSchema.parse(await provision(provisionInput))
+    const replayProvision = accountProvisioningResultSchema.parse(
+      await provision({ ...provisionInput }),
+    )
+    assert(
+      firstProvision.adapterAccountRef === replayProvision.adapterAccountRef,
+      "provision replay must return the same account",
+    )
+    assert(
+      firstProvision.inboundSourceRef === control.sourceRef,
+      "provisioning must return the channel-scoped inbound source",
+    )
+    let provisionDriftRejected = false
+    try {
+      await provision({
+        ...provisionInput,
+        address: control.channel === "sms" ? "+12025550101" : "other@example.test",
+      })
+    } catch {
+      provisionDriftRejected = true
+    }
+    assert(provisionDriftRejected, "provision operation payload drift must fail closed")
     passed.push("capability truthfulness and negotiation")
   }
 
@@ -135,6 +178,21 @@ export async function runChannelAdapterConformance(
       }),
     )
     assert(!result.authentic, "an invalid authenticity proof must be rejected")
+    const queue = requireValue(
+      control.adapter.queueVerifiedInbound,
+      "queueVerifiedInbound is missing",
+    ).bind(control.adapter)
+    const queued = await queue({
+      adapterAccountRef: control.accountRef,
+      headers: {},
+      body: new Uint8Array([1]),
+    })
+    assert(!queued.accepted, "invalid raw bytes must not be queued")
+    const page = await requireValue(control.adapter.listInbound, "listInbound is missing").call(
+      control.adapter,
+      { adapterAccountRef: control.accountRef, sourceRef: control.sourceRef, limit: 10 },
+    )
+    assert(page.items.length === 0, "invalid raw bytes must never become listable")
     passed.push("invalid authenticity proof rejection")
   }
 
@@ -186,19 +244,43 @@ export async function runChannelAdapterConformance(
     const ack = requireValue(control.adapter.ackInbound, "ackInbound is missing").bind(
       control.adapter,
     )
-    const beforeFetch = await list({ adapterAccountRef: control.accountRef, limit: 10 })
+    const beforeFetch = await list({
+      adapterAccountRef: control.accountRef,
+      sourceRef: control.sourceRef,
+      limit: 10,
+    })
     assert(beforeFetch.items.length === 1, "queued inbound item must be listed")
     const firstPayload = inboundEnvelopeSchema.parse(await fetch(beforeFetch.items[0]!))
-    assert(firstPayload.threadRef === "conformance-thread-1", "thread reference must be preserved")
-    assert(
-      firstPayload.replyToExternalMessageId === "conformance-parent-1",
-      "reply relationship must be preserved",
-    )
+    if (control.channel === "email") {
+      assert(
+        firstPayload.threadRef === "conformance-thread-1",
+        "thread reference must be preserved",
+      )
+      assert(
+        firstPayload.replyToExternalMessageId === "conformance-parent-1",
+        "reply relationship must be preserved",
+      )
+    } else {
+      assert(firstPayload.sender.address === "+12025550123", "SMS sender must remain strict E.164")
+      assert(
+        firstPayload.recipients[0]?.address === "+12025550100",
+        "SMS receiving identity must remain strict E.164",
+      )
+      assert(firstPayload.sms?.policyEvent === "hard_opt_out", "SMS policy event must be preserved")
+      assert(
+        firstPayload.sms?.adapterHandledResponse,
+        "SMS adapter-handled response must be preserved",
+      )
+    }
     assert(
       ledger.observe("inbound", firstPayload.externalEnvelopeId, firstPayload) === "new",
       "first inbound item must be new",
     )
-    const afterCrash = await list({ adapterAccountRef: control.accountRef, limit: 10 })
+    const afterCrash = await list({
+      adapterAccountRef: control.accountRef,
+      sourceRef: control.sourceRef,
+      limit: 10,
+    })
     assert(afterCrash.items.length === 1, "fetch without ack must leave the item available")
     const duplicatePayload = inboundEnvelopeSchema.parse(await fetch(afterCrash.items[0]!))
     assert(
@@ -216,7 +298,11 @@ export async function runChannelAdapterConformance(
     }
     assert(driftRejected, "refetched payload drift must fail closed")
     await ack(beforeFetch.items[0]!)
-    const afterAck = await list({ adapterAccountRef: control.accountRef, limit: 10 })
+    const afterAck = await list({
+      adapterAccountRef: control.accountRef,
+      sourceRef: control.sourceRef,
+      limit: 10,
+    })
     assert(afterAck.items.length === 0, "acknowledged item must leave the queue")
     passed.push("fetch and acknowledgement crash safety, replay and payload drift")
   }
@@ -253,6 +339,50 @@ export async function runChannelAdapterConformance(
 
   {
     const control = createControl()
+    const event = fixtureLifecycleEvent(control)
+    control.enqueueLifecycle(event)
+    const list = requireValue(control.adapter.listLifecycle, "listLifecycle is missing").bind(
+      control.adapter,
+    )
+    const fetch = requireValue(control.adapter.fetchLifecycle, "fetchLifecycle is missing").bind(
+      control.adapter,
+    )
+    const ack = requireValue(control.adapter.ackLifecycle, "ackLifecycle is missing").bind(
+      control.adapter,
+    )
+    const page = await list({
+      adapterAccountRef: control.accountRef,
+      sourceRef: control.sourceRef,
+      limit: 10,
+    })
+    const fetched = deliveryLifecycleEventSchema.parse(await fetch(page.items[0]!))
+    assert(fetched.externalEventId === event.externalEventId, "lifecycle event must fetch")
+    assert(
+      (
+        await list({
+          adapterAccountRef: control.accountRef,
+          sourceRef: control.sourceRef,
+          limit: 10,
+        })
+      ).items.length === 1,
+      "lifecycle fetch must not acknowledge",
+    )
+    await ack(page.items[0]!)
+    assert(
+      (
+        await list({
+          adapterAccountRef: control.accountRef,
+          sourceRef: control.sourceRef,
+          limit: 10,
+        })
+      ).items.length === 0,
+      "lifecycle acknowledgement removes the event",
+    )
+    passed.push("lifecycle fetch and acknowledgement crash safety")
+  }
+
+  {
+    const control = createControl()
     const evaluate = requireValue(control.adapter.evaluatePolicy, "evaluatePolicy is missing").bind(
       control.adapter,
     )
@@ -261,7 +391,7 @@ export async function runChannelAdapterConformance(
       await evaluate({
         adapterAccountRef: control.accountRef,
         channel: control.channel,
-        recipient: "suppressed@example.test",
+        recipient: control.channel === "sms" ? "+12025550123" : "suppressed@example.test",
         purpose: "conversation",
       }),
     )
@@ -276,7 +406,11 @@ export async function runChannelAdapterConformance(
       "readPrivateAttachment is missing",
     ).bind(control.adapter)
     control.putPrivateAttachment("conformance-attachment-1", new Uint8Array([1, 2, 3]))
-    const stream = await read("conformance-attachment-1")
+    const stream = await read({
+      adapterAccountRef: control.accountRef,
+      sourceRef: control.sourceRef,
+      handle: "conformance-attachment-1",
+    })
     const bytes: number[] = []
     for await (const chunk of stream) bytes.push(...chunk)
     assert(bytes.join(",") === "1,2,3", "private attachment bytes must stream without a public URL")
@@ -327,8 +461,8 @@ function fixtureOutboundMessage(control: ChannelAdapterConformanceControl) {
     operationId: "conformance-operation-1",
     adapterAccountRef: control.accountRef,
     channel: control.channel,
-    recipient: "customer@example.test",
-    subject: "Conformance",
+    recipient: control.channel === "sms" ? "+12025550123" : "customer@example.test",
+    subject: control.channel === "sms" ? null : "Conformance",
     text: "Hello",
     sanitizedHtml: null,
     attachments: [],
@@ -341,19 +475,32 @@ function fixtureEnvelope(control: ChannelAdapterConformanceControl): InboundEnve
   return {
     protocolVersion: CHANNEL_ADAPTER_PROTOCOL_VERSION,
     adapterAccountRef: control.accountRef,
+    sourceRef: control.sourceRef,
     channel: control.channel,
     externalEnvelopeId: "conformance-envelope-1",
     externalMessageId: "conformance-message-1",
     occurredAt: "2026-01-01T00:00:00.000Z",
-    sender: { address: "sender@example.test", displayName: null },
-    recipients: [{ address: "inbox@example.test", displayName: null }],
-    subject: "Conformance",
+    sender: {
+      address: control.channel === "sms" ? "+12025550123" : "sender@example.test",
+      displayName: null,
+    },
+    recipients: [
+      {
+        address: control.channel === "sms" ? "+12025550100" : "inbox@example.test",
+        displayName: null,
+      },
+    ],
+    subject: control.channel === "sms" ? null : "Conformance",
     text: "Hello",
     untrustedHtml: null,
     attachments: [],
     threadRef: "conformance-thread-1",
     replyToExternalMessageId: "conformance-parent-1",
     classification: "message",
+    sms:
+      control.channel === "sms"
+        ? { policyEvent: "hard_opt_out", adapterHandledResponse: true }
+        : null,
   }
 }
 

--- a/packages/channel-adapter-contracts/src/contracts.ts
+++ b/packages/channel-adapter-contracts/src/contracts.ts
@@ -10,9 +10,9 @@ export const channelAdapterProtocolVersionSchema = z.literal(CHANNEL_ADAPTER_PRO
  */
 export const channelKindSchema = z.string().trim().min(1).max(64)
 
-export const channelAdapterCapabilitiesSchema = z
+export const channelCapabilitiesSchema = z
   .object({
-    channels: z.array(channelKindSchema).min(1),
+    channel: channelKindSchema,
     outbound: z.boolean(),
     inbound: z.boolean(),
     lifecycleEvents: z.boolean(),
@@ -20,22 +20,75 @@ export const channelAdapterCapabilitiesSchema = z
     privateAttachments: z.boolean(),
     accountValidation: z.boolean(),
     health: z.boolean(),
+    /** MMS/file transport is negotiated independently for every channel. */
+    multimedia: z.boolean(),
   })
   .strict()
 
+export type ChannelCapabilities = z.infer<typeof channelCapabilitiesSchema>
+export const channelAdapterCapabilitiesSchema = z
+  .array(channelCapabilitiesSchema)
+  .min(1)
+  .superRefine((channels, context) => {
+    const seen = new Set<string>()
+    for (const entry of channels) {
+      if (seen.has(entry.channel)) {
+        context.addIssue({
+          code: "custom",
+          message: `Duplicate channel capability: ${entry.channel}`,
+        })
+      }
+      seen.add(entry.channel)
+    }
+  })
 export type ChannelAdapterCapabilities = z.infer<typeof channelAdapterCapabilitiesSchema>
 
 export const channelAdapterDescriptorSchema = z
   .object({
     protocolVersion: channelAdapterProtocolVersionSchema,
     adapterId: z.string().trim().min(1).max(128),
-    capabilities: channelAdapterCapabilitiesSchema,
+    channels: channelAdapterCapabilitiesSchema,
   })
   .strict()
 
 export type ChannelAdapterDescriptor = z.infer<typeof channelAdapterDescriptorSchema>
 
 export const adapterAccountRefSchema = z.string().trim().min(1).max(512)
+export const adapterSourceRefSchema = z.string().trim().min(1).max(512)
+export const smsPolicyEventSchema = z.enum(["hard_opt_out", "opt_in"]).nullable()
+export type SmsPolicyEvent = z.infer<typeof smsPolicyEventSchema>
+export const smsTransportMetadataSchema = z
+  .object({ policyEvent: smsPolicyEventSchema, adapterHandledResponse: z.boolean() })
+  .strict()
+
+const E164_PATTERN = /^\+[1-9]\d{1,14}$/
+export function normalizeE164(value: string): string {
+  const normalized = value.trim()
+  if (!E164_PATTERN.test(normalized)) throw new Error("Address must be strict E.164")
+  return normalized
+}
+
+export const accountProvisioningInputSchema = z
+  .object({
+    operationId: z.string().trim().min(1).max(256),
+    channel: channelKindSchema,
+    address: z.string().trim().min(1).max(2048),
+    displayName: z.string().trim().min(1).max(512),
+    inbound: z.boolean(),
+    outbound: z.boolean(),
+  })
+  .strict()
+export type AccountProvisioningInput = z.infer<typeof accountProvisioningInputSchema>
+
+export const accountProvisioningResultSchema = z
+  .object({
+    adapterAccountRef: adapterAccountRefSchema,
+    normalizedAddress: z.string().trim().min(1).max(2048),
+    displayAddress: z.string().trim().min(1).max(2048),
+    inboundSourceRef: adapterSourceRefSchema.nullable(),
+  })
+  .strict()
+export type AccountProvisioningResult = z.infer<typeof accountProvisioningResultSchema>
 
 export const accountValidationInputSchema = z
   .object({
@@ -108,6 +161,19 @@ export const outboundMessageSchema = z
   .refine((value) => value.text !== null || value.sanitizedHtml !== null, {
     message: "A message must have text or sanitizedHtml content",
   })
+  .superRefine((value, context) => {
+    if (value.channel === "sms") {
+      try {
+        normalizeE164(value.recipient)
+      } catch {
+        context.addIssue({
+          code: "custom",
+          path: ["recipient"],
+          message: "SMS recipient must be strict E.164",
+        })
+      }
+    }
+  })
 
 export type OutboundMessage = z.infer<typeof outboundMessageSchema>
 
@@ -121,7 +187,14 @@ export const outboundAcceptanceSchema = z
 
 export type OutboundAcceptance = z.infer<typeof outboundAcceptanceSchema>
 
-export const inboundItemRefSchema = z.object({ id: z.string().trim().min(1).max(1024) }).strict()
+/** Queue references are opaque only inside their account and ingress source scope. */
+export const inboundItemRefSchema = z
+  .object({
+    adapterAccountRef: adapterAccountRefSchema,
+    sourceRef: adapterSourceRefSchema,
+    id: z.string().trim().min(1).max(1024),
+  })
+  .strict()
 export type InboundItemRef = z.infer<typeof inboundItemRefSchema>
 
 export const inboundListPageSchema = z
@@ -143,6 +216,7 @@ export const inboundEnvelopeSchema = z
   .object({
     protocolVersion: channelAdapterProtocolVersionSchema,
     adapterAccountRef: adapterAccountRefSchema,
+    sourceRef: adapterSourceRefSchema,
     channel: channelKindSchema,
     externalEnvelopeId: z.string().trim().min(1).max(1024),
     externalMessageId: z.string().trim().min(1).max(1024),
@@ -156,8 +230,26 @@ export const inboundEnvelopeSchema = z
     threadRef: z.string().trim().min(1).max(1024).nullable(),
     replyToExternalMessageId: z.string().trim().min(1).max(1024).nullable(),
     classification: z.enum(["message", "automatic_reply", "delivery_status", "complaint"]),
+    sms: smsTransportMetadataSchema.nullable().default(null),
   })
   .strict()
+  .superRefine((value, context) => {
+    if (value.channel !== "sms") {
+      if (value.sms !== null)
+        context.addIssue({
+          code: "custom",
+          path: ["sms"],
+          message: "SMS metadata is channel-specific",
+        })
+      return
+    }
+    try {
+      normalizeE164(value.sender.address)
+      for (const recipient of value.recipients) normalizeE164(recipient.address)
+    } catch {
+      context.addIssue({ code: "custom", message: "SMS addresses must be strict E.164" })
+    }
+  })
 
 export type InboundEnvelope = z.infer<typeof inboundEnvelopeSchema>
 
@@ -182,6 +274,21 @@ export const inboundAuthenticityResultSchema = z.discriminatedUnion("authentic",
 ])
 
 export type InboundAuthenticityResult = z.infer<typeof inboundAuthenticityResultSchema>
+export const rawQueueAcceptanceSchema = z.discriminatedUnion("accepted", [
+  z.object({ accepted: z.literal(true), item: inboundItemRefSchema }).strict(),
+  z
+    .object({
+      accepted: z.literal(false),
+      code: z.enum([
+        "invalid_authenticity_proof",
+        "stale_request",
+        "unknown_account",
+        "invalid_payload",
+      ]),
+    })
+    .strict(),
+])
+export type RawQueueAcceptance = z.infer<typeof rawQueueAcceptanceSchema>
 
 export const deliveryLifecycleEventSchema = z
   .object({
@@ -189,7 +296,15 @@ export const deliveryLifecycleEventSchema = z
     externalEventId: z.string().trim().min(1).max(1024),
     externalSubmissionId: z.string().trim().min(1).max(1024),
     occurredAt: z.string().datetime({ offset: true }),
-    state: z.enum(["accepted", "delivered", "failed", "bounced", "complained", "suppressed"]),
+    state: z.enum([
+      "accepted",
+      "delivered",
+      "failed",
+      "bounced",
+      "complained",
+      "suppressed",
+      "cancelled",
+    ]),
     reasonCode: z.string().trim().min(1).max(128).nullable(),
   })
   .strict()
@@ -233,13 +348,57 @@ export const lifecycleNormalizationInputSchema = z
 
 export type LifecycleNormalizationInput = z.infer<typeof lifecycleNormalizationInputSchema>
 
+export const lifecycleItemRefSchema = z
+  .object({
+    adapterAccountRef: adapterAccountRefSchema,
+    sourceRef: adapterSourceRefSchema,
+    id: z.string().trim().min(1).max(1024),
+  })
+  .strict()
+export type LifecycleItemRef = z.infer<typeof lifecycleItemRefSchema>
+export const lifecycleListPageSchema = z
+  .object({
+    items: z.array(lifecycleItemRefSchema),
+    cursor: z.string().min(1).max(4096).nullable(),
+  })
+  .strict()
+export type LifecycleListPage = z.infer<typeof lifecycleListPageSchema>
+
+/** 3GPP concatenation boundaries: 160/153 septets for GSM-7, 70/67 units for UCS-2. */
+export function smsSegmentCount(text: string): { encoding: "gsm7" | "ucs2"; segments: number } {
+  if (text.length === 0) return { encoding: "gsm7", segments: 0 }
+  const gsmBasic = new Set(
+    "@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞÆæßÉ !\"#¤%&'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà",
+  )
+  const gsmExtension = new Set("\f^{}\\[~]|€")
+  let septets = 0
+  let gsm7 = true
+  for (const character of text) {
+    if (gsmBasic.has(character)) septets += 1
+    else if (gsmExtension.has(character)) septets += 2
+    else {
+      gsm7 = false
+      break
+    }
+  }
+  const units = gsm7 ? septets : text.length
+  const single = gsm7 ? 160 : 70
+  const concatenated = gsm7 ? 153 : 67
+  return {
+    encoding: gsm7 ? "gsm7" : "ucs2",
+    segments: units <= single ? 1 : Math.ceil(units / concatenated),
+  }
+}
+
 export interface ChannelAdapterV1 {
   readonly descriptor: ChannelAdapterDescriptor
+  provisionAccount?(input: AccountProvisioningInput): Promise<AccountProvisioningResult>
   validateAccount?(input: AccountValidationInput): Promise<AccountValidationResult>
   getHealth?(input: { adapterAccountRef: string }): Promise<AdapterHealth>
   submitOutbound?(message: OutboundMessage): Promise<OutboundAcceptance>
   listInbound?(input: {
     adapterAccountRef: string
+    sourceRef: string
     cursor?: string
     limit: number
   }): Promise<InboundListPage>
@@ -248,14 +407,30 @@ export interface ChannelAdapterV1 {
   verifyInboundAuthenticity?(
     request: InboundAuthenticityRequest,
   ): Promise<InboundAuthenticityResult>
+  /** Atomically verifies the untouched request bytes before making an item listable. */
+  queueVerifiedInbound?(request: InboundAuthenticityRequest): Promise<RawQueueAcceptance>
   verifyLifecycleAuthenticity?(
     request: LifecycleNormalizationInput,
   ): Promise<InboundAuthenticityResult>
+  /** Lifecycle counterpart to queueVerifiedInbound; invalid raw bytes never enter the queue. */
+  queueVerifiedLifecycle?(request: LifecycleNormalizationInput): Promise<{ accepted: boolean }>
   normalizeLifecycleEvents?(
     input: LifecycleNormalizationInput,
   ): Promise<readonly DeliveryLifecycleEvent[]>
+  listLifecycle?(input: {
+    adapterAccountRef: string
+    sourceRef: string
+    cursor?: string
+    limit: number
+  }): Promise<LifecycleListPage>
+  fetchLifecycle?(ref: LifecycleItemRef): Promise<DeliveryLifecycleEvent>
+  ackLifecycle?(ref: LifecycleItemRef): Promise<void>
   evaluatePolicy?(input: PolicyEvaluationInput): Promise<PolicyEvaluationResult>
-  readPrivateAttachment?(handle: string): Promise<AsyncIterable<Uint8Array>>
+  readPrivateAttachment?(input: {
+    adapterAccountRef: string
+    sourceRef: string
+    handle: string
+  }): Promise<AsyncIterable<Uint8Array>>
 }
 
 export class ChannelAdapterCompatibilityError extends Error {
@@ -270,16 +445,33 @@ export class ChannelAdapterCompatibilityError extends Error {
 
 const capabilityMethods = {
   outbound: ["submitOutbound"],
-  inbound: ["listInbound", "fetchInbound", "ackInbound", "verifyInboundAuthenticity"],
-  lifecycleEvents: ["verifyLifecycleAuthenticity", "normalizeLifecycleEvents"],
+  inbound: [
+    "listInbound",
+    "fetchInbound",
+    "ackInbound",
+    "verifyInboundAuthenticity",
+    "queueVerifiedInbound",
+  ],
+  lifecycleEvents: [
+    "verifyLifecycleAuthenticity",
+    "queueVerifiedLifecycle",
+    "normalizeLifecycleEvents",
+    "listLifecycle",
+    "fetchLifecycle",
+    "ackLifecycle",
+  ],
   policyEvaluation: ["evaluatePolicy"],
   privateAttachments: ["readPrivateAttachment"],
-  accountValidation: ["validateAccount"],
+  accountValidation: ["provisionAccount", "validateAccount"],
   health: ["getHealth"],
 } as const
 
 export function validateChannelAdapter(adapter: ChannelAdapterV1): ChannelAdapterDescriptor {
-  if (adapter.descriptor.protocolVersion !== CHANNEL_ADAPTER_PROTOCOL_VERSION) {
+  const candidate = z
+    .object({ protocolVersion: z.string(), adapterId: z.string(), channels: z.unknown() })
+    .passthrough()
+    .parse(adapter.descriptor)
+  if (candidate.protocolVersion !== CHANNEL_ADAPTER_PROTOCOL_VERSION) {
     throw new ChannelAdapterCompatibilityError(
       "unsupported_protocol",
       "Adapter protocol is not supported",
@@ -287,7 +479,9 @@ export function validateChannelAdapter(adapter: ChannelAdapterV1): ChannelAdapte
   }
   const descriptor = channelAdapterDescriptorSchema.parse(adapter.descriptor)
   for (const [capability, methods] of Object.entries(capabilityMethods)) {
-    const enabled = descriptor.capabilities[capability as keyof typeof capabilityMethods]
+    const enabled = descriptor.channels.some(
+      (channel) => channel[capability as keyof typeof capabilityMethods],
+    )
     for (const method of methods) {
       const implemented = typeof adapter[method as keyof ChannelAdapterV1] === "function"
       if (enabled !== implemented) {
@@ -306,7 +500,7 @@ export function negotiateChannelAdapter(
   requirements: {
     protocolVersion: typeof CHANNEL_ADAPTER_PROTOCOL_VERSION
     channel: string
-    capabilities: readonly (keyof Omit<ChannelAdapterCapabilities, "channels">)[]
+    capabilities: readonly (keyof Omit<ChannelCapabilities, "channel">)[]
   },
 ): ChannelAdapterDescriptor {
   const descriptor = validateChannelAdapter(adapter)
@@ -316,14 +510,15 @@ export function negotiateChannelAdapter(
       "Adapter protocol is not supported",
     )
   }
-  if (!descriptor.capabilities.channels.includes(requirements.channel)) {
+  const channel = descriptor.channels.find(({ channel }) => channel === requirements.channel)
+  if (!channel) {
     throw new ChannelAdapterCompatibilityError(
       "channel_not_supported",
       "Required channel is not supported",
     )
   }
   for (const capability of requirements.capabilities) {
-    if (!descriptor.capabilities[capability]) {
+    if (!channel[capability]) {
       throw new ChannelAdapterCompatibilityError(
         "missing_capability",
         `Required capability is missing: ${capability}`,
@@ -337,10 +532,32 @@ export function canonicalAdapterPayload(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(canonicalAdapterPayload).join(",")}]`
   if (value instanceof Uint8Array) return JSON.stringify(Array.from(value))
   if (value && typeof value === "object") {
+    const prototype = Object.getPrototypeOf(value)
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error("Canonical adapter payload requires plain JSON objects")
+    }
     return `{${Object.entries(value as Record<string, unknown>)
       .sort(([left], [right]) => left.localeCompare(right))
       .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalAdapterPayload(entry)}`)
       .join(",")}}`
   }
-  return JSON.stringify(value)
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    throw new Error("Canonical adapter payload requires finite JSON numbers")
+  }
+  if (
+    value === undefined ||
+    typeof value === "function" ||
+    typeof value === "symbol" ||
+    typeof value === "bigint"
+  ) {
+    throw new Error("Canonical adapter payload must be JSON-compatible")
+  }
+  const serialized = JSON.stringify(value)
+  if (serialized === undefined) throw new Error("Canonical adapter payload must be JSON-compatible")
+  return serialized
+}
+
+/** Canonicalize the schema-normalized value, never caller-owned pre-parse JSON. */
+export function canonicalSchemaPayload<T>(schema: z.ZodType<T>, value: unknown): string {
+  return canonicalAdapterPayload(schema.parse(value))
 }

--- a/packages/channel-adapter-contracts/src/contracts.ts
+++ b/packages/channel-adapter-contracts/src/contracts.ts
@@ -1,0 +1,346 @@
+import { z } from "zod"
+
+export const CHANNEL_ADAPTER_PROTOCOL_VERSION = "channel-adapter.v1" as const
+export const channelAdapterProtocolVersionSchema = z.literal(CHANNEL_ADAPTER_PROTOCOL_VERSION)
+
+/**
+ * Channel identifiers are deliberately open strings. A host negotiates support
+ * from capabilities instead of assuming that today's built-in channels are the
+ * complete set.
+ */
+export const channelKindSchema = z.string().trim().min(1).max(64)
+
+export const channelAdapterCapabilitiesSchema = z
+  .object({
+    channels: z.array(channelKindSchema).min(1),
+    outbound: z.boolean(),
+    inbound: z.boolean(),
+    lifecycleEvents: z.boolean(),
+    policyEvaluation: z.boolean(),
+    privateAttachments: z.boolean(),
+    accountValidation: z.boolean(),
+    health: z.boolean(),
+  })
+  .strict()
+
+export type ChannelAdapterCapabilities = z.infer<typeof channelAdapterCapabilitiesSchema>
+
+export const channelAdapterDescriptorSchema = z
+  .object({
+    protocolVersion: channelAdapterProtocolVersionSchema,
+    adapterId: z.string().trim().min(1).max(128),
+    capabilities: channelAdapterCapabilitiesSchema,
+  })
+  .strict()
+
+export type ChannelAdapterDescriptor = z.infer<typeof channelAdapterDescriptorSchema>
+
+export const adapterAccountRefSchema = z.string().trim().min(1).max(512)
+
+export const accountValidationInputSchema = z
+  .object({
+    adapterAccountRef: adapterAccountRefSchema,
+    requiredChannels: z.array(channelKindSchema).min(1),
+    requiredCapabilities: z
+      .array(
+        z.enum([
+          "outbound",
+          "inbound",
+          "lifecycleEvents",
+          "policyEvaluation",
+          "privateAttachments",
+          "health",
+        ]),
+      )
+      .default([]),
+  })
+  .strict()
+
+export type AccountValidationInput = z.infer<typeof accountValidationInputSchema>
+
+export const accountValidationResultSchema = z.discriminatedUnion("valid", [
+  z.object({ valid: z.literal(true), normalizedAccountRef: adapterAccountRefSchema }).strict(),
+  z
+    .object({
+      valid: z.literal(false),
+      code: z.enum(["not_found", "disabled", "missing_capability", "invalid_account"]),
+    })
+    .strict(),
+])
+
+export type AccountValidationResult = z.infer<typeof accountValidationResultSchema>
+
+export const adapterHealthSchema = z
+  .object({
+    status: z.enum(["healthy", "degraded", "unavailable"]),
+    checkedAt: z.string().datetime({ offset: true }),
+    reasonCode: z.string().trim().min(1).max(128).nullable(),
+  })
+  .strict()
+
+export type AdapterHealth = z.infer<typeof adapterHealthSchema>
+
+export const privateAttachmentHandleSchema = z
+  .object({
+    handle: z.string().trim().min(1).max(1024),
+    filename: z.string().trim().min(1).max(512),
+    contentType: z.string().trim().min(1).max(255),
+    size: z.number().int().nonnegative(),
+  })
+  .strict()
+
+export type PrivateAttachmentHandle = z.infer<typeof privateAttachmentHandleSchema>
+
+export const outboundMessageSchema = z
+  .object({
+    operationId: z.string().trim().min(1).max(256),
+    adapterAccountRef: adapterAccountRefSchema,
+    channel: channelKindSchema,
+    recipient: z.string().trim().min(1).max(2048),
+    subject: z.string().max(998).nullable(),
+    text: z.string().max(1_000_000).nullable(),
+    sanitizedHtml: z.string().max(2_000_000).nullable(),
+    attachments: z.array(privateAttachmentHandleSchema).max(100),
+    threadRef: z.string().trim().min(1).max(1024).nullable(),
+    metadata: z.record(z.string(), z.string().max(2048)).default({}),
+  })
+  .strict()
+  .refine((value) => value.text !== null || value.sanitizedHtml !== null, {
+    message: "A message must have text or sanitizedHtml content",
+  })
+
+export type OutboundMessage = z.infer<typeof outboundMessageSchema>
+
+export const outboundAcceptanceSchema = z
+  .object({
+    state: z.literal("accepted"),
+    externalSubmissionId: z.string().trim().min(1).max(1024),
+    acceptedAt: z.string().datetime({ offset: true }),
+  })
+  .strict()
+
+export type OutboundAcceptance = z.infer<typeof outboundAcceptanceSchema>
+
+export const inboundItemRefSchema = z.object({ id: z.string().trim().min(1).max(1024) }).strict()
+export type InboundItemRef = z.infer<typeof inboundItemRefSchema>
+
+export const inboundListPageSchema = z
+  .object({
+    items: z.array(inboundItemRefSchema),
+    cursor: z.string().min(1).max(4096).nullable(),
+  })
+  .strict()
+export type InboundListPage = z.infer<typeof inboundListPageSchema>
+
+export const normalizedAddressSchema = z
+  .object({
+    address: z.string().trim().min(1).max(2048),
+    displayName: z.string().max(512).nullable(),
+  })
+  .strict()
+
+export const inboundEnvelopeSchema = z
+  .object({
+    protocolVersion: channelAdapterProtocolVersionSchema,
+    adapterAccountRef: adapterAccountRefSchema,
+    channel: channelKindSchema,
+    externalEnvelopeId: z.string().trim().min(1).max(1024),
+    externalMessageId: z.string().trim().min(1).max(1024),
+    occurredAt: z.string().datetime({ offset: true }),
+    sender: normalizedAddressSchema,
+    recipients: z.array(normalizedAddressSchema).min(1),
+    subject: z.string().max(998).nullable(),
+    text: z.string().max(1_000_000).nullable(),
+    untrustedHtml: z.string().max(2_000_000).nullable(),
+    attachments: z.array(privateAttachmentHandleSchema).max(100),
+    threadRef: z.string().trim().min(1).max(1024).nullable(),
+    replyToExternalMessageId: z.string().trim().min(1).max(1024).nullable(),
+    classification: z.enum(["message", "automatic_reply", "delivery_status", "complaint"]),
+  })
+  .strict()
+
+export type InboundEnvelope = z.infer<typeof inboundEnvelopeSchema>
+
+export const inboundAuthenticityRequestSchema = z
+  .object({
+    adapterAccountRef: adapterAccountRefSchema,
+    headers: z.record(z.string(), z.string()),
+    body: z.instanceof(Uint8Array),
+  })
+  .strict()
+
+export type InboundAuthenticityRequest = z.infer<typeof inboundAuthenticityRequestSchema>
+
+export const inboundAuthenticityResultSchema = z.discriminatedUnion("authentic", [
+  z.object({ authentic: z.literal(true) }).strict(),
+  z
+    .object({
+      authentic: z.literal(false),
+      code: z.enum(["invalid_authenticity_proof", "stale_request", "unknown_account"]),
+    })
+    .strict(),
+])
+
+export type InboundAuthenticityResult = z.infer<typeof inboundAuthenticityResultSchema>
+
+export const deliveryLifecycleEventSchema = z
+  .object({
+    adapterAccountRef: adapterAccountRefSchema,
+    externalEventId: z.string().trim().min(1).max(1024),
+    externalSubmissionId: z.string().trim().min(1).max(1024),
+    occurredAt: z.string().datetime({ offset: true }),
+    state: z.enum(["accepted", "delivered", "failed", "bounced", "complained", "suppressed"]),
+    reasonCode: z.string().trim().min(1).max(128).nullable(),
+  })
+  .strict()
+
+export type DeliveryLifecycleEvent = z.infer<typeof deliveryLifecycleEventSchema>
+
+export const policyEvaluationInputSchema = z
+  .object({
+    adapterAccountRef: adapterAccountRefSchema,
+    channel: channelKindSchema,
+    recipient: z.string().trim().min(1).max(2048),
+    purpose: z.enum(["transactional", "conversation", "marketing"]),
+  })
+  .strict()
+
+export const policyEvaluationResultSchema = z.discriminatedUnion("allowed", [
+  z.object({ allowed: z.literal(true) }).strict(),
+  z
+    .object({
+      allowed: z.literal(false),
+      code: z.enum([
+        "recipient_suppressed",
+        "consent_required",
+        "account_policy",
+        "channel_policy",
+      ]),
+    })
+    .strict(),
+])
+
+export type PolicyEvaluationInput = z.infer<typeof policyEvaluationInputSchema>
+export type PolicyEvaluationResult = z.infer<typeof policyEvaluationResultSchema>
+
+export const lifecycleNormalizationInputSchema = z
+  .object({
+    adapterAccountRef: adapterAccountRefSchema,
+    headers: z.record(z.string(), z.string()),
+    body: z.instanceof(Uint8Array),
+  })
+  .strict()
+
+export type LifecycleNormalizationInput = z.infer<typeof lifecycleNormalizationInputSchema>
+
+export interface ChannelAdapterV1 {
+  readonly descriptor: ChannelAdapterDescriptor
+  validateAccount?(input: AccountValidationInput): Promise<AccountValidationResult>
+  getHealth?(input: { adapterAccountRef: string }): Promise<AdapterHealth>
+  submitOutbound?(message: OutboundMessage): Promise<OutboundAcceptance>
+  listInbound?(input: {
+    adapterAccountRef: string
+    cursor?: string
+    limit: number
+  }): Promise<InboundListPage>
+  fetchInbound?(ref: InboundItemRef): Promise<InboundEnvelope>
+  ackInbound?(ref: InboundItemRef): Promise<void>
+  verifyInboundAuthenticity?(
+    request: InboundAuthenticityRequest,
+  ): Promise<InboundAuthenticityResult>
+  verifyLifecycleAuthenticity?(
+    request: LifecycleNormalizationInput,
+  ): Promise<InboundAuthenticityResult>
+  normalizeLifecycleEvents?(
+    input: LifecycleNormalizationInput,
+  ): Promise<readonly DeliveryLifecycleEvent[]>
+  evaluatePolicy?(input: PolicyEvaluationInput): Promise<PolicyEvaluationResult>
+  readPrivateAttachment?(handle: string): Promise<AsyncIterable<Uint8Array>>
+}
+
+export class ChannelAdapterCompatibilityError extends Error {
+  constructor(
+    readonly code: "unsupported_protocol" | "missing_capability" | "channel_not_supported",
+    message: string,
+  ) {
+    super(message)
+    this.name = "ChannelAdapterCompatibilityError"
+  }
+}
+
+const capabilityMethods = {
+  outbound: ["submitOutbound"],
+  inbound: ["listInbound", "fetchInbound", "ackInbound", "verifyInboundAuthenticity"],
+  lifecycleEvents: ["verifyLifecycleAuthenticity", "normalizeLifecycleEvents"],
+  policyEvaluation: ["evaluatePolicy"],
+  privateAttachments: ["readPrivateAttachment"],
+  accountValidation: ["validateAccount"],
+  health: ["getHealth"],
+} as const
+
+export function validateChannelAdapter(adapter: ChannelAdapterV1): ChannelAdapterDescriptor {
+  if (adapter.descriptor.protocolVersion !== CHANNEL_ADAPTER_PROTOCOL_VERSION) {
+    throw new ChannelAdapterCompatibilityError(
+      "unsupported_protocol",
+      "Adapter protocol is not supported",
+    )
+  }
+  const descriptor = channelAdapterDescriptorSchema.parse(adapter.descriptor)
+  for (const [capability, methods] of Object.entries(capabilityMethods)) {
+    const enabled = descriptor.capabilities[capability as keyof typeof capabilityMethods]
+    for (const method of methods) {
+      const implemented = typeof adapter[method as keyof ChannelAdapterV1] === "function"
+      if (enabled !== implemented) {
+        throw new ChannelAdapterCompatibilityError(
+          "missing_capability",
+          `${capability} capability must exactly match its method surface`,
+        )
+      }
+    }
+  }
+  return descriptor
+}
+
+export function negotiateChannelAdapter(
+  adapter: ChannelAdapterV1,
+  requirements: {
+    protocolVersion: typeof CHANNEL_ADAPTER_PROTOCOL_VERSION
+    channel: string
+    capabilities: readonly (keyof Omit<ChannelAdapterCapabilities, "channels">)[]
+  },
+): ChannelAdapterDescriptor {
+  const descriptor = validateChannelAdapter(adapter)
+  if (descriptor.protocolVersion !== requirements.protocolVersion) {
+    throw new ChannelAdapterCompatibilityError(
+      "unsupported_protocol",
+      "Adapter protocol is not supported",
+    )
+  }
+  if (!descriptor.capabilities.channels.includes(requirements.channel)) {
+    throw new ChannelAdapterCompatibilityError(
+      "channel_not_supported",
+      "Required channel is not supported",
+    )
+  }
+  for (const capability of requirements.capabilities) {
+    if (!descriptor.capabilities[capability]) {
+      throw new ChannelAdapterCompatibilityError(
+        "missing_capability",
+        `Required capability is missing: ${capability}`,
+      )
+    }
+  }
+  return descriptor
+}
+
+export function canonicalAdapterPayload(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalAdapterPayload).join(",")}]`
+  if (value instanceof Uint8Array) return JSON.stringify(Array.from(value))
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalAdapterPayload(entry)}`)
+      .join(",")}}`
+  }
+  return JSON.stringify(value)
+}

--- a/packages/channel-adapter-contracts/src/index.ts
+++ b/packages/channel-adapter-contracts/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./v1.js"

--- a/packages/channel-adapter-contracts/src/testing.ts
+++ b/packages/channel-adapter-contracts/src/testing.ts
@@ -1,0 +1,209 @@
+import type { ChannelAdapterConformanceControl } from "./conformance.js"
+import {
+  type AdapterHealth,
+  CHANNEL_ADAPTER_PROTOCOL_VERSION,
+  type ChannelAdapterCapabilities,
+  type ChannelAdapterDescriptor,
+  type ChannelAdapterV1,
+  canonicalAdapterPayload,
+  type DeliveryLifecycleEvent,
+  deliveryLifecycleEventSchema,
+  type InboundEnvelope,
+  type InboundItemRef,
+  inboundEnvelopeSchema,
+  type OutboundAcceptance,
+  type OutboundMessage,
+} from "./contracts.js"
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+
+const completeCapabilities: ChannelAdapterCapabilities = {
+  channels: ["fixture"],
+  outbound: true,
+  inbound: true,
+  lifecycleEvents: true,
+  policyEvaluation: true,
+  privateAttachments: true,
+  accountValidation: true,
+  health: true,
+}
+
+/** A deterministic, non-networked adapter for contract and host integration tests. */
+export class FixtureChannelAdapter implements ChannelAdapterV1 {
+  readonly descriptor: ChannelAdapterDescriptor
+  readonly #accountRef: string
+  readonly #inbound = new Map<string, InboundEnvelope>()
+  readonly #submissions = new Map<string, { fingerprint: string; acceptance: OutboundAcceptance }>()
+  readonly #attachments = new Map<string, Uint8Array>()
+  #authentic = true
+  #health: AdapterHealth["status"] = "healthy"
+  #recipientSuppressed = false
+
+  constructor(input?: { adapterId?: string; accountRef?: string }) {
+    this.#accountRef = input?.accountRef ?? "fixture-account"
+    this.descriptor = {
+      protocolVersion: CHANNEL_ADAPTER_PROTOCOL_VERSION,
+      adapterId: input?.adapterId ?? "fixture-channel-adapter",
+      capabilities: { ...completeCapabilities, channels: [...completeCapabilities.channels] },
+    }
+  }
+
+  async validateAccount(input: {
+    adapterAccountRef: string
+    requiredChannels: string[]
+    requiredCapabilities: (
+      | "outbound"
+      | "inbound"
+      | "lifecycleEvents"
+      | "policyEvaluation"
+      | "privateAttachments"
+      | "health"
+    )[]
+  }) {
+    if (input.adapterAccountRef !== this.#accountRef) {
+      return { valid: false as const, code: "not_found" as const }
+    }
+    if (
+      input.requiredChannels.some(
+        (channel) => !this.descriptor.capabilities.channels.includes(channel),
+      )
+    ) {
+      return {
+        valid: false as const,
+        code: "missing_capability" as const,
+      }
+    }
+    if (
+      input.requiredCapabilities.some((capability) => !this.descriptor.capabilities[capability])
+    ) {
+      return {
+        valid: false as const,
+        code: "missing_capability" as const,
+      }
+    }
+    return { valid: true as const, normalizedAccountRef: this.#accountRef }
+  }
+
+  async getHealth(): Promise<AdapterHealth> {
+    return {
+      status: this.#health,
+      checkedAt: "2026-01-01T00:00:00.000Z",
+      reasonCode: this.#health === "healthy" ? null : `fixture_${this.#health}`,
+    }
+  }
+
+  async submitOutbound(message: OutboundMessage): Promise<OutboundAcceptance> {
+    const fingerprint = canonicalAdapterPayload(message)
+    const existing = this.#submissions.get(message.operationId)
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) throw new Error("Outbound operation payload drift")
+      return existing.acceptance
+    }
+    const acceptance = {
+      state: "accepted" as const,
+      externalSubmissionId: `fixture-submission-${this.#submissions.size + 1}`,
+      acceptedAt: "2026-01-01T00:00:00.000Z",
+    }
+    this.#submissions.set(message.operationId, { fingerprint, acceptance })
+    return acceptance
+  }
+
+  async listInbound(input: { adapterAccountRef: string; cursor?: string; limit: number }) {
+    if (input.adapterAccountRef !== this.#accountRef) return { items: [], cursor: null }
+    const items = [...this.#inbound.keys()]
+      .sort()
+      .filter((id) => !input.cursor || id > input.cursor)
+      .slice(0, input.limit)
+      .map((id) => ({ id }))
+    return { items, cursor: items.at(-1)?.id ?? null }
+  }
+
+  async fetchInbound(ref: InboundItemRef): Promise<InboundEnvelope> {
+    const envelope = this.#inbound.get(ref.id)
+    if (!envelope) throw new Error("Inbound item not found")
+    return structuredClone(envelope)
+  }
+
+  async ackInbound(ref: InboundItemRef): Promise<void> {
+    this.#inbound.delete(ref.id)
+  }
+
+  async verifyInboundAuthenticity() {
+    return this.#authentic
+      ? ({ authentic: true } as const)
+      : ({ authentic: false, code: "invalid_authenticity_proof" } as const)
+  }
+
+  async verifyLifecycleAuthenticity() {
+    return this.#authentic
+      ? ({ authentic: true } as const)
+      : ({ authentic: false, code: "invalid_authenticity_proof" } as const)
+  }
+
+  async normalizeLifecycleEvents(input: { body: Uint8Array }): Promise<DeliveryLifecycleEvent[]> {
+    return deliveryLifecycleEventSchema.array().parse(JSON.parse(textDecoder.decode(input.body)))
+  }
+
+  async evaluatePolicy() {
+    return this.#recipientSuppressed
+      ? ({ allowed: false, code: "recipient_suppressed" } as const)
+      : ({ allowed: true } as const)
+  }
+
+  async readPrivateAttachment(handle: string): Promise<AsyncIterable<Uint8Array>> {
+    const bytes = this.#attachments.get(handle)
+    if (!bytes) throw new Error("Private attachment not found")
+    const copy = new Uint8Array(bytes)
+    return (async function* stream() {
+      yield copy
+    })()
+  }
+
+  enqueueInbound(envelope: InboundEnvelope): void {
+    const parsed = inboundEnvelopeSchema.parse(envelope)
+    if (this.#inbound.has(parsed.externalEnvelopeId)) throw new Error("Inbound item already exists")
+    this.#inbound.set(parsed.externalEnvelopeId, parsed)
+  }
+
+  replaceInbound(envelope: InboundEnvelope): void {
+    const parsed = inboundEnvelopeSchema.parse(envelope)
+    this.#inbound.set(parsed.externalEnvelopeId, parsed)
+  }
+
+  setInboundAuthenticity(authentic: boolean): void {
+    this.#authentic = authentic
+  }
+
+  setHealth(status: AdapterHealth["status"]): void {
+    this.#health = status
+  }
+
+  setRecipientSuppressed(suppressed: boolean): void {
+    this.#recipientSuppressed = suppressed
+  }
+
+  putPrivateAttachment(handle: string, bytes: Uint8Array): void {
+    this.#attachments.set(handle, new Uint8Array(bytes))
+  }
+}
+
+export function createFixtureChannelAdapterControl(): ChannelAdapterConformanceControl {
+  const adapter = new FixtureChannelAdapter()
+  return {
+    adapter,
+    accountRef: "fixture-account",
+    channel: "fixture",
+    enqueueInbound: (envelope) => adapter.enqueueInbound(envelope),
+    replaceInbound: (envelope) => adapter.replaceInbound(envelope),
+    setInboundAuthenticity: (authentic) => adapter.setInboundAuthenticity(authentic),
+    setHealth: (status) => adapter.setHealth(status),
+    setRecipientSuppressed: (suppressed) => adapter.setRecipientSuppressed(suppressed),
+    putPrivateAttachment: (handle, bytes) => adapter.putPrivateAttachment(handle, bytes),
+    lifecycleRequest: (events) => ({
+      adapterAccountRef: "fixture-account",
+      headers: {},
+      body: textEncoder.encode(JSON.stringify(events)),
+    }),
+  }
+}

--- a/packages/channel-adapter-contracts/src/testing.ts
+++ b/packages/channel-adapter-contracts/src/testing.ts
@@ -18,8 +18,8 @@ import {
 const textEncoder = new TextEncoder()
 const textDecoder = new TextDecoder()
 
-const completeCapabilities: ChannelAdapterCapabilities = {
-  channels: ["fixture"],
+const completeCapabilities: ChannelAdapterCapabilities[number] = {
+  channel: "email",
   outbound: true,
   inbound: true,
   lifecycleEvents: true,
@@ -27,26 +27,57 @@ const completeCapabilities: ChannelAdapterCapabilities = {
   privateAttachments: true,
   accountValidation: true,
   health: true,
+  multimedia: true,
 }
 
 /** A deterministic, non-networked adapter for contract and host integration tests. */
 export class FixtureChannelAdapter implements ChannelAdapterV1 {
   readonly descriptor: ChannelAdapterDescriptor
   readonly #accountRef: string
+  readonly #sourceRef: string
   readonly #inbound = new Map<string, InboundEnvelope>()
   readonly #submissions = new Map<string, { fingerprint: string; acceptance: OutboundAcceptance }>()
   readonly #attachments = new Map<string, Uint8Array>()
+  readonly #provisions = new Map<
+    string,
+    { fingerprint: string; result: import("./contracts.js").AccountProvisioningResult }
+  >()
+  readonly #lifecycle = new Map<string, DeliveryLifecycleEvent>()
   #authentic = true
   #health: AdapterHealth["status"] = "healthy"
   #recipientSuppressed = false
 
-  constructor(input?: { adapterId?: string; accountRef?: string }) {
-    this.#accountRef = input?.accountRef ?? "fixture-account"
+  constructor(input?: {
+    adapterId?: string
+    accountRef?: string
+    sourceRef?: string
+    channel?: "email" | "sms"
+  }) {
+    const channel = input?.channel ?? "email"
+    this.#accountRef = input?.accountRef ?? `${channel}-fixture-account`
+    this.#sourceRef = input?.sourceRef ?? `${channel}-fixture-source`
     this.descriptor = {
       protocolVersion: CHANNEL_ADAPTER_PROTOCOL_VERSION,
       adapterId: input?.adapterId ?? "fixture-channel-adapter",
-      capabilities: { ...completeCapabilities, channels: [...completeCapabilities.channels] },
+      channels: [{ ...completeCapabilities, channel }],
     }
+  }
+
+  async provisionAccount(input: import("./contracts.js").AccountProvisioningInput) {
+    const fingerprint = canonicalAdapterPayload(input)
+    const existing = this.#provisions.get(input.operationId)
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) throw new Error("Account provision payload drift")
+      return existing.result
+    }
+    const result = {
+      adapterAccountRef: this.#accountRef,
+      normalizedAddress: input.address,
+      displayAddress: input.address,
+      inboundSourceRef: input.inbound ? this.#sourceRef : null,
+    }
+    this.#provisions.set(input.operationId, { fingerprint, result })
+    return result
   }
 
   async validateAccount(input: {
@@ -66,7 +97,7 @@ export class FixtureChannelAdapter implements ChannelAdapterV1 {
     }
     if (
       input.requiredChannels.some(
-        (channel) => !this.descriptor.capabilities.channels.includes(channel),
+        (channel) => !this.descriptor.channels.some((entry) => entry.channel === channel),
       )
     ) {
       return {
@@ -75,7 +106,9 @@ export class FixtureChannelAdapter implements ChannelAdapterV1 {
       }
     }
     if (
-      input.requiredCapabilities.some((capability) => !this.descriptor.capabilities[capability])
+      input.requiredCapabilities.some(
+        (capability) => !this.descriptor.channels.some((entry) => entry[capability]),
+      )
     ) {
       return {
         valid: false as const,
@@ -109,13 +142,18 @@ export class FixtureChannelAdapter implements ChannelAdapterV1 {
     return acceptance
   }
 
-  async listInbound(input: { adapterAccountRef: string; cursor?: string; limit: number }) {
+  async listInbound(input: {
+    adapterAccountRef: string
+    sourceRef: string
+    cursor?: string
+    limit: number
+  }) {
     if (input.adapterAccountRef !== this.#accountRef) return { items: [], cursor: null }
     const items = [...this.#inbound.keys()]
       .sort()
       .filter((id) => !input.cursor || id > input.cursor)
       .slice(0, input.limit)
-      .map((id) => ({ id }))
+      .map((id) => ({ adapterAccountRef: this.#accountRef, sourceRef: this.#sourceRef, id }))
     return { items, cursor: items.at(-1)?.id ?? null }
   }
 
@@ -135,14 +173,48 @@ export class FixtureChannelAdapter implements ChannelAdapterV1 {
       : ({ authentic: false, code: "invalid_authenticity_proof" } as const)
   }
 
+  async queueVerifiedInbound() {
+    if (!this.#authentic)
+      return { accepted: false as const, code: "invalid_authenticity_proof" as const }
+    return { accepted: false as const, code: "invalid_payload" as const }
+  }
+
   async verifyLifecycleAuthenticity() {
     return this.#authentic
       ? ({ authentic: true } as const)
       : ({ authentic: false, code: "invalid_authenticity_proof" } as const)
   }
 
+  async queueVerifiedLifecycle() {
+    return { accepted: this.#authentic }
+  }
+
   async normalizeLifecycleEvents(input: { body: Uint8Array }): Promise<DeliveryLifecycleEvent[]> {
     return deliveryLifecycleEventSchema.array().parse(JSON.parse(textDecoder.decode(input.body)))
+  }
+
+  async listLifecycle(input: {
+    adapterAccountRef: string
+    sourceRef: string
+    cursor?: string
+    limit: number
+  }) {
+    const items = [...this.#lifecycle.keys()]
+      .sort()
+      .filter((id) => !input.cursor || id > input.cursor)
+      .slice(0, input.limit)
+      .map((id) => ({ adapterAccountRef: input.adapterAccountRef, sourceRef: input.sourceRef, id }))
+    return { items, cursor: items.at(-1)?.id ?? null }
+  }
+
+  async fetchLifecycle(ref: import("./contracts.js").LifecycleItemRef) {
+    const event = this.#lifecycle.get(ref.id)
+    if (!event) throw new Error("Lifecycle item not found")
+    return structuredClone(event)
+  }
+
+  async ackLifecycle(ref: import("./contracts.js").LifecycleItemRef) {
+    this.#lifecycle.delete(ref.id)
   }
 
   async evaluatePolicy() {
@@ -151,8 +223,12 @@ export class FixtureChannelAdapter implements ChannelAdapterV1 {
       : ({ allowed: true } as const)
   }
 
-  async readPrivateAttachment(handle: string): Promise<AsyncIterable<Uint8Array>> {
-    const bytes = this.#attachments.get(handle)
+  async readPrivateAttachment(input: {
+    adapterAccountRef: string
+    sourceRef: string
+    handle: string
+  }): Promise<AsyncIterable<Uint8Array>> {
+    const bytes = this.#attachments.get(input.handle)
     if (!bytes) throw new Error("Private attachment not found")
     const copy = new Uint8Array(bytes)
     return (async function* stream() {
@@ -186,22 +262,32 @@ export class FixtureChannelAdapter implements ChannelAdapterV1 {
   putPrivateAttachment(handle: string, bytes: Uint8Array): void {
     this.#attachments.set(handle, new Uint8Array(bytes))
   }
+
+  enqueueLifecycle(event: DeliveryLifecycleEvent): void {
+    this.#lifecycle.set(event.externalEventId, deliveryLifecycleEventSchema.parse(event))
+  }
 }
 
-export function createFixtureChannelAdapterControl(): ChannelAdapterConformanceControl {
-  const adapter = new FixtureChannelAdapter()
+export function createFixtureChannelAdapterControl(
+  channel: "email" | "sms" = "email",
+): ChannelAdapterConformanceControl {
+  const accountRef = `${channel}-fixture-account`
+  const sourceRef = `${channel}-fixture-source`
+  const adapter = new FixtureChannelAdapter({ channel, accountRef, sourceRef })
   return {
     adapter,
-    accountRef: "fixture-account",
-    channel: "fixture",
+    accountRef,
+    sourceRef,
+    channel,
     enqueueInbound: (envelope) => adapter.enqueueInbound(envelope),
     replaceInbound: (envelope) => adapter.replaceInbound(envelope),
     setInboundAuthenticity: (authentic) => adapter.setInboundAuthenticity(authentic),
     setHealth: (status) => adapter.setHealth(status),
     setRecipientSuppressed: (suppressed) => adapter.setRecipientSuppressed(suppressed),
     putPrivateAttachment: (handle, bytes) => adapter.putPrivateAttachment(handle, bytes),
+    enqueueLifecycle: (event) => adapter.enqueueLifecycle(event),
     lifecycleRequest: (events) => ({
-      adapterAccountRef: "fixture-account",
+      adapterAccountRef: accountRef,
       headers: {},
       body: textEncoder.encode(JSON.stringify(events)),
     }),

--- a/packages/channel-adapter-contracts/src/v1.ts
+++ b/packages/channel-adapter-contracts/src/v1.ts
@@ -1,0 +1,1 @@
+export * from "./contracts.js"

--- a/packages/channel-adapter-contracts/tests/contracts.test.ts
+++ b/packages/channel-adapter-contracts/tests/contracts.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest"
+import {
+  AdapterPayloadDriftError,
+  AdapterReplayLedger,
+  runChannelAdapterConformance,
+} from "../src/conformance.js"
+import {
+  CHANNEL_ADAPTER_PROTOCOL_VERSION,
+  ChannelAdapterCompatibilityError,
+  channelAdapterDescriptorSchema,
+  negotiateChannelAdapter,
+  outboundAcceptanceSchema,
+  validateChannelAdapter,
+} from "../src/index.js"
+import { createFixtureChannelAdapterControl, FixtureChannelAdapter } from "../src/testing.js"
+
+describe("custom channel adapter contract", () => {
+  it("runs the reusable conformance suite against the deterministic fixture", async () => {
+    const result = await runChannelAdapterConformance(createFixtureChannelAdapterControl)
+    expect(result.passed).toEqual([
+      "capability truthfulness and negotiation",
+      "invalid authenticity proof rejection",
+      "invalid lifecycle authenticity proof rejection",
+      "outbound idempotency and payload drift",
+      "fetch and acknowledgement crash safety, replay and payload drift",
+      "delivery normalization, duplicate replay and payload drift",
+      "policy suppression",
+      "private attachment streaming",
+      "health transitions",
+      "credential and configuration non-exposure",
+    ])
+  })
+
+  it("fails setup negotiation on unsupported channels and capabilities", () => {
+    const adapter = new FixtureChannelAdapter()
+    expect(() =>
+      negotiateChannelAdapter(adapter, {
+        protocolVersion: CHANNEL_ADAPTER_PROTOCOL_VERSION,
+        channel: "not-supported",
+        capabilities: ["outbound"],
+      }),
+    ).toThrowError(ChannelAdapterCompatibilityError)
+  })
+
+  it("rejects capabilities that do not truthfully match the method surface", () => {
+    const adapter = new FixtureChannelAdapter()
+    const lyingAdapter = {
+      descriptor: {
+        ...adapter.descriptor,
+        capabilities: { ...adapter.descriptor.capabilities, outbound: false },
+      },
+      validateAccount: adapter.validateAccount.bind(adapter),
+      getHealth: adapter.getHealth.bind(adapter),
+      submitOutbound: adapter.submitOutbound.bind(adapter),
+      listInbound: adapter.listInbound.bind(adapter),
+      fetchInbound: adapter.fetchInbound.bind(adapter),
+      ackInbound: adapter.ackInbound.bind(adapter),
+      verifyInboundAuthenticity: adapter.verifyInboundAuthenticity.bind(adapter),
+      verifyLifecycleAuthenticity: adapter.verifyLifecycleAuthenticity.bind(adapter),
+      normalizeLifecycleEvents: adapter.normalizeLifecycleEvents.bind(adapter),
+      evaluatePolicy: adapter.evaluatePolicy.bind(adapter),
+      readPrivateAttachment: adapter.readPrivateAttachment.bind(adapter),
+    }
+    expect(() => validateChannelAdapter(lyingAdapter)).toThrowError(/must exactly match/)
+  })
+
+  it("accepts identical replays and fails closed on payload drift", () => {
+    const ledger = new AdapterReplayLedger()
+    expect(ledger.observe("inbound", "item-1", { value: 1 })).toBe("new")
+    expect(ledger.observe("inbound", "item-1", { value: 1 })).toBe("duplicate")
+    expect(() => ledger.observe("inbound", "item-1", { value: 2 })).toThrowError(
+      AdapterPayloadDriftError,
+    )
+  })
+
+  it("keeps credentials and adapter configuration outside public DTOs", () => {
+    expect(() =>
+      channelAdapterDescriptorSchema.parse({
+        protocolVersion: CHANNEL_ADAPTER_PROTOCOL_VERSION,
+        adapterId: "custom",
+        capabilities: {
+          channels: ["custom-channel"],
+          outbound: true,
+          inbound: false,
+          lifecycleEvents: false,
+          policyEvaluation: false,
+          privateAttachments: false,
+          accountValidation: false,
+          health: false,
+        },
+        credentials: { token: "must-not-cross-the-boundary" },
+      }),
+    ).toThrow()
+    expect(() =>
+      outboundAcceptanceSchema.parse({
+        state: "accepted",
+        externalSubmissionId: "submission-1",
+        acceptedAt: "2026-01-01T00:00:00.000Z",
+        configuration: { endpoint: "private" },
+      }),
+    ).toThrow()
+  })
+
+  it("keeps an item available across fetch until acknowledgement", async () => {
+    const control = createFixtureChannelAdapterControl()
+    const envelope = {
+      protocolVersion: CHANNEL_ADAPTER_PROTOCOL_VERSION,
+      adapterAccountRef: control.accountRef,
+      channel: control.channel,
+      externalEnvelopeId: "crash-safe-1",
+      externalMessageId: "message-1",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      sender: { address: "customer@example.test", displayName: null },
+      recipients: [{ address: "inbox@example.test", displayName: null }],
+      subject: null,
+      text: "Question",
+      untrustedHtml: null,
+      attachments: [],
+      threadRef: null,
+      replyToExternalMessageId: null,
+      classification: "message" as const,
+    }
+    control.enqueueInbound(envelope)
+    const first = await control.adapter.listInbound?.({
+      adapterAccountRef: control.accountRef,
+      limit: 10,
+    })
+    await control.adapter.fetchInbound?.(first!.items[0]!)
+    expect(
+      await control.adapter.listInbound?.({ adapterAccountRef: control.accountRef, limit: 10 }),
+    ).toMatchObject({ items: [{ id: "crash-safe-1" }] })
+    await control.adapter.ackInbound?.(first!.items[0]!)
+    expect(
+      await control.adapter.listInbound?.({ adapterAccountRef: control.accountRef, limit: 10 }),
+    ).toMatchObject({ items: [] })
+  })
+})

--- a/packages/channel-adapter-contracts/tests/contracts.test.ts
+++ b/packages/channel-adapter-contracts/tests/contracts.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { z } from "zod"
 import {
   AdapterPayloadDriftError,
   AdapterReplayLedger,
@@ -7,16 +8,25 @@ import {
 import {
   CHANNEL_ADAPTER_PROTOCOL_VERSION,
   ChannelAdapterCompatibilityError,
+  canonicalAdapterPayload,
+  canonicalSchemaPayload,
   channelAdapterDescriptorSchema,
   negotiateChannelAdapter,
   outboundAcceptanceSchema,
+  outboundMessageSchema,
+  smsSegmentCount,
   validateChannelAdapter,
 } from "../src/index.js"
 import { createFixtureChannelAdapterControl, FixtureChannelAdapter } from "../src/testing.js"
 
 describe("custom channel adapter contract", () => {
-  it("runs the reusable conformance suite against the deterministic fixture", async () => {
-    const result = await runChannelAdapterConformance(createFixtureChannelAdapterControl)
+  it.each([
+    "email",
+    "sms",
+  ] as const)("runs a complete %s Inbox flow through its channel-scoped account and source", async (channel) => {
+    const result = await runChannelAdapterConformance(() =>
+      createFixtureChannelAdapterControl(channel),
+    )
     expect(result.passed).toEqual([
       "capability truthfulness and negotiation",
       "invalid authenticity proof rejection",
@@ -24,6 +34,7 @@ describe("custom channel adapter contract", () => {
       "outbound idempotency and payload drift",
       "fetch and acknowledgement crash safety, replay and payload drift",
       "delivery normalization, duplicate replay and payload drift",
+      "lifecycle fetch and acknowledgement crash safety",
       "policy suppression",
       "private attachment streaming",
       "health transitions",
@@ -47,8 +58,9 @@ describe("custom channel adapter contract", () => {
     const lyingAdapter = {
       descriptor: {
         ...adapter.descriptor,
-        capabilities: { ...adapter.descriptor.capabilities, outbound: false },
+        channels: adapter.descriptor.channels.map((channel) => ({ ...channel, outbound: false })),
       },
+      provisionAccount: adapter.provisionAccount.bind(adapter),
       validateAccount: adapter.validateAccount.bind(adapter),
       getHealth: adapter.getHealth.bind(adapter),
       submitOutbound: adapter.submitOutbound.bind(adapter),
@@ -56,8 +68,13 @@ describe("custom channel adapter contract", () => {
       fetchInbound: adapter.fetchInbound.bind(adapter),
       ackInbound: adapter.ackInbound.bind(adapter),
       verifyInboundAuthenticity: adapter.verifyInboundAuthenticity.bind(adapter),
+      queueVerifiedInbound: adapter.queueVerifiedInbound.bind(adapter),
       verifyLifecycleAuthenticity: adapter.verifyLifecycleAuthenticity.bind(adapter),
+      queueVerifiedLifecycle: adapter.queueVerifiedLifecycle.bind(adapter),
       normalizeLifecycleEvents: adapter.normalizeLifecycleEvents.bind(adapter),
+      listLifecycle: adapter.listLifecycle.bind(adapter),
+      fetchLifecycle: adapter.fetchLifecycle.bind(adapter),
+      ackLifecycle: adapter.ackLifecycle.bind(adapter),
       evaluatePolicy: adapter.evaluatePolicy.bind(adapter),
       readPrivateAttachment: adapter.readPrivateAttachment.bind(adapter),
     }
@@ -73,22 +90,34 @@ describe("custom channel adapter contract", () => {
     )
   })
 
+  it("rejects non-JSON canonical fingerprints, including explicit optional undefined", () => {
+    expect(() => canonicalAdapterPayload(undefined)).toThrow(/JSON-compatible/)
+    expect(() => canonicalAdapterPayload(Number.NaN)).toThrow(/finite/)
+    expect(() => canonicalAdapterPayload(new Date())).toThrow(/plain JSON/)
+    expect(() =>
+      canonicalSchemaPayload(z.object({ value: z.string().optional() }), { value: undefined }),
+    ).toThrow(/JSON-compatible/)
+  })
+
   it("keeps credentials and adapter configuration outside public DTOs", () => {
     expect(() =>
       channelAdapterDescriptorSchema.parse({
         protocolVersion: CHANNEL_ADAPTER_PROTOCOL_VERSION,
         adapterId: "custom",
-        capabilities: {
-          channels: ["custom-channel"],
-          outbound: true,
-          inbound: false,
-          lifecycleEvents: false,
-          policyEvaluation: false,
-          privateAttachments: false,
-          accountValidation: false,
-          health: false,
-        },
-        credentials: { token: "must-not-cross-the-boundary" },
+        channels: [
+          {
+            channel: "custom-channel",
+            outbound: true,
+            inbound: false,
+            lifecycleEvents: false,
+            policyEvaluation: false,
+            privateAttachments: false,
+            accountValidation: false,
+            health: false,
+            multimedia: false,
+          },
+        ],
+        credentials: { token: "x" },
       }),
     ).toThrow()
     expect(() =>
@@ -106,6 +135,7 @@ describe("custom channel adapter contract", () => {
     const envelope = {
       protocolVersion: CHANNEL_ADAPTER_PROTOCOL_VERSION,
       adapterAccountRef: control.accountRef,
+      sourceRef: control.sourceRef,
       channel: control.channel,
       externalEnvelopeId: "crash-safe-1",
       externalMessageId: "message-1",
@@ -119,19 +149,54 @@ describe("custom channel adapter contract", () => {
       threadRef: null,
       replyToExternalMessageId: null,
       classification: "message" as const,
+      sms: null,
     }
     control.enqueueInbound(envelope)
     const first = await control.adapter.listInbound?.({
       adapterAccountRef: control.accountRef,
+      sourceRef: control.sourceRef,
       limit: 10,
     })
     await control.adapter.fetchInbound?.(first!.items[0]!)
     expect(
-      await control.adapter.listInbound?.({ adapterAccountRef: control.accountRef, limit: 10 }),
+      await control.adapter.listInbound?.({
+        adapterAccountRef: control.accountRef,
+        sourceRef: control.sourceRef,
+        limit: 10,
+      }),
     ).toMatchObject({ items: [{ id: "crash-safe-1" }] })
     await control.adapter.ackInbound?.(first!.items[0]!)
     expect(
-      await control.adapter.listInbound?.({ adapterAccountRef: control.accountRef, limit: 10 }),
+      await control.adapter.listInbound?.({
+        adapterAccountRef: control.accountRef,
+        sourceRef: control.sourceRef,
+        limit: 10,
+      }),
     ).toMatchObject({ items: [] })
+  })
+
+  it("enforces SMS address and segmentation boundaries", () => {
+    expect(smsSegmentCount("")).toEqual({ encoding: "gsm7", segments: 0 })
+    expect(smsSegmentCount("a".repeat(160))).toEqual({ encoding: "gsm7", segments: 1 })
+    expect(smsSegmentCount("a".repeat(161))).toEqual({ encoding: "gsm7", segments: 2 })
+    expect(smsSegmentCount("✓".repeat(70))).toEqual({ encoding: "ucs2", segments: 1 })
+    expect(smsSegmentCount("✓".repeat(71))).toEqual({ encoding: "ucs2", segments: 2 })
+    expect(smsSegmentCount("^".repeat(80))).toEqual({ encoding: "gsm7", segments: 1 })
+    expect(smsSegmentCount("^".repeat(81))).toEqual({ encoding: "gsm7", segments: 2 })
+    expect(smsSegmentCount("£".repeat(160))).toEqual({ encoding: "gsm7", segments: 1 })
+    expect(() =>
+      outboundMessageSchema.parse({
+        operationId: "sms-1",
+        adapterAccountRef: "account",
+        channel: "sms",
+        recipient: "2025550123",
+        subject: null,
+        text: "hello",
+        sanitizedHtml: null,
+        attachments: [],
+        threadRef: null,
+        metadata: {},
+      }),
+    ).toThrow(/E.164/)
   })
 })

--- a/packages/channel-adapter-contracts/tsconfig.build.json
+++ b/packages/channel-adapter-contracts/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}

--- a/packages/channel-adapter-contracts/tsconfig.json
+++ b/packages/channel-adapter-contracts/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@voyant-travel/voyant-typescript-config/base.json",
+  "compilerOptions": { "composite": false, "module": "ESNext", "moduleResolution": "Bundler" },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/channel-adapter-contracts/tsconfig.typecheck.json
+++ b/packages/channel-adapter-contracts/tsconfig.typecheck.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": { "noEmit": true }
+}

--- a/packages/communications-adapter-runtime/README.md
+++ b/packages/communications-adapter-runtime/README.md
@@ -1,0 +1,7 @@
+# Communications adapter runtime
+
+Provider-neutral graph bridge for `ChannelAdapterV1`. A deployment supplies one
+`communications.channel-adapter-bundle`; this adapter validates it before
+activation and fans it into Notifications durable delivery and lifecycle jobs,
+plus Conversations inbound ingestion. Provider credentials and configuration
+remain behind the supplied adapter instance.

--- a/packages/communications-adapter-runtime/package.json
+++ b/packages/communications-adapter-runtime/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@voyant-travel/communications-adapter-runtime",
+  "version": "0.1.0",
+  "description": "Provider-neutral graph bridge for custom communications channel adapters.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./voyant": "./src/voyant.ts",
+    "./runtime-contributor": "./src/runtime-contributor.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "test": "vitest run",
+    "lint": "biome check src/ tests/"
+  },
+  "dependencies": {
+    "@voyant-travel/channel-adapter-contracts": "workspace:^",
+    "@voyant-travel/conversations": "workspace:^",
+    "@voyant-travel/conversations-contracts": "workspace:^",
+    "@voyant-travel/core": "workspace:^",
+    "@voyant-travel/notifications": "workspace:^"
+  },
+  "devDependencies": {
+    "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./voyant": {
+        "types": "./dist/voyant.d.ts",
+        "import": "./dist/voyant.js",
+        "default": "./dist/voyant.js"
+      },
+      "./runtime-contributor": {
+        "types": "./dist/runtime-contributor.d.ts",
+        "import": "./dist/runtime-contributor.js",
+        "default": "./dist/runtime-contributor.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "adapter",
+    "manifest": "./voyant",
+    "runtime": {
+      "entry": "./runtime-contributor",
+      "export": "createCommunicationsAdapterRuntimePortContribution"
+    }
+  },
+  "private": true
+}

--- a/packages/communications-adapter-runtime/src/bridge.ts
+++ b/packages/communications-adapter-runtime/src/bridge.ts
@@ -1,0 +1,455 @@
+import {
+  accountProvisioningResultSchema,
+  accountValidationResultSchema,
+  adapterHealthSchema,
+  type ChannelAdapterV1,
+  type InboundItemRef,
+  inboundEnvelopeSchema,
+  type LifecycleItemRef,
+  normalizeE164,
+  outboundAcceptanceSchema,
+  outboundMessageSchema,
+  validateChannelAdapter,
+} from "@voyant-travel/channel-adapter-contracts"
+import type {
+  ConversationIngressSource,
+  InboundConversationEnvelopeV1,
+} from "@voyant-travel/conversations-contracts"
+import type { NotificationDeliveryLifecycleSource } from "@voyant-travel/notifications/delivery-lifecycle-source-port"
+import type { DurableNotificationProviderRuntime } from "@voyant-travel/notifications/durable-provider-port"
+import type { NotificationProvider } from "@voyant-travel/notifications/types"
+import {
+  assertCommunicationsAdapterBundle,
+  type CommunicationsAdapterAccountBinding,
+  type CommunicationsAdapterBundle,
+} from "./runtime-port.js"
+
+function required<T>(value: T | null | undefined, name: string): T {
+  if (value === null || value === undefined) throw new Error(`Channel adapter is missing ${name}`)
+  return value
+}
+
+export function createCommunicationsAdapterBridge(bundle: CommunicationsAdapterBundle): {
+  durableRuntime: DurableNotificationProviderRuntime
+  ingressSource: ConversationIngressSource
+  lifecycleSource: NotificationDeliveryLifecycleSource
+} {
+  assertCommunicationsAdapterBundle(bundle)
+  const accounts = bundle.accounts.map((account) => ({ ...account }))
+  return {
+    durableRuntime: createDurableRuntime(bundle, accounts),
+    ingressSource: createIngressSource(bundle, accounts),
+    lifecycleSource: createLifecycleSource(bundle.adapter, accounts),
+  }
+}
+
+function createProvider(
+  adapter: ChannelAdapterV1,
+  accounts: CommunicationsAdapterAccountBinding[],
+): NotificationProvider {
+  const descriptor = validateChannelAdapter(adapter)
+  const knownAccounts = new Set(accounts.map(({ adapterAccountRef }) => adapterAccountRef))
+  return {
+    name: descriptor.adapterId,
+    channels: descriptor.channels.filter(({ outbound }) => outbound).map(({ channel }) => channel),
+    durableDelivery: {
+      protocol: "notification-provider-idempotency-v1",
+      async send(payload, context) {
+        const binding = accounts.find(
+          ({ address, channel, outbound }) =>
+            outbound && channel === payload.channel && address === payload.from,
+        )
+        if (!binding) throw new Error(`No outbound ${payload.channel} account matches its sender`)
+        const policy = await required(adapter.evaluatePolicy, "evaluatePolicy").call(adapter, {
+          adapterAccountRef: binding.adapterAccountRef,
+          channel: payload.channel,
+          recipient: payload.channel === "sms" ? normalizeE164(payload.to) : payload.to,
+          purpose: toPolicyPurpose(payload.purpose),
+        })
+        if (!policy.allowed) {
+          throw new Error(`Channel adapter policy rejected delivery: ${policy.code}`)
+        }
+        const health = adapterHealthSchema.parse(
+          await required(adapter.getHealth, "getHealth").call(adapter, {
+            adapterAccountRef: binding.adapterAccountRef,
+          }),
+        )
+        if (health.status === "unavailable")
+          throw new Error("Channel adapter account is unavailable")
+        const channel = descriptor.channels.find(({ channel }) => channel === payload.channel)!
+        if (
+          (payload.attachments?.length ?? 0) > 0 &&
+          (!channel.multimedia || !channel.privateAttachments)
+        ) {
+          throw new Error(`Attachments are not negotiated for ${payload.channel}`)
+        }
+        const message = outboundMessageSchema.parse({
+          operationId: context.idempotencyKey,
+          adapterAccountRef: binding.adapterAccountRef,
+          channel: payload.channel,
+          recipient: payload.channel === "sms" ? normalizeE164(payload.to) : payload.to,
+          subject: payload.subject ?? null,
+          text: payload.text ?? null,
+          sanitizedHtml: payload.html ?? null,
+          attachments: (payload.attachments ?? []).map((attachment) => ({
+            handle: required(attachment.privateHandle, "private attachment handle"),
+            filename: attachment.filename,
+            contentType: attachment.contentType ?? "application/octet-stream",
+            size: 0,
+          })),
+          threadRef: null,
+          metadata: {},
+        })
+        const accepted = outboundAcceptanceSchema.parse(
+          await required(adapter.submitOutbound, "submitOutbound").call(adapter, message),
+        )
+        return { id: accepted.externalSubmissionId, provider: descriptor.adapterId }
+      },
+    },
+    channelAccounts: {
+      protocol: "notification-channel-account-v1",
+      matches(adapterRef) {
+        return knownAccounts.has(adapterRef)
+      },
+      async provision(draft) {
+        if (!draft.inboundCapable || !draft.outboundCapable) {
+          throw new Error("Selected Inbox Channel Account must be provisioned two-way")
+        }
+        const channelCapabilities = descriptor.channels.find(
+          ({ channel }) => channel === draft.channel,
+        )
+        if (
+          !channelCapabilities?.inbound ||
+          !channelCapabilities.outbound ||
+          !channelCapabilities.lifecycleEvents ||
+          !channelCapabilities.policyEvaluation ||
+          !channelCapabilities.accountValidation ||
+          !channelCapabilities.health
+        ) {
+          throw new Error(`Two-way ${draft.channel} setup is incomplete`)
+        }
+        const result = accountProvisioningResultSchema.parse(
+          await required(adapter.provisionAccount, "provisionAccount").call(adapter, {
+            operationId: `provision:${draft.channel}:${draft.address}`.slice(0, 256),
+            channel: draft.channel,
+            address: draft.channel === "sms" ? normalizeE164(draft.address) : draft.address,
+            displayName: draft.displayName,
+            inbound: draft.inboundCapable ?? false,
+            outbound: draft.outboundCapable ?? true,
+          }),
+        )
+        const binding: CommunicationsAdapterAccountBinding = {
+          adapterAccountRef: result.adapterAccountRef,
+          sourceRef: result.inboundSourceRef ?? `outbound:${result.adapterAccountRef}`,
+          channel: draft.channel === "sms" ? "sms" : "email",
+          address: result.normalizedAddress,
+          inbound: draft.inboundCapable ?? false,
+          outbound: draft.outboundCapable ?? true,
+        }
+        const existing = accounts.findIndex(
+          ({ adapterAccountRef }) => adapterAccountRef === result.adapterAccountRef,
+        )
+        if (existing === -1) accounts.push(binding)
+        else accounts[existing] = { ...accounts[existing], ...binding }
+        knownAccounts.add(result.adapterAccountRef)
+        return {
+          adapterRef: result.adapterAccountRef,
+          normalizedAddress: result.normalizedAddress,
+          displayAddress: result.displayAddress,
+        }
+      },
+      async validate(adapterRef) {
+        const binding = accounts.find(({ adapterAccountRef }) => adapterAccountRef === adapterRef)
+        if (!binding) throw new Error("Channel adapter account is not bound")
+        const validation = accountValidationResultSchema.parse(
+          await required(adapter.validateAccount, "validateAccount").call(adapter, {
+            adapterAccountRef: adapterRef,
+            requiredChannels: [binding.channel],
+            requiredCapabilities: [
+              "health",
+              "inbound",
+              "outbound",
+              "lifecycleEvents",
+              "policyEvaluation",
+            ],
+          }),
+        )
+        if (!validation.valid)
+          throw new Error(`Channel adapter account validation failed: ${validation.code}`)
+        const health = adapterHealthSchema.parse(
+          await required(adapter.getHealth, "getHealth").call(adapter, {
+            adapterAccountRef: validation.normalizedAccountRef,
+          }),
+        )
+        return {
+          health: health.status,
+          inboundCapable: binding?.inbound ?? false,
+          outboundCapable: binding?.outbound ?? false,
+          inboundIdentity: binding?.inbound ? "unambiguous" : undefined,
+          inboundSourceId: binding.inbound ? `${descriptor.adapterId}:inbound` : undefined,
+          attachmentsCapable:
+            descriptor.channels.find(({ channel }) => channel === binding?.channel)?.multimedia ??
+            false,
+        }
+      },
+      activate({ channelAccountId, adapterRef }) {
+        const binding = accounts.find((account) => account.adapterAccountRef === adapterRef)
+        if (!binding) throw new Error("Cannot activate an unbound Channel Account")
+        binding.channelAccountId = channelAccountId
+      },
+    },
+  }
+}
+
+function toPolicyPurpose(
+  purpose: string | undefined,
+): "transactional" | "conversation" | "marketing" {
+  if (purpose?.toLowerCase().includes("marketing")) return "marketing"
+  if (purpose?.toLowerCase().includes("conversation")) return "conversation"
+  return "transactional"
+}
+
+function createDurableRuntime(
+  bundle: CommunicationsAdapterBundle,
+  accounts: CommunicationsAdapterAccountBinding[],
+): DurableNotificationProviderRuntime {
+  return {
+    providers: [createProvider(bundle.adapter, accounts)],
+    async createIsolatedProbe() {
+      const probe = await bundle.createIsolatedProbe()
+      let adapter = probe.adapter
+      return {
+        get providers() {
+          return [
+            createProvider(
+              adapter,
+              accounts.map((account) => ({ ...account })),
+            ),
+          ]
+        },
+        async restart() {
+          adapter = await probe.restart()
+          return [
+            createProvider(
+              adapter,
+              accounts.map((account) => ({ ...account })),
+            ),
+          ]
+        },
+        acceptedCount(_providerName, key) {
+          return probe.acceptedCount(key)
+        },
+      }
+    },
+  }
+}
+
+function assertRef(
+  accounts: readonly CommunicationsAdapterAccountBinding[],
+  ref: InboundItemRef | LifecycleItemRef,
+) {
+  if (
+    !accounts.some(
+      (account) =>
+        account.adapterAccountRef === ref.adapterAccountRef && account.sourceRef === ref.sourceRef,
+    )
+  ) {
+    throw new Error("Adapter item reference escaped its account/source scope")
+  }
+}
+
+function createIngressSource(
+  bundle: CommunicationsAdapterBundle,
+  accounts: CommunicationsAdapterAccountBinding[],
+): ConversationIngressSource {
+  const adapter = bundle.adapter
+  const descriptor = validateChannelAdapter(adapter)
+  const inbound = () => accounts.filter(({ inbound }) => inbound)
+  const pendingAttachments = new Map<
+    string,
+    { adapterAccountRef: string; sourceRef: string; handle: string }
+  >()
+  const pendingByInboundRef = new Map<string, string[]>()
+  let attachmentSequence = 0
+  const refKey = (ref: InboundItemRef) =>
+    `${ref.adapterAccountRef}\u0000${ref.sourceRef}\u0000${ref.id}`
+  const clearPending = (key: string) => {
+    for (const token of pendingByInboundRef.get(key) ?? []) pendingAttachments.delete(token)
+    pendingByInboundRef.delete(key)
+  }
+  return {
+    id: `${descriptor.adapterId}:inbound`,
+    async list({ limit }) {
+      const items: InboundItemRef[] = []
+      for (const account of inbound()) {
+        const health = adapterHealthSchema.parse(
+          await required(adapter.getHealth, "getHealth").call(adapter, {
+            adapterAccountRef: account.adapterAccountRef,
+          }),
+        )
+        if (health.status === "unavailable") continue
+        const page = await required(adapter.listInbound, "listInbound").call(adapter, {
+          adapterAccountRef: account.adapterAccountRef,
+          sourceRef: account.sourceRef,
+          limit: limit - items.length,
+        })
+        items.push(...page.items)
+        if (items.length >= limit) break
+      }
+      return { items, cursor: undefined }
+    },
+    async fetch(ref) {
+      const scoped = ref as InboundItemRef
+      assertRef(inbound(), scoped)
+      const key = refKey(scoped)
+      clearPending(key)
+      let envelope: ReturnType<typeof inboundEnvelopeSchema.parse>
+      try {
+        envelope = inboundEnvelopeSchema.parse(
+          await required(adapter.fetchInbound, "fetchInbound").call(adapter, scoped),
+        )
+      } catch (error) {
+        clearPending(key)
+        throw error
+      }
+      if (
+        envelope.adapterAccountRef !== scoped.adapterAccountRef ||
+        envelope.sourceRef !== scoped.sourceRef
+      )
+        throw new Error("Inbound payload scope drift")
+      const binding = inbound().find(
+        ({ adapterAccountRef, sourceRef }) =>
+          adapterAccountRef === scoped.adapterAccountRef && sourceRef === scoped.sourceRef,
+      )!
+      return toConversationEnvelope(
+        `${descriptor.adapterId}:inbound`,
+        binding,
+        envelope,
+        (attachment) => {
+          const token = `${descriptor.adapterId}:pending-attachment:${++attachmentSequence}`
+          pendingAttachments.set(token, {
+            adapterAccountRef: envelope.adapterAccountRef,
+            sourceRef: envelope.sourceRef,
+            handle: attachment.handle,
+          })
+          const tokens = pendingByInboundRef.get(key) ?? []
+          tokens.push(token)
+          pendingByInboundRef.set(key, tokens)
+          return token
+        },
+      )
+    },
+    async ack(ref) {
+      const scoped = ref as InboundItemRef
+      assertRef(inbound(), scoped)
+      try {
+        await required(adapter.ackInbound, "ackInbound").call(adapter, scoped)
+      } finally {
+        clearPending(refKey(scoped))
+      }
+    },
+    async importInboundAttachment(input) {
+      const scoped = pendingAttachments.get(input.privateHandle)
+      if (!scoped) throw new Error("Inbound attachment handle is not pending for this source")
+      const bytes = await required(adapter.readPrivateAttachment, "readPrivateAttachment").call(
+        adapter,
+        scoped,
+      )
+      const imported = await required(
+        bundle.importInboundAttachment,
+        "importInboundAttachment",
+      )({ ...input, bytes })
+      pendingAttachments.delete(input.privateHandle)
+      return imported
+    },
+  }
+}
+
+function toConversationEnvelope(
+  sourceId: string,
+  binding: CommunicationsAdapterAccountBinding,
+  envelope: ReturnType<typeof inboundEnvelopeSchema.parse>,
+  attachmentHandle: (attachment: (typeof envelope.attachments)[number]) => string,
+): InboundConversationEnvelopeV1 {
+  const attachments = envelope.attachments.map((attachment) => ({
+    externalId: attachment.handle,
+    filename: attachment.filename,
+    contentType: attachment.contentType,
+    size: attachment.size,
+    privateHandle: attachmentHandle(attachment),
+  }))
+  if (envelope.channel === "sms")
+    return {
+      version: "1",
+      channel: "sms",
+      sourceId,
+      externalEnvelopeId: envelope.externalEnvelopeId,
+      externalMessageId: envelope.externalMessageId,
+      channelAccountId: required(binding.channelAccountId, "SMS Channel Account id"),
+      receivingAddress: normalizeE164(envelope.recipients[0]!.address),
+      senderAddress: normalizeE164(envelope.sender.address),
+      text: required(envelope.text, "SMS text"),
+      attachments,
+      policyEvent: envelope.sms?.policyEvent ?? null,
+      adapterHandledResponse: envelope.sms?.adapterHandledResponse ?? false,
+      occurredAt: envelope.occurredAt,
+    }
+  return {
+    version: "1",
+    sourceId,
+    externalEnvelopeId: envelope.externalEnvelopeId,
+    externalMessageId: envelope.externalMessageId,
+    sender: { address: envelope.sender.address, name: envelope.sender.displayName },
+    to: envelope.recipients.map(({ address, displayName }) => ({ address, name: displayName })),
+    cc: [],
+    replyTo: [],
+    subject: envelope.subject,
+    text: envelope.text,
+    html: envelope.untrustedHtml,
+    attachments,
+    classification: envelope.classification,
+    threading: {
+      messageId: envelope.externalMessageId,
+      inReplyTo: envelope.replyToExternalMessageId,
+      references: envelope.threadRef ? [envelope.threadRef] : [],
+    },
+    occurredAt: envelope.occurredAt,
+  }
+}
+
+function createLifecycleSource(
+  adapter: ChannelAdapterV1,
+  bindings: CommunicationsAdapterAccountBinding[],
+): NotificationDeliveryLifecycleSource {
+  const accounts = () => bindings.filter(({ outbound }) => outbound)
+  return {
+    id: `${validateChannelAdapter(adapter).adapterId}:lifecycle`,
+    async list({ limit }) {
+      const items: LifecycleItemRef[] = []
+      for (const account of accounts()) {
+        const health = adapterHealthSchema.parse(
+          await required(adapter.getHealth, "getHealth").call(adapter, {
+            adapterAccountRef: account.adapterAccountRef,
+          }),
+        )
+        if (health.status === "unavailable") continue
+        const page = await required(adapter.listLifecycle, "listLifecycle").call(adapter, {
+          adapterAccountRef: account.adapterAccountRef,
+          sourceRef: account.sourceRef,
+          limit: limit - items.length,
+        })
+        items.push(...page.items)
+        if (items.length >= limit) break
+      }
+      return { items, cursor: null }
+    },
+    async fetch(ref) {
+      assertRef(accounts(), ref)
+      return required(adapter.fetchLifecycle, "fetchLifecycle").call(adapter, ref)
+    },
+    async ack(ref) {
+      assertRef(accounts(), ref)
+      await required(adapter.ackLifecycle, "ackLifecycle").call(adapter, ref)
+    },
+  }
+}

--- a/packages/communications-adapter-runtime/src/index.ts
+++ b/packages/communications-adapter-runtime/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./bridge.js"
+export * from "./runtime-port.js"

--- a/packages/communications-adapter-runtime/src/runtime-contributor.ts
+++ b/packages/communications-adapter-runtime/src/runtime-contributor.ts
@@ -1,0 +1,24 @@
+import { conversationIngressSourcePort } from "@voyant-travel/conversations/runtime-port"
+import type { VoyantPort } from "@voyant-travel/core/project"
+import { notificationDeliveryLifecycleSourcePort } from "@voyant-travel/notifications/delivery-lifecycle-source-port"
+import { durableNotificationProviderPort } from "@voyant-travel/notifications/durable-provider-port"
+import { createCommunicationsAdapterBridge } from "./bridge.js"
+import {
+  type CommunicationsAdapterBundle,
+  communicationsAdapterBundlePort,
+} from "./runtime-port.js"
+
+export function createCommunicationsAdapterRuntimePortContribution(host: {
+  getRuntimePort<T>(port: Pick<VoyantPort<T>, "id">): T | Promise<T>
+}): Readonly<Record<string, unknown>> {
+  const bridge = Promise.resolve(
+    host.getRuntimePort<CommunicationsAdapterBundle>(communicationsAdapterBundlePort),
+  ).then(createCommunicationsAdapterBridge)
+  return {
+    [durableNotificationProviderPort.id]: bridge.then(({ durableRuntime }) => durableRuntime),
+    [conversationIngressSourcePort.id]: bridge.then(({ ingressSource }) => ingressSource),
+    [notificationDeliveryLifecycleSourcePort.id]: bridge.then(
+      ({ lifecycleSource }) => lifecycleSource,
+    ),
+  }
+}

--- a/packages/communications-adapter-runtime/src/runtime-port.ts
+++ b/packages/communications-adapter-runtime/src/runtime-port.ts
@@ -1,0 +1,74 @@
+import type { ChannelAdapterV1 } from "@voyant-travel/channel-adapter-contracts"
+import { validateChannelAdapter } from "@voyant-travel/channel-adapter-contracts"
+import { definePort } from "@voyant-travel/core/project"
+
+export interface CommunicationsAdapterAccountBinding {
+  adapterAccountRef: string
+  sourceRef: string
+  channel: "email" | "sms"
+  /** Host-normalized sender/receiving identity used for account-specific dispatch. */
+  address: string
+  /** Persisted Notifications account id, required for inbound SMS policy projection. */
+  channelAccountId?: string
+  inbound: boolean
+  outbound: boolean
+}
+
+export interface CommunicationsAdapterBundle {
+  readonly adapter: ChannelAdapterV1
+  readonly accounts: readonly CommunicationsAdapterAccountBinding[]
+  /** Streams ephemeral adapter bytes into the deployment private-documents authority. */
+  importInboundAttachment?(input: {
+    sourceId: string
+    externalId: string
+    filename: string
+    contentType: string
+    sizeBytes: number
+    bytes: AsyncIterable<Uint8Array>
+  }): Promise<{ privateHandle: string; filename: string; contentType: string; sizeBytes: number }>
+  /** Isolated backend probe used by Notifications durable-provider conformance. */
+  createIsolatedProbe(): Promise<{
+    adapter: ChannelAdapterV1
+    restart(): Promise<ChannelAdapterV1>
+    acceptedCount(operationId: string): number | Promise<number>
+  }>
+}
+
+export const communicationsAdapterBundlePort = definePort<CommunicationsAdapterBundle>({
+  id: "communications.channel-adapter-bundle",
+  test: assertCommunicationsAdapterBundle,
+})
+
+export function assertCommunicationsAdapterBundle(bundle: CommunicationsAdapterBundle): void {
+  const descriptor = validateChannelAdapter(bundle.adapter)
+  if (!Array.isArray(bundle.accounts) || typeof bundle.createIsolatedProbe !== "function") {
+    throw new Error("communications adapter bundle requires accounts and an isolated probe")
+  }
+  for (const account of bundle.accounts) {
+    if (!account.address.trim()) throw new Error("Communications account address is required")
+    const channel = descriptor.channels.find((entry) => entry.channel === account.channel)
+    if (!channel) throw new Error(`Communications adapter does not declare ${account.channel}`)
+    if (!account.inbound || !account.outbound) {
+      throw new Error(`Selected Inbox account ${account.channel} must be two-way`)
+    }
+    if (
+      !channel.inbound ||
+      !channel.outbound ||
+      !channel.lifecycleEvents ||
+      !channel.policyEvaluation ||
+      !channel.accountValidation ||
+      !channel.health
+    ) {
+      throw new Error(`Two-way ${account.channel} setup is incomplete`)
+    }
+    if (account.inbound && channel.privateAttachments && !bundle.importInboundAttachment) {
+      throw new Error("Inbound attachments require a private documents importer")
+    }
+    if (account.channel === "sms" && channel.multimedia && !channel.privateAttachments) {
+      throw new Error("SMS multimedia requires scoped private attachment reads")
+    }
+    if (account.channel === "sms" && account.inbound && !account.channelAccountId?.trim()) {
+      throw new Error("Inbound SMS requires its persisted Channel Account id")
+    }
+  }
+}

--- a/packages/communications-adapter-runtime/src/voyant.ts
+++ b/packages/communications-adapter-runtime/src/voyant.ts
@@ -1,0 +1,20 @@
+import { conversationIngressSourcePort } from "@voyant-travel/conversations/runtime-port"
+import { defineAdapter, providePort, requirePort } from "@voyant-travel/core/project"
+import { notificationDeliveryLifecycleSourcePort } from "@voyant-travel/notifications/delivery-lifecycle-source-port"
+import { durableNotificationProviderPort } from "@voyant-travel/notifications/durable-provider-port"
+import { communicationsAdapterBundlePort } from "./runtime-port.js"
+
+export const communicationsAdapterRuntime = defineAdapter({
+  id: "@voyant-travel/communications-adapter-runtime",
+  packageName: "@voyant-travel/communications-adapter-runtime",
+  localId: "communications-adapter-runtime",
+  runtimePorts: [requirePort(communicationsAdapterBundlePort)],
+  provides: {
+    ports: [
+      providePort(durableNotificationProviderPort),
+      providePort(conversationIngressSourcePort),
+      providePort(notificationDeliveryLifecycleSourcePort),
+    ],
+  },
+})
+export default communicationsAdapterRuntime

--- a/packages/communications-adapter-runtime/tests/bridge.test.ts
+++ b/packages/communications-adapter-runtime/tests/bridge.test.ts
@@ -1,0 +1,298 @@
+import { CHANNEL_ADAPTER_PROTOCOL_VERSION } from "@voyant-travel/channel-adapter-contracts"
+import { FixtureChannelAdapter } from "@voyant-travel/channel-adapter-contracts/testing"
+import { describe, expect, it, vi } from "vitest"
+import { createCommunicationsAdapterBridge } from "../src/bridge.js"
+import type { CommunicationsAdapterBundle } from "../src/runtime-port.js"
+
+function adapterFor(channel: "email" | "sms") {
+  return new FixtureChannelAdapter({
+    accountRef: "fixture-account",
+    sourceRef: `${channel}-fixture-source`,
+    channel,
+  })
+}
+
+function bundle(adapter: FixtureChannelAdapter): CommunicationsAdapterBundle {
+  return {
+    adapter,
+    accounts: [],
+    async importInboundAttachment(input) {
+      const bytes: number[] = []
+      for await (const chunk of input.bytes) bytes.push(...chunk)
+      return {
+        privateHandle: `documents:${bytes.join("-")}`,
+        filename: input.filename,
+        contentType: input.contentType,
+        sizeBytes: bytes.length,
+      }
+    },
+    async createIsolatedProbe() {
+      return {
+        adapter,
+        async restart() {
+          return adapterFor(adapter.descriptor.channels[0]!.channel as "email" | "sms")
+        },
+        acceptedCount: () => 1,
+      }
+    },
+  }
+}
+
+describe("communications adapter graph bridge", () => {
+  it("provisions, validates, activates and immediately sends through the bound account", async () => {
+    const adapter = adapterFor("email")
+    const bridge = createCommunicationsAdapterBridge(bundle(adapter))
+    const provider = bridge.durableRuntime.providers[0]!
+    const capability = provider.channelAccounts!
+    const provisioned = await capability.provision({
+      channel: "email",
+      address: "inbox@example.test",
+      displayName: "Inbox",
+      allowedPurposes: ["conversation-reply"],
+      inboundCapable: true,
+      outboundCapable: true,
+    })
+    expect(await capability.validate(provisioned.adapterRef)).toMatchObject({
+      inboundCapable: true,
+      outboundCapable: true,
+      inboundSourceId: "fixture-channel-adapter:inbound",
+    })
+    await capability.activate?.({
+      channelAccountId: "channel-account-1",
+      adapterRef: provisioned.adapterRef,
+    })
+    await expect(
+      provider.durableDelivery.send(
+        {
+          channel: "email",
+          to: "guest@example.test",
+          from: "inbox@example.test",
+          template: "rendered",
+          purpose: "conversation-reply",
+          text: "Hello",
+        },
+        { idempotencyKey: "send-1" },
+      ),
+    ).resolves.toMatchObject({ id: "fixture-submission-1" })
+  })
+
+  it("rejects outbound-only Inbox bindings and incomplete two-way setup", () => {
+    const adapter = adapterFor("email")
+    expect(() =>
+      createCommunicationsAdapterBridge({
+        ...bundle(adapter),
+        accounts: [
+          {
+            adapterAccountRef: "fixture-account",
+            sourceRef: "email-fixture-source",
+            channel: "email",
+            address: "inbox@example.test",
+            inbound: false,
+            outbound: true,
+          },
+        ],
+      }),
+    ).toThrow(/two-way/)
+
+    adapter.descriptor.channels[0] = {
+      ...adapter.descriptor.channels[0]!,
+      policyEvaluation: false,
+    }
+    expect(() =>
+      createCommunicationsAdapterBridge({
+        ...bundle(adapter),
+        accounts: [
+          {
+            adapterAccountRef: "fixture-account",
+            sourceRef: "email-fixture-source",
+            channel: "email",
+            address: "inbox@example.test",
+            inbound: true,
+            outbound: true,
+          },
+        ],
+      }),
+    ).toThrow(/must exactly match|incomplete/)
+  })
+
+  it("evaluates authoritative purpose and suppression before outbound submission", async () => {
+    const adapter = adapterFor("sms")
+    const evaluatePolicy = vi.spyOn(adapter, "evaluatePolicy")
+    const bridge = createCommunicationsAdapterBridge({
+      ...bundle(adapter),
+      accounts: [
+        {
+          adapterAccountRef: "fixture-account",
+          sourceRef: "sms-fixture-source",
+          channel: "sms",
+          address: "+12025550100",
+          channelAccountId: "channel-account-1",
+          inbound: true,
+          outbound: true,
+        },
+      ],
+    })
+    adapter.setRecipientSuppressed(true)
+    await expect(
+      bridge.durableRuntime.providers[0]!.durableDelivery.send(
+        {
+          channel: "sms",
+          to: "+12025550123",
+          from: "+12025550100",
+          template: "rendered",
+          purpose: "conversation-reply",
+          text: "Hello",
+        },
+        { idempotencyKey: "suppressed-send-1" },
+      ),
+    ).rejects.toThrow(/recipient_suppressed/)
+    expect(evaluatePolicy).toHaveBeenCalledWith({
+      adapterAccountRef: "fixture-account",
+      channel: "sms",
+      recipient: "+12025550123",
+      purpose: "conversation",
+    })
+    adapter.setRecipientSuppressed(false)
+    await expect(
+      bridge.durableRuntime.providers[0]!.durableDelivery.send(
+        {
+          channel: "sms",
+          to: "+12025550123",
+          from: "+12025550100",
+          template: "rendered",
+          purpose: "conversation-reply",
+          text: "Hello",
+        },
+        { idempotencyKey: "allowed-send-1" },
+      ),
+    ).resolves.toMatchObject({ id: "fixture-submission-1" })
+  })
+
+  it("rejects provisioning configuration drift", async () => {
+    const adapter = adapterFor("email")
+    const capability = createCommunicationsAdapterBridge(bundle(adapter)).durableRuntime
+      .providers[0]!.channelAccounts!
+    const draft = {
+      channel: "email" as const,
+      address: "inbox@example.test",
+      displayName: "Inbox",
+      allowedPurposes: ["conversation-reply"],
+      inboundCapable: true,
+      outboundCapable: true,
+    }
+    await capability.provision(draft)
+    await expect(capability.provision({ ...draft, displayName: "Changed" })).rejects.toThrow(
+      /payload drift/,
+    )
+    await expect(capability.provision({ ...draft, inboundCapable: false })).rejects.toThrow(
+      /two-way/,
+    )
+  })
+
+  it("imports scoped attachment bytes without exposing the adapter handle as durable storage", async () => {
+    const adapter = adapterFor("email")
+    const bridge = createCommunicationsAdapterBridge(bundle(adapter))
+    const capability = bridge.durableRuntime.providers[0]!.channelAccounts!
+    const provisioned = await capability.provision({
+      channel: "email",
+      address: "inbox@example.test",
+      displayName: "Inbox",
+      allowedPurposes: [],
+      inboundCapable: true,
+      outboundCapable: true,
+    })
+    await capability.activate?.({
+      channelAccountId: "channel-account-1",
+      adapterRef: provisioned.adapterRef,
+    })
+    adapter.putPrivateAttachment("raw-adapter-handle", new Uint8Array([1, 2, 3]))
+    adapter.enqueueInbound({
+      protocolVersion: CHANNEL_ADAPTER_PROTOCOL_VERSION,
+      adapterAccountRef: provisioned.adapterRef,
+      sourceRef: "email-fixture-source",
+      channel: "email",
+      externalEnvelopeId: "envelope-1",
+      externalMessageId: "message-1",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      sender: { address: "guest@example.test", displayName: null },
+      recipients: [{ address: "inbox@example.test", displayName: null }],
+      subject: "Question",
+      text: "Hello",
+      untrustedHtml: null,
+      attachments: [
+        { handle: "raw-adapter-handle", filename: "note.txt", contentType: "text/plain", size: 3 },
+      ],
+      threadRef: null,
+      replyToExternalMessageId: null,
+      classification: "message",
+      sms: null,
+    })
+    const page = await bridge.ingressSource.list({ limit: 10 })
+    const envelope = await bridge.ingressSource.fetch(page.items[0]!)
+    expect(envelope.attachments[0]!.privateHandle).not.toContain("raw-adapter-handle")
+    const replay = await bridge.ingressSource.fetch(page.items[0]!)
+    await expect(
+      bridge.ingressSource.importInboundAttachment!({
+        sourceId: bridge.ingressSource.id,
+        externalId: "raw-adapter-handle",
+        privateHandle: envelope.attachments[0]!.privateHandle,
+        filename: "note.txt",
+        contentType: "text/plain",
+        sizeBytes: 3,
+      }),
+    ).rejects.toThrow(/not pending/)
+    await expect(
+      bridge.ingressSource.importInboundAttachment!({
+        sourceId: bridge.ingressSource.id,
+        externalId: "raw-adapter-handle",
+        privateHandle: replay.attachments[0]!.privateHandle,
+        filename: "note.txt",
+        contentType: "text/plain",
+        sizeBytes: 3,
+      }),
+    ).resolves.toMatchObject({ privateHandle: "documents:1-2-3" })
+    const uncommittedReplay = await bridge.ingressSource.fetch(page.items[0]!)
+    await bridge.ingressSource.ack(page.items[0]!)
+    await expect(
+      bridge.ingressSource.importInboundAttachment!({
+        sourceId: bridge.ingressSource.id,
+        externalId: "raw-adapter-handle",
+        privateHandle: uncommittedReplay.attachments[0]!.privateHandle,
+        filename: "note.txt",
+        contentType: "text/plain",
+        sizeBytes: 3,
+      }),
+    ).rejects.toThrow(/not pending/)
+  })
+
+  it("makes unavailable health affect send and polling behavior", async () => {
+    const adapter = adapterFor("email")
+    const bridge = createCommunicationsAdapterBridge({
+      ...bundle(adapter),
+      accounts: [
+        {
+          adapterAccountRef: "fixture-account",
+          sourceRef: "email-fixture-source",
+          channel: "email",
+          address: "inbox@example.test",
+          inbound: true,
+          outbound: true,
+        },
+      ],
+    })
+    adapter.setHealth("unavailable")
+    await expect(
+      bridge.durableRuntime.providers[0]!.durableDelivery.send(
+        {
+          channel: "email",
+          to: "guest@example.test",
+          from: "inbox@example.test",
+          template: "rendered",
+          text: "Hello",
+        },
+        { idempotencyKey: "send-1" },
+      ),
+    ).rejects.toThrow(/unavailable/)
+    await expect(bridge.ingressSource.list({ limit: 10 })).resolves.toMatchObject({ items: [] })
+  })
+})

--- a/packages/communications-adapter-runtime/tsconfig.build.json
+++ b/packages/communications-adapter-runtime/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@voyant-travel/voyant-typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/communications-adapter-runtime/tsconfig.json
+++ b/packages/communications-adapter-runtime/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@voyant-travel/voyant-typescript-config/base.json",
+  "compilerOptions": { "noEmit": true },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/communications-adapter-runtime/tsconfig.typecheck.json
+++ b/packages/communications-adapter-runtime/tsconfig.typecheck.json
@@ -1,0 +1,1 @@
+{ "extends": "./tsconfig.json", "compilerOptions": { "noEmit": true } }

--- a/packages/conversations-contracts/src/index.ts
+++ b/packages/conversations-contracts/src/index.ts
@@ -94,6 +94,15 @@ export interface ConversationIngressSource {
   list(input: { cursor?: string; limit: number }): Promise<IngressListPage>
   fetch(ref: IngressItemRef): Promise<InboundConversationEnvelopeV1>
   ack(ref: IngressItemRef): Promise<void>
+  /** Import an ephemeral source handle into the deployment's private documents store. */
+  importInboundAttachment?(input: {
+    sourceId: string
+    externalId: string
+    privateHandle: string
+    filename: string
+    contentType: string
+    sizeBytes: number
+  }): Promise<{ privateHandle: string; filename: string; contentType: string; sizeBytes: number }>
 }
 
 export interface ConversationRenderedServiceMessage {

--- a/packages/conversations/src/ingress-job.ts
+++ b/packages/conversations/src/ingress-job.ts
@@ -38,7 +38,16 @@ export async function processConversationIngress(input: {
       summary.fetched += 1
       const result = await (input.ingest ?? ingestEnvelope)(input.db, envelope, {
         personDirectory: input.personDirectory,
-        attachmentRuntime: input.attachmentRuntime,
+        attachmentRuntime: source.importInboundAttachment
+          ? {
+              ...input.attachmentRuntime,
+              importInbound: (attachment) => source.importInboundAttachment!(attachment),
+              scan: input.attachmentRuntime?.scan ?? (async () => ({ status: "failed" as const })),
+              download: input.attachmentRuntime?.download ?? (async () => null),
+              delete: input.attachmentRuntime?.delete ?? (async () => undefined),
+              resolveForSend: input.attachmentRuntime?.resolveForSend ?? (async () => null),
+            }
+          : input.attachmentRuntime,
         channelPolicy: input.channelPolicy,
       })
       if (result.duplicate) summary.duplicates += 1

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -15,6 +15,8 @@
     "./job-runtime": "./src/job-runtime.ts",
     "./runtime-port": "./src/runtime-port.ts",
     "./durable-provider-port": "./src/durable-provider-port.ts",
+    "./delivery-lifecycle-source-port": "./src/delivery-lifecycle-source-port.ts",
+    "./delivery-lifecycle-job": "./src/delivery-lifecycle-job.ts",
     "./subscriber-runtime": "./src/subscriber-runtime.ts",
     "./staff-alert-subscriber": "./src/staff-alert-subscriber.ts",
     "./tools": "./src/mcp-runtime.ts",
@@ -41,6 +43,7 @@
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/conversations": "workspace:^",
     "@voyant-travel/conversations-contracts": "workspace:^",
+    "@voyant-travel/channel-adapter-contracts": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/finance": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
@@ -128,6 +131,16 @@
         "types": "./dist/durable-provider-port.d.ts",
         "import": "./dist/durable-provider-port.js",
         "default": "./dist/durable-provider-port.js"
+      },
+      "./delivery-lifecycle-source-port": {
+        "types": "./dist/delivery-lifecycle-source-port.d.ts",
+        "import": "./dist/delivery-lifecycle-source-port.js",
+        "default": "./dist/delivery-lifecycle-source-port.js"
+      },
+      "./delivery-lifecycle-job": {
+        "types": "./dist/delivery-lifecycle-job.d.ts",
+        "import": "./dist/delivery-lifecycle-job.js",
+        "default": "./dist/delivery-lifecycle-job.js"
       },
       "./subscriber-runtime": {
         "types": "./dist/subscriber-runtime.d.ts",

--- a/packages/notifications/src/delivery-lifecycle-job.ts
+++ b/packages/notifications/src/delivery-lifecycle-job.ts
@@ -1,0 +1,77 @@
+import {
+  canonicalSchemaPayload,
+  deliveryLifecycleEventSchema,
+} from "@voyant-travel/channel-adapter-contracts"
+import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
+import { and, eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import {
+  type NotificationDeliveryLifecycleSource,
+  notificationDeliveryLifecycleSourcePort,
+} from "./delivery-lifecycle-source-port.js"
+import { notificationsRuntimePort } from "./runtime-port.js"
+import { notificationChannelAccounts, notificationDeliveries } from "./schema.js"
+import { reconcileNotificationDeliveryEvent } from "./service-channel-accounts.js"
+
+export async function processNotificationDeliveryLifecycle(input: {
+  db: PostgresJsDatabase
+  sources: readonly NotificationDeliveryLifecycleSource[]
+  limit?: number
+}) {
+  const summary = { fetched: 0, committed: 0, duplicates: 0, acknowledged: 0 }
+  for (const source of input.sources) {
+    const page = await source.list({ limit: Math.min(input.limit ?? 50, 100) })
+    for (const ref of page.items) {
+      const raw = await source.fetch(ref)
+      const event = deliveryLifecycleEventSchema.parse(raw)
+      if (event.adapterAccountRef !== ref.adapterAccountRef)
+        throw new Error("Lifecycle event account scope mismatch")
+      const [delivery] = await input.db
+        .select({
+          id: notificationDeliveries.id,
+          adapterRef: notificationChannelAccounts.adapterRef,
+        })
+        .from(notificationDeliveries)
+        .innerJoin(
+          notificationChannelAccounts,
+          eq(notificationDeliveries.channelAccountId, notificationChannelAccounts.id),
+        )
+        .where(
+          and(
+            eq(notificationDeliveries.providerMessageId, event.externalSubmissionId),
+            eq(notificationChannelAccounts.adapterRef, event.adapterAccountRef),
+          ),
+        )
+        .limit(1)
+      if (!delivery) throw new Error("Lifecycle event does not match a durable delivery")
+      const result = await reconcileNotificationDeliveryEvent(input.db, {
+        adapterRef: delivery.adapterRef,
+        adapterEventId: event.externalEventId,
+        deliveryId: delivery.id,
+        status: event.state,
+        occurredAt: new Date(event.occurredAt),
+        details: {
+          reasonCode: event.reasonCode,
+          canonicalPayload: canonicalSchemaPayload(deliveryLifecycleEventSchema, event),
+        },
+      })
+      summary.fetched += 1
+      if (result.created) summary.committed += 1
+      else summary.duplicates += 1
+      // The ledger transaction committed before this acknowledgement.
+      await source.ack(ref)
+      summary.acknowledged += 1
+    }
+  }
+  return summary
+}
+
+export async function runNotificationDeliveryLifecycleJob(
+  context: VoyantGraphRuntimeFactoryContext,
+): Promise<void> {
+  const runtime = await context.getPort(notificationsRuntimePort)
+  await processNotificationDeliveryLifecycle({
+    db: runtime.resolveDb() as PostgresJsDatabase,
+    sources: await context.getPorts(notificationDeliveryLifecycleSourcePort),
+  })
+}

--- a/packages/notifications/src/delivery-lifecycle-source-port.ts
+++ b/packages/notifications/src/delivery-lifecycle-source-port.ts
@@ -1,0 +1,30 @@
+import type {
+  DeliveryLifecycleEvent,
+  LifecycleItemRef,
+  LifecycleListPage,
+} from "@voyant-travel/channel-adapter-contracts"
+import { definePort } from "@voyant-travel/core/project"
+
+export interface NotificationDeliveryLifecycleSource {
+  readonly id: string
+  list(input: { cursor?: string; limit: number }): Promise<LifecycleListPage>
+  fetch(ref: LifecycleItemRef): Promise<DeliveryLifecycleEvent>
+  ack(ref: LifecycleItemRef): Promise<void>
+}
+
+export const notificationDeliveryLifecycleSourcePort =
+  definePort<NotificationDeliveryLifecycleSource>({
+    id: "notifications.delivery-lifecycle-source",
+    test(source) {
+      if (
+        !source ||
+        typeof source !== "object" ||
+        typeof source.id !== "string" ||
+        typeof source.list !== "function" ||
+        typeof source.fetch !== "function" ||
+        typeof source.ack !== "function"
+      ) {
+        throw new Error("notifications.delivery-lifecycle-source must implement list/fetch/ack")
+      }
+    },
+  })

--- a/packages/notifications/src/service-channel-accounts.ts
+++ b/packages/notifications/src/service-channel-accounts.ts
@@ -1,6 +1,6 @@
 import { normalizeE164 } from "@voyant-travel/conversations-contracts"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
-import { desc, eq } from "drizzle-orm"
+import { and, desc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
@@ -63,26 +63,57 @@ export async function provisionChannelAccount(
   ) {
     throw new NotificationError("Inbound SMS requires one unambiguous receiving identity")
   }
+  const [existing] = await db
+    .select()
+    .from(notificationChannelAccounts)
+    .where(eq(notificationChannelAccounts.adapterRef, provisioned.adapterRef))
+    .limit(1)
+  if (
+    existing &&
+    (existing.channel !== draft.channel ||
+      existing.normalizedAddress !== normalizedAddress ||
+      existing.displayName !== draft.displayName ||
+      existing.displayAddress !== provisioned.displayAddress ||
+      (draft.inboundCapable !== undefined && existing.inboundCapable !== draft.inboundCapable) ||
+      (draft.outboundCapable !== undefined && existing.outboundCapable !== draft.outboundCapable) ||
+      JSON.stringify(existing.allowedPurposes) !==
+        JSON.stringify(normalizePurposes(draft.allowedPurposes)))
+  ) {
+    throw new NotificationError("Provisioned Channel Account replay payload drift")
+  }
+  if (existing?.lifecycle === "archived" || existing?.lifecycle === "disabled") {
+    throw new NotificationError("Provision replay cannot reactivate a disabled Channel Account")
+  }
+  if (existing?.lifecycle === "active") return existing
+  const [pending] = existing
+    ? [existing]
+    : await db
+        .insert(notificationChannelAccounts)
+        .values({
+          channel: draft.channel,
+          normalizedAddress,
+          displayName: draft.displayName,
+          displayAddress: provisioned.displayAddress,
+          lifecycle: "pending",
+          health: validation.health,
+          inboundCapable: validation.inboundCapable,
+          outboundCapable: validation.outboundCapable,
+          inboundIdentity: validation.inboundIdentity ?? null,
+          inboundSourceId: validation.inboundSourceId ?? null,
+          attachmentsCapable: validation.attachmentsCapable ?? false,
+          allowedPurposes: normalizePurposes(draft.allowedPurposes),
+          adapterRef: provisioned.adapterRef,
+          lastValidatedAt: new Date(),
+        })
+        .returning()
+  if (!pending) throw new NotificationError("Failed to persist the provisioned Channel Account")
+  await capability.activate?.({ channelAccountId: pending.id, adapterRef: pending.adapterRef })
   const [account] = await db
-    .insert(notificationChannelAccounts)
-    .values({
-      channel: draft.channel,
-      normalizedAddress,
-      displayName: draft.displayName,
-      displayAddress: provisioned.displayAddress,
-      lifecycle: "active",
-      health: validation.health,
-      inboundCapable: validation.inboundCapable,
-      outboundCapable: validation.outboundCapable,
-      inboundIdentity: validation.inboundIdentity ?? null,
-      inboundSourceId: validation.inboundSourceId ?? null,
-      attachmentsCapable: validation.attachmentsCapable ?? false,
-      allowedPurposes: normalizePurposes(draft.allowedPurposes),
-      adapterRef: provisioned.adapterRef,
-      lastValidatedAt: new Date(),
-    })
+    .update(notificationChannelAccounts)
+    .set({ lifecycle: "active", updatedAt: new Date() })
+    .where(eq(notificationChannelAccounts.id, pending.id))
     .returning()
-  if (!account) throw new NotificationError("Failed to persist the provisioned Channel Account")
+  if (!account) throw new NotificationError("Failed to activate the provisioned Channel Account")
   return account
 }
 
@@ -251,6 +282,29 @@ export async function reconcileNotificationDeliveryEvent(
       })
       .onConflictDoNothing()
       .returning()
+
+    if (inserted.length === 0) {
+      const [replayed] = await transaction
+        .select()
+        .from(notificationDeliveryEvents)
+        .where(
+          and(
+            eq(notificationDeliveryEvents.adapterRef, event.adapterRef),
+            eq(notificationDeliveryEvents.adapterEventId, event.adapterEventId),
+          ),
+        )
+        .limit(1)
+      const canonical = event.details?.canonicalPayload
+      if (
+        !replayed ||
+        replayed.deliveryId !== event.deliveryId ||
+        replayed.status !== event.status ||
+        replayed.occurredAt.toISOString() !== event.occurredAt.toISOString() ||
+        (canonical !== undefined && replayed.details?.canonicalPayload !== canonical)
+      ) {
+        throw new NotificationError("Delivery lifecycle replay payload drift")
+      }
+    }
 
     const [latest] = await transaction
       .select()

--- a/packages/notifications/src/service-durable-send.ts
+++ b/packages/notifications/src/service-durable-send.ts
@@ -383,6 +383,7 @@ export async function enqueueNotification({
     provider: providerName,
     template: template?.slug ?? input.templateSlug ?? "direct",
     data,
+    ...(input.purpose ? { purpose: input.purpose } : {}),
     ...(fromAddress ? { from: fromAddress } : {}),
     ...(subject ? { subject } : {}),
     ...(html ? { html } : {}),
@@ -1054,6 +1055,7 @@ function notificationPayload(value: Record<string, unknown>): NotificationPayloa
   const subject = optionalPayloadString(value, "subject")
   const html = optionalPayloadString(value, "html")
   const text = optionalPayloadString(value, "text")
+  const purpose = optionalPayloadString(value, "purpose")
   const attachments = notificationAttachments(value.attachments)
   return {
     to,
@@ -1065,6 +1067,7 @@ function notificationPayload(value: Record<string, unknown>): NotificationPayloa
     ...(subject ? { subject } : {}),
     ...(html ? { html } : {}),
     ...(text ? { text } : {}),
+    ...(purpose ? { purpose } : {}),
     ...(attachments ? { attachments } : {}),
   }
 }

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -113,6 +113,8 @@ export interface ChannelAccountAdapterCapability {
   matches(adapterRef: string): boolean
   provision(draft: ChannelAccountDraft): Promise<ProvisionedChannelAccount>
   validate(adapterRef: string): Promise<ValidatedChannelAccount>
+  /** Bind the committed host row id before inbound activation. */
+  activate?(input: { channelAccountId: string; adapterRef: string }): Promise<void> | void
 }
 
 /**
@@ -128,6 +130,8 @@ export interface NotificationPayload {
   provider?: string
   /** Template identifier — interpretation is provider-specific. */
   template: string
+  /** Domain-authoritative delivery purpose when admission supplied one. */
+  purpose?: string
   /** Data passed to the template for rendering. */
   data?: unknown
   /** Optional sender override. Providers may have their own defaults. */

--- a/packages/notifications/src/voyant.ts
+++ b/packages/notifications/src/voyant.ts
@@ -17,6 +17,7 @@ import { financeNotificationsRuntimePort } from "@voyant-travel/finance/runtime-
 import { customerVerificationRuntimePort } from "@voyant-travel/identity/runtime-port"
 import { proposalsNotificationsRuntimePort } from "@voyant-travel/proposals/runtime-port"
 import { relationshipsPersonNotificationsRuntimePort } from "@voyant-travel/relationships/runtime-port"
+import { notificationDeliveryLifecycleSourcePort } from "./delivery-lifecycle-source-port.js"
 import { durableNotificationProviderPort } from "./durable-provider-port.js"
 import { bookingDocumentsSentEventPayloadSchema } from "./event-payload-schemas.js"
 import { notificationsReminderJobRuntimePort } from "./reminder-job-runtime-port.js"
@@ -33,6 +34,7 @@ export const notificationsVoyantModule = defineModule({
     requirePort(notificationsRuntimePort),
     requirePort(notificationsReminderJobRuntimePort),
     requirePort(durableNotificationProviderPort, { optional: true }),
+    requirePort(notificationDeliveryLifecycleSourcePort, { optional: true, cardinality: "many" }),
     requirePort(bookingActionProjectionRuntimePort, { optional: true }),
     requirePort(bookingActionSourceRuntimePort, { optional: true, cardinality: "many" }),
   ],
@@ -126,6 +128,23 @@ export const notificationsVoyantModule = defineModule({
     },
   ],
   jobs: [
+    {
+      id: "notifications.reconcile-delivery-lifecycle",
+      schedule: { cron: "* * * * *", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          eager: { cron: "* * * * *", overlap: "skip" },
+          economical: { cron: "*/5 * * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
+        },
+      },
+      wakeup: true,
+      runtime: {
+        entry: "@voyant-travel/notifications/delivery-lifecycle-job",
+        export: "runNotificationDeliveryLifecycleJob",
+      },
+    },
     {
       id: "notifications.deliver-durable-sends",
       schedule: { cron: "* * * * *", overlap: "skip" },

--- a/packages/notifications/tests/integration/channel-accounts.test.ts
+++ b/packages/notifications/tests/integration/channel-accounts.test.ts
@@ -13,6 +13,7 @@ import {
   admitRenderedServiceMessage,
   provisionChannelAccount,
   reconcileNotificationDeliveryEvent,
+  updateChannelAccountLifecycle,
 } from "../../src/service-channel-accounts.js"
 import {
   getOutboundSmsState,
@@ -244,6 +245,37 @@ describe.skipIf(!DB_AVAILABLE)("Channel Account rendered delivery", () => {
     ).rejects.toThrow("unambiguous")
     expect(await context.db.select().from(notificationChannelAccounts)).toHaveLength(0)
     inboundIdentity = "unambiguous"
+  })
+
+  it("rejects provisioning replay drift and never reactivates an archived account", async () => {
+    const draft = {
+      channel: "email" as const,
+      address: "replay@example.test",
+      displayName: "Replay inbox",
+      allowedPurposes: ["conversation-reply"],
+      inboundCapable: true,
+      outboundCapable: true,
+    }
+    const account = await provisionChannelAccount(context.db, adapter, draft)
+    await expect(
+      provisionChannelAccount(context.db, adapter, {
+        ...draft,
+        allowedPurposes: ["marketing"],
+      }),
+    ).rejects.toThrow(/payload drift/)
+    await expect(
+      provisionChannelAccount(context.db, adapter, { ...draft, inboundCapable: false }),
+    ).rejects.toThrow(/payload drift/)
+    await updateChannelAccountLifecycle(context.db, account.id, "archived")
+    await expect(provisionChannelAccount(context.db, adapter, draft)).rejects.toThrow(
+      /cannot reactivate/,
+    )
+    const disabledDraft = { ...draft, address: "disabled-replay@example.test" }
+    const disabled = await provisionChannelAccount(context.db, adapter, disabledDraft)
+    await updateChannelAccountLifecycle(context.db, disabled.id, "disabled")
+    await expect(provisionChannelAccount(context.db, adapter, disabledDraft)).rejects.toThrow(
+      /cannot reactivate/,
+    )
   })
 
   it("enforces account-scoped hard opt-out for staff and automated SMS until a newer opt-in", async () => {

--- a/packages/notifications/tests/unit/voyant-manifest.test.ts
+++ b/packages/notifications/tests/unit/voyant-manifest.test.ts
@@ -45,6 +45,11 @@ describe("notifications deployment manifest", () => {
           optional: true,
           conformance: expect.any(Object),
         },
+        {
+          id: "notifications.delivery-lifecycle-source",
+          optional: true,
+          cardinality: "many",
+        },
         { id: "bookings.booking-action-projection.runtime", optional: true },
         {
           id: "bookings.booking-action-source.runtime",
@@ -67,6 +72,23 @@ describe("notifications deployment manifest", () => {
       schema: [{ id: "@voyant-travel/notifications#schema" }],
       migrations: [{ id: "@voyant-travel/notifications#migrations" }],
       jobs: [
+        {
+          id: "notifications.reconcile-delivery-lifecycle",
+          schedule: { cron: "* * * * *", overlap: "skip" },
+          scheduling: {
+            required: true,
+            profiles: {
+              eager: { cron: "* * * * *", overlap: "skip" },
+              economical: { cron: "*/5 * * * *", overlap: "skip" },
+              "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
+            },
+          },
+          wakeup: true,
+          runtime: {
+            entry: "@voyant-travel/notifications/delivery-lifecycle-job",
+            export: "runNotificationDeliveryLifecycleJob",
+          },
+        },
         {
           id: "notifications.deliver-durable-sends",
           schedule: { cron: "* * * * *", overlap: "skip" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1906,6 +1906,22 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
 
+  packages/channel-adapter-contracts:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@voyant-travel/voyant-typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+
   packages/charters:
     dependencies:
       '@hono/zod-openapi':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2176,6 +2176,34 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
 
+  packages/communications-adapter-runtime:
+    dependencies:
+      '@voyant-travel/channel-adapter-contracts':
+        specifier: workspace:^
+        version: link:../channel-adapter-contracts
+      '@voyant-travel/conversations':
+        specifier: workspace:^
+        version: link:../conversations
+      '@voyant-travel/conversations-contracts':
+        specifier: workspace:^
+        version: link:../conversations-contracts
+      '@voyant-travel/core':
+        specifier: workspace:^
+        version: link:../core
+      '@voyant-travel/notifications':
+        specifier: workspace:^
+        version: link:../notifications
+    devDependencies:
+      '@voyant-travel/voyant-typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+
   packages/conversations:
     dependencies:
       '@hono/zod-openapi':
@@ -4324,6 +4352,9 @@ importers:
       '@voyant-travel/bookings':
         specifier: workspace:^
         version: link:../bookings
+      '@voyant-travel/channel-adapter-contracts':
+        specifier: workspace:^
+        version: link:../channel-adapter-contracts
       '@voyant-travel/conversations':
         specifier: workspace:^
         version: link:../conversations

--- a/scripts/checks/manifests/public-surface.json
+++ b/scripts/checks/manifests/public-surface.json
@@ -14,6 +14,7 @@
   "extensionSurface": [
     "@voyant-travel/admin-extension-sdk",
     "@voyant-travel/app-manifest",
+    "@voyant-travel/channel-adapter-contracts",
     "@voyant-travel/conversations-contracts",
     "@voyant-travel/custom-fields-contracts",
     "@voyant-travel/graph-contracts",

--- a/scripts/verify-package-exports.ts
+++ b/scripts/verify-package-exports.ts
@@ -34,6 +34,41 @@ const financeContractsPaymentValidationExports = [
 
 const checks: ExportCheck[] = [
   {
+    packageName: "@voyant-travel/channel-adapter-contracts",
+    entry: "packages/channel-adapter-contracts/dist/index.js",
+    requiredExports: [
+      "CHANNEL_ADAPTER_PROTOCOL_VERSION",
+      "channelAdapterDescriptorSchema",
+      "inboundEnvelopeSchema",
+      "outboundMessageSchema",
+      "validateChannelAdapter",
+      "negotiateChannelAdapter",
+    ],
+  },
+  {
+    packageName: "@voyant-travel/channel-adapter-contracts/conformance",
+    entry: "packages/channel-adapter-contracts/dist/conformance.js",
+    requiredExports: [
+      "AdapterPayloadDriftError",
+      "AdapterReplayLedger",
+      "runChannelAdapterConformance",
+    ],
+  },
+  {
+    packageName: "@voyant-travel/channel-adapter-contracts/v1",
+    entry: "packages/channel-adapter-contracts/dist/v1.js",
+    requiredExports: [
+      "CHANNEL_ADAPTER_PROTOCOL_VERSION",
+      "channelAdapterDescriptorSchema",
+      "validateChannelAdapter",
+    ],
+  },
+  {
+    packageName: "@voyant-travel/channel-adapter-contracts/testing",
+    entry: "packages/channel-adapter-contracts/dist/testing.js",
+    requiredExports: ["FixtureChannelAdapter", "createFixtureChannelAdapterControl"],
+  },
+  {
     packageName: "@voyant-travel/storage",
     entry: "packages/storage/dist/index.js",
     requiredExports: [


### PR DESCRIPTION
## Summary

Publishes the provider-neutral custom channel adapter contract and adds the private deployment bridge that connects a selected adapter bundle to Notifications and Conversations.

- requires two-way email and SMS capabilities for selected Inbox accounts
- streams durable inbound list/fetch/ack and normalized lifecycle reconciliation
- evaluates adapter policy before outbound submission
- keeps credentials and deployment configuration outside domain DTOs and admin APIs
- ships deterministic email and SMS fixture flows plus reusable conformance tests

## Verification

- channel adapter contracts: typecheck, lint, 9 tests
- communications adapter runtime: typecheck, lint, 6 tests
- Notifications manifest contract: 4 tests
- public surface and graph conformance
- frozen workspace install
- provider-name scan of added OSS lines

Database-backed lifecycle tests remain environment-gated when no test database is configured.

Closes #4831