### PR TITLE
Generate eighteen more documents, and let a document have two generators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,12 @@ jobs:
   architecture:
     name: architecture
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    # `verify:architecture` has grown from 62 chain links to 102, and two of them
+    # drive the real OpenAPI generators. At 10 minutes the job started being
+    # CANCELLED rather than failing, which the `checks` and `db-checks`
+    # aggregates then render as a red X with no failing step under it — main
+    # itself went red that way and read as a flake for two runs.
+    timeout-minutes: 25
     env:
       HUSKY: 0
       NODE_OPTIONS: --conditions=development --max-old-space-size=12288

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "verify:route-conformance": "node --import tsx --test scripts/tests/route-conformance.test.mjs && tsx scripts/checks/routes/index.ts",
     "verify:analytics-conformance": "node --import tsx --test scripts/tests/analytics-conformance.test.mjs && tsx scripts/checks/analytics/index.ts",
     "verify:openapi-key-kind": "pnpm --filter operator prepare:verify && node --test scripts/tests/openapi-key-kind-authority.test.mjs && node scripts/check-openapi-key-kind-authority.mjs",
-    "verify:openapi-drift": "node --test scripts/tests/openapi-drift.test.mjs && node scripts/checks/openapi/index.mjs",
+    "verify:openapi-drift": "node --test scripts/tests/openapi-drift.test.mjs scripts/tests/openapi-generator-groups.test.mjs && node scripts/checks/openapi/index.mjs",
     "verify:ref-mirrors": "node --import tsx --test scripts/tests/ref-mirrors.test.mjs && tsx scripts/checks/schema/index.ts",
     "verify:cross-package-fk": "node --import tsx --test scripts/tests/cross-package-fk.test.mjs && tsx scripts/checks/schema/cross-package-fk-runner.ts",
     "verify:typecheck-coverage": "node --test scripts/tests/typecheck-coverage.test.mjs && node scripts/checks/typecheck/index.mjs",

--- a/packages/accommodations/openapi/public-api/accommodations-content-public.json
+++ b/packages/accommodations/openapi/public-api/accommodations-content-public.json
@@ -18,7 +18,6 @@
   "paths": {
     "/v1/public/accommodations/properties/{id}/effective": {
       "get": {
-        "x-voyant-api-id": "@voyant-travel/accommodations#content-extension.api.public",
         "parameters": [
           {
             "schema": {
@@ -126,7 +125,8 @@
                               "type": ["string", "null"]
                             },
                             "hero_image_url": {
-                              "type": ["string", "null"]
+                              "type": ["string", "null"],
+                              "format": "uri"
                             },
                             "gallery": {
                               "type": "array",
@@ -216,13 +216,18 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getPublicAccommodationsPropertiesByIdEffective",
+        "summary": "GET /v1/public/accommodations/properties/{id}/effective",
+        "tags": ["accommodations"],
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "public-api",
+        "x-voyant-api-id": "@voyant-travel/accommodations#content-extension.api.public"
       }
     },
     "/v1/public/accommodations/{id}/content": {
       "get": {
         "summary": "Get accommodation content",
-        "x-voyant-api-id": "@voyant-travel/accommodations#content-extension.api.public",
         "responses": {
           "200": {
             "description": "Localized accommodation content and provenance."
@@ -230,7 +235,12 @@
           "404": {
             "description": "Accommodation content was not found."
           }
-        }
+        },
+        "operationId": "getPublicAccommodationsByIdContent",
+        "tags": ["accommodations"],
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "public-api",
+        "x-voyant-api-id": "@voyant-travel/accommodations#content-extension.api.public"
       }
     }
   },

--- a/packages/accommodations/package.json
+++ b/packages/accommodations/package.json
@@ -34,7 +34,7 @@
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=accommodations_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
-    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && biome format --write openapi/admin/accommodations.json",
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && node --import tsx scripts/generate-public-openapi.ts && biome format --write openapi/admin/accommodations.json openapi/public-api/accommodations-content-public.json",
     "lint": "biome check src/",
     "prepack": "pnpm run build",
     "test": "vitest run",

--- a/packages/accommodations/scripts/generate-public-openapi.ts
+++ b/packages/accommodations/scripts/generate-public-openapi.ts
@@ -1,0 +1,112 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createAccommodationContentRoutes } from "../src/routes-content.js"
+
+const PREFIX = "/v1/public/accommodations"
+const MODULE = "accommodations"
+const artifactPath = resolve(
+  import.meta.dirname,
+  "..",
+  "openapi/public-api/accommodations-content-public.json",
+)
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+/**
+ * Runtime concerns that never reach the document — the schemas come from static
+ * route definitions. The public surface registers no editorial-overlay legs, so
+ * the write gate stays off here.
+ */
+const NEVER_RUN = { resolveRegistry: () => ({}) } as never
+
+const live = createAccommodationContentRoutes(NEVER_RUN).getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+// Metadata the route declared itself, captured before stamping fills in
+// derived placeholders for anything it left out.
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+// Precedence: what the ROUTE declared, then what the document already said,
+// then what `stampModuleMetadata` derived.
+//
+// The derived values are placeholders — a summary of "GET /v1/admin/apps" where
+// a human wrote "List app registrations" — so they must not beat curated prose.
+// But copying the committed value unconditionally is worse: a route that changes
+// its own `operationId`, `summary`, `tags` or `x-voyant-api-id` would have the
+// change silently reverted, and `verify:openapi-drift` would then reproduce the
+// stale contract forever. So the route wins whenever it actually said something.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/admin-api-client/src/generated/catalog.ts
+++ b/packages/admin-api-client/src/generated/catalog.ts
@@ -4,23 +4,6 @@
  */
 
 export interface paths {
-  "/v1/admin/catalog/search": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** POST /v1/admin/catalog/search */
-    post: operations["postAdminCatalogSearch"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   "/v1/admin/catalog/package-offers": {
     parameters: {
       query?: never
@@ -123,6 +106,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/v1/admin/catalog/search": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** POST /v1/admin/catalog/search */
+    post: operations["postAdminCatalogSearch"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
 }
 export type webhooks = Record<string, never>
 export interface components {
@@ -166,175 +166,6 @@ export interface components {
 }
 export type $defs = Record<string, never>
 export interface operations {
-  postAdminCatalogSearch: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": {
-          vertical?: string
-          query?: string
-          /** @enum {string} */
-          mode?: "keyword" | "semantic" | "hybrid"
-          /** @enum {string} */
-          sort?: "relevance" | "price-asc" | "price-desc" | "departure-asc" | "newest"
-          /** @enum {string} */
-          projection?: "raw" | "storefront-card"
-          filters?: components["schemas"]["CatalogSearchFilter"][]
-          facets?: {
-            field: string
-            limit?: number
-          }[]
-          pagination?: {
-            limit?: number
-            cursor?: string
-          }
-          alpha?: number
-          distance_threshold?: number
-          query_embedding?: number[]
-          market?: string
-          locale?: string
-          channel?: string
-        }
-      }
-    }
-    responses: {
-      /** @description Search results for the requested vertical slice */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": {
-            vertical: string
-            /** @enum {string} */
-            mode: "keyword" | "semantic" | "hybrid"
-            total: number
-            /** @enum {string} */
-            totalRelation?: "eq" | "gte"
-            next_cursor?: string
-            hits: {
-              id: string
-              score: number
-              document: {
-                id: string
-                fields: {
-                  [key: string]: unknown
-                }
-                embeddings?: {
-                  [key: string]: number[]
-                }
-                embedding_model_id?: string
-              }
-            }[]
-            cards?: {
-              id: string
-              name: string | null
-              slug: string | null
-              primaryCategory: {
-                id: string | null
-                name: string | null
-                slug: string | null
-              } | null
-              media: {
-                thumbnailUrl: string | null
-                coverMediaUrl: string | null
-              }
-              priceFrom: {
-                amountCents: number
-                currency: string | null
-                originalAmountCents: number | null
-              } | null
-              offerBadges: {
-                id: string | null
-                name: string | null
-                discountKind: string | null
-                discountPercent: number | null
-                discountAmountCents: number | null
-                minPax?: number | null
-              }[]
-              departures: {
-                upcomingCount: number | null
-                nextDepartureAt: string | null
-                nextDepartureDate: string | null
-                nextDepartureEndsAt: string | null
-                nextDepartureEndDate: string | null
-                timezone: string | null
-                months: string[]
-                dates: string[]
-              }
-              destinations: {
-                regions: string[]
-                countries: string[]
-                cities: string[]
-                ids: string[]
-                slugs: string[]
-              }
-              coordinates: {
-                latitude: number
-                longitude: number
-              } | null
-            }[]
-            facets: {
-              [key: string]: {
-                value: string | number
-                count: number
-              }[]
-            }
-          }
-        }
-      }
-      /** @description invalid_request — body failed validation, `vertical` is missing, or `vertical` names a product-owned vertical that is never independently sellable */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": {
-            error: string
-            /** @constant */
-            reason?: "not_independently_sellable"
-            vertical?: string
-            ownedBy?: string
-          }
-        }
-      }
-      /** @description Search execution failed */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": {
-            error: string
-            /** @constant */
-            reason?: "not_independently_sellable"
-            vertical?: string
-            ownedBy?: string
-          }
-        }
-      }
-      /** @description Search indexer is not configured for this deployment */
-      503: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": {
-            error: string
-            /** @constant */
-            reason?: "not_independently_sellable"
-            vertical?: string
-            ownedBy?: string
-          }
-        }
-      }
-    }
-  }
   postAdminCatalogPackageOffers: {
     parameters: {
       query?: never
@@ -574,6 +405,190 @@ export interface operations {
           "application/json": {
             error: string
             details?: unknown
+          }
+        }
+      }
+    }
+  }
+  postAdminCatalogSearch: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          vertical?: string
+          query?: string
+          /** @enum {string} */
+          mode?: "keyword" | "semantic" | "hybrid"
+          /** @enum {string} */
+          sort?: "relevance" | "price-asc" | "price-desc" | "departure-asc" | "newest"
+          /** @enum {string} */
+          projection?: "raw" | "storefront-card"
+          filters?: components["schemas"]["CatalogSearchFilter"][]
+          facets?: {
+            field: string
+            limit?: number
+          }[]
+          pagination?: {
+            limit?: number
+            cursor?: string
+          }
+          alpha?: number
+          distance_threshold?: number
+          query_embedding?: number[]
+          market?: string
+          locale?: string
+          channel?: string
+        }
+      }
+    }
+    responses: {
+      /** @description Search results for the requested vertical slice */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            vertical: string
+            /** @enum {string} */
+            mode: "keyword" | "semantic" | "hybrid"
+            total: number
+            /** @enum {string} */
+            totalRelation?: "eq" | "gte"
+            next_cursor?: string
+            hits: {
+              id: string
+              score: number
+              document: {
+                id: string
+                fields: {
+                  [key: string]: unknown
+                }
+                embeddings?: {
+                  [key: string]: number[]
+                }
+                embedding_model_id?: string
+              }
+            }[]
+            cards?: {
+              id: string
+              name: string | null
+              slug: string | null
+              primaryCategory: {
+                id: string | null
+                name: string | null
+                slug: string | null
+              } | null
+              media: {
+                thumbnailUrl: string | null
+                coverMediaUrl: string | null
+              }
+              priceFrom: {
+                amountCents: number
+                currency: string | null
+                originalAmountCents: number | null
+              } | null
+              offerBadges: {
+                id: string | null
+                name: string | null
+                discountKind: string | null
+                discountPercent: number | null
+                discountAmountCents: number | null
+                minPax?: number | null
+              }[]
+              departures: {
+                upcomingCount: number | null
+                nextDepartureAt: string | null
+                nextDepartureDate: string | null
+                nextDepartureEndsAt: string | null
+                nextDepartureEndDate: string | null
+                timezone: string | null
+                months: string[]
+                dates: string[]
+              }
+              destinations: {
+                regions: string[]
+                countries: string[]
+                cities: string[]
+                ids: string[]
+                slugs: string[]
+              }
+              coordinates: {
+                latitude: number
+                longitude: number
+              } | null
+            }[]
+            facets: {
+              [key: string]: {
+                value: string | number
+                count: number
+              }[]
+            }
+          }
+        }
+      }
+      /** @description invalid_request — body failed validation, `vertical` is missing, or `vertical` names a product-owned vertical that is never independently sellable */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+            /** @enum {string} */
+            reason?: "not_independently_sellable"
+            vertical?: string
+            ownedBy?: string
+          }
+        }
+      }
+      /** @description Public storefront channel context is missing or inactive */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+            /** @enum {string} */
+            reason?: "not_independently_sellable"
+            vertical?: string
+            ownedBy?: string
+          }
+        }
+      }
+      /** @description Search execution failed */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+            /** @enum {string} */
+            reason?: "not_independently_sellable"
+            vertical?: string
+            ownedBy?: string
+          }
+        }
+      }
+      /** @description Search indexer is not configured for this deployment */
+      503: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+            /** @enum {string} */
+            reason?: "not_independently_sellable"
+            vertical?: string
+            ownedBy?: string
           }
         }
       }

--- a/packages/admin-api-client/src/generated/customer-accounts.ts
+++ b/packages/admin-api-client/src/generated/customer-accounts.ts
@@ -11,6 +11,7 @@ export interface paths {
       path?: never
       cookie?: never
     }
+    /** GET /v1/admin/customer-accounts/capabilities */
     get: operations["getCustomerAccountCapabilities"]
     put?: never
     post?: never
@@ -27,6 +28,7 @@ export interface paths {
       path?: never
       cookie?: never
     }
+    /** GET /v1/admin/customer-accounts/settings */
     get: operations["getCustomerAccountSettings"]
     put?: never
     post?: never
@@ -44,6 +46,7 @@ export interface paths {
       cookie?: never
     }
     get?: never
+    /** PUT /v1/admin/customer-accounts/settings/methods */
     put: operations["updateCustomerAuthMethods"]
     post?: never
     delete?: never
@@ -60,6 +63,7 @@ export interface paths {
       cookie?: never
     }
     get?: never
+    /** PUT /v1/admin/customer-accounts/settings/account-policy */
     put: operations["updateCustomerAccountPolicy"]
     post?: never
     delete?: never
@@ -75,6 +79,7 @@ export interface paths {
       path?: never
       cookie?: never
     }
+    /** GET /v1/admin/customer-accounts/provider-credentials */
     get: operations["listCustomerProviderCredentials"]
     put?: never
     post?: never
@@ -92,8 +97,10 @@ export interface paths {
       cookie?: never
     }
     get?: never
+    /** PUT /v1/admin/customer-accounts/provider-credentials/{provider} */
     put: operations["putCustomerProviderCredential"]
     post?: never
+    /** DELETE /v1/admin/customer-accounts/provider-credentials/{provider} */
     delete: operations["deleteCustomerProviderCredential"]
     options?: never
     head?: never
@@ -121,8 +128,22 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description Customer-account capabilities for this deployment. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
         headers: {
           [name: string]: unknown
         }
@@ -139,8 +160,22 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description Deployment customer-account settings. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
         headers: {
           [name: string]: unknown
         }
@@ -155,10 +190,43 @@ export interface operations {
       path?: never
       cookie?: never
     }
-    requestBody?: never
+    requestBody: {
+      content: {
+        "application/json": {
+          methods: {
+            emailCode: boolean
+            emailPassword: boolean
+            google: boolean
+            facebook: boolean
+            apple: boolean
+          }
+        }
+      }
+    }
     responses: {
-      /** @description Updated sign-in methods. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 400 */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
         headers: {
           [name: string]: unknown
         }
@@ -173,10 +241,43 @@ export interface operations {
       path?: never
       cookie?: never
     }
-    requestBody?: never
+    requestBody: {
+      content: {
+        "application/json": {
+          accountPolicy: {
+            allowedKinds: ("personal" | "business")[]
+            /** @enum {string} */
+            personalSignup: "open" | "disabled"
+            /** @enum {string} */
+            businessOnboarding: "disabled" | "open" | "request" | "invite-only"
+          }
+        }
+      }
+    }
     responses: {
-      /** @description Updated buyer-account policy. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 400 */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
         headers: {
           [name: string]: unknown
         }
@@ -193,8 +294,22 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description Provider credential status, never the secrets. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
         headers: {
           [name: string]: unknown
         }
@@ -206,13 +321,44 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        provider: "google" | "facebook" | "apple"
+      }
       cookie?: never
     }
-    requestBody?: never
+    requestBody: {
+      content: {
+        "application/json": {
+          credentials: {
+            [key: string]: unknown
+          }
+        }
+      }
+    }
     responses: {
-      /** @description Credential stored. */
+      /** @description HTTP 204 */
       204: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 400 */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
         headers: {
           [name: string]: unknown
         }
@@ -224,13 +370,36 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        provider: "google" | "facebook" | "apple"
+      }
       cookie?: never
     }
     requestBody?: never
     responses: {
-      /** @description Credential removed. */
+      /** @description HTTP 204 */
       204: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 400 */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
         headers: {
           [name: string]: unknown
         }

--- a/packages/admin-api-client/src/generated/customer-business-accounts.ts
+++ b/packages/admin-api-client/src/generated/customer-business-accounts.ts
@@ -11,6 +11,7 @@ export interface paths {
       path?: never
       cookie?: never
     }
+    /** GET /v1/admin/customer-business-accounts/capabilities */
     get: operations["getCustomerBusinessAccountCapabilities"]
     put?: never
     post?: never
@@ -27,6 +28,7 @@ export interface paths {
       path?: never
       cookie?: never
     }
+    /** GET /v1/admin/customer-business-accounts/requests */
     get: operations["listCustomerBusinessAccountRequests"]
     put?: never
     post?: never
@@ -45,6 +47,7 @@ export interface paths {
     }
     get?: never
     put?: never
+    /** POST /v1/admin/customer-business-accounts/requests/{requestId}/approve */
     post: operations["approveCustomerBusinessAccountRequest"]
     delete?: never
     options?: never
@@ -61,6 +64,7 @@ export interface paths {
     }
     get?: never
     put?: never
+    /** POST /v1/admin/customer-business-accounts/requests/{requestId}/reject */
     post: operations["rejectCustomerBusinessAccountRequest"]
     delete?: never
     options?: never
@@ -77,6 +81,7 @@ export interface paths {
     }
     get?: never
     put?: never
+    /** POST /v1/admin/customer-business-accounts/accounts */
     post: operations["provisionCustomerBusinessAccount"]
     delete?: never
     options?: never
@@ -112,11 +117,27 @@ export interface operations {
         }
         content?: never
       }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
     }
   }
   listCustomerBusinessAccountRequests: {
     parameters: {
-      query?: never
+      query?: {
+        status?: "pending" | "approved" | "rejected" | "canceled"
+      }
       header?: never
       path?: never
       cookie?: never
@@ -125,6 +146,20 @@ export interface operations {
     responses: {
       /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
         headers: {
           [name: string]: unknown
         }
@@ -136,13 +171,56 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        requestId: string
+      }
       cookie?: never
     }
-    requestBody?: never
+    requestBody: {
+      content: {
+        "application/json": {
+          reason?: string | null
+        }
+      }
+    }
     responses: {
       /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 400 */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 404 */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 409 */
+      409: {
         headers: {
           [name: string]: unknown
         }
@@ -154,13 +232,56 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        requestId: string
+      }
       cookie?: never
     }
-    requestBody?: never
+    requestBody: {
+      content: {
+        "application/json": {
+          reason?: string | null
+        }
+      }
+    }
     responses: {
       /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 400 */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 404 */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 409 */
+      409: {
         headers: {
           [name: string]: unknown
         }
@@ -175,10 +296,66 @@ export interface operations {
       path?: never
       cookie?: never
     }
-    requestBody?: never
+    requestBody: {
+      content: {
+        "application/json": {
+          idempotencyKey: string
+          /** Format: uri */
+          publicApiOrigin: string
+          owner: {
+            userId?: string
+            /** Format: email */
+            email?: string
+          }
+          relationshipOrganizationId?: string
+          profile?: {
+            name: string
+            legalName?: string | null
+            taxId?: string | null
+            /** Format: uri */
+            website?: string | null
+          }
+        }
+      }
+    }
     responses: {
       /** @description HTTP 201 */
       201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 400 */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 404 */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 409 */
+      409: {
         headers: {
           [name: string]: unknown
         }

--- a/packages/admin-api-client/src/generated/distribution-booking.ts
+++ b/packages/admin-api-client/src/generated/distribution-booking.ts
@@ -8,90 +8,16 @@ export interface paths {
     parameters: {
       query?: never
       header?: never
-      path: {
-        bookingId: string
-      }
+      path?: never
       cookie?: never
     }
     /** Get distribution details for a booking */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path: {
-          bookingId: string
-        }
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description Distribution details, or null when none are recorded */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content: {
-            "application/json": {
-              data: components["schemas"]["BookingDistributionDetails"]
-            }
-          }
-        }
-      }
-    }
+    get: operations["getAdminBookingsByBookingIdDistributionDetails"]
     /** Create or replace distribution details for a booking */
-    put: {
-      parameters: {
-        query?: never
-        header?: never
-        path: {
-          bookingId: string
-        }
-        cookie?: never
-      }
-      requestBody: {
-        content: {
-          "application/json": components["schemas"]["BookingDistributionDetailsInput"]
-        }
-      }
-      responses: {
-        /** @description Distribution details were stored */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content?: never
-        }
-      }
-    }
+    put: operations["putAdminBookingsByBookingIdDistributionDetails"]
     post?: never
     /** Remove distribution details from a booking */
-    delete: {
-      parameters: {
-        query?: never
-        header?: never
-        path: {
-          bookingId: string
-        }
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description Distribution details were removed */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content?: never
-        }
-        /** @description No distribution details exist for the booking */
-        404: {
-          headers: {
-            [name: string]: unknown
-          }
-          content?: never
-        }
-      }
-    }
+    delete: operations["deleteAdminBookingsByBookingIdDistributionDetails"]
     options?: never
     head?: never
     patch?: never
@@ -128,4 +54,120 @@ export interface components {
   pathItems: never
 }
 export type $defs = Record<string, never>
-export type operations = Record<string, never>
+export interface operations {
+  getAdminBookingsByBookingIdDistributionDetails: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        bookingId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Booking distribution details */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              bookingId: string
+              marketId: string | null
+              sourceChannelId: string | null
+              fxRateSetId: string | null
+              /** @enum {string} */
+              paymentOwner: "operator" | "channel" | "split"
+              createdAt: string
+              updatedAt: string
+            } | null
+          }
+        }
+      }
+    }
+  }
+  putAdminBookingsByBookingIdDistributionDetails: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        bookingId: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          marketId?: string | null
+          sourceChannelId?: string | null
+          fxRateSetId?: string | null
+          /**
+           * @default operator
+           * @enum {string}
+           */
+          paymentOwner?: "operator" | "channel" | "split"
+        }
+      }
+    }
+    responses: {
+      /** @description Updated booking distribution details */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            data: {
+              bookingId: string
+              marketId: string | null
+              sourceChannelId: string | null
+              fxRateSetId: string | null
+              /** @enum {string} */
+              paymentOwner: "operator" | "channel" | "split"
+              createdAt: string
+              updatedAt: string
+            } | null
+          }
+        }
+      }
+    }
+  }
+  deleteAdminBookingsByBookingIdDistributionDetails: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        bookingId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Booking distribution details deleted */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            /** @enum {boolean} */
+            success: true
+          }
+        }
+      }
+      /** @description Booking distribution details not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            error: string
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/admin-api-client/src/generated/invitations.ts
+++ b/packages/admin-api-client/src/generated/invitations.ts
@@ -60,14 +60,14 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description The most recent user invitations. */
+      /** @description HTTP 200 */
       200: {
         headers: {
           [name: string]: unknown
         }
         content?: never
       }
-      /** @description The caller is not a super administrator. */
+      /** @description HTTP 403 */
       403: {
         headers: {
           [name: string]: unknown
@@ -96,21 +96,21 @@ export interface operations {
       }
     }
     responses: {
-      /** @description The invitation and its acceptance URL. */
+      /** @description HTTP 200 */
       200: {
         headers: {
           [name: string]: unknown
         }
         content?: never
       }
-      /** @description The caller is not a super administrator. */
+      /** @description HTTP 403 */
       403: {
         headers: {
           [name: string]: unknown
         }
         content?: never
       }
-      /** @description A user already exists for the email address. */
+      /** @description HTTP 409 */
       409: {
         headers: {
           [name: string]: unknown
@@ -130,14 +130,14 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description The deleted invitation identifier. */
+      /** @description HTTP 200 */
       200: {
         headers: {
           [name: string]: unknown
         }
         content?: never
       }
-      /** @description The caller is not a super administrator. */
+      /** @description HTTP 403 */
       403: {
         headers: {
           [name: string]: unknown

--- a/packages/admin-api-client/src/generated/mcp.ts
+++ b/packages/admin-api-client/src/generated/mcp.ts
@@ -4,23 +4,6 @@
  */
 
 export interface paths {
-  "/v1/admin/mcp": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Send an MCP JSON-RPC request */
-    post: operations["callMcp"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   "/v1/admin/mcp/manifest": {
     parameters: {
       query?: never
@@ -32,6 +15,23 @@ export interface paths {
     get: operations["getMcpManifest"]
     put?: never
     post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/v1/admin/mcp": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Send an MCP JSON-RPC request */
+    post: operations["callMcp"]
     delete?: never
     options?: never
     head?: never
@@ -50,36 +50,6 @@ export interface components {
 }
 export type $defs = Record<string, never>
 export interface operations {
-  callMcp: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": {
-          /** @constant */
-          jsonrpc: "2.0"
-          id?: string | number | null
-          method: string
-          params?: {
-            [key: string]: unknown
-          }
-        }
-      }
-    }
-    responses: {
-      /** @description The MCP JSON-RPC response. */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
   getMcpManifest: {
     parameters: {
       query?: never
@@ -91,6 +61,43 @@ export interface operations {
     responses: {
       /** @description The contract-versioned tools visible to the caller. */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  callMcp: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": {
+          /** @enum {string} */
+          jsonrpc: "2.0"
+          id?: string | number | null
+          method: string
+          params?: {
+            [key: string]: unknown
+          }
+        }
+      }
+    }
+    responses: {
+      /** @description The MCP JSON-RPC response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description The MCP notification was accepted */
+      204: {
         headers: {
           [name: string]: unknown
         }

--- a/packages/admin-api-client/src/generated/proposal-version-snapshot.ts
+++ b/packages/admin-api-client/src/generated/proposal-version-snapshot.ts
@@ -14,41 +14,7 @@ export interface paths {
     get?: never
     put?: never
     /** Freeze a Trip snapshot into a Proposal Version */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path: {
-          envelopeId: string
-          proposalVersionId: string
-        }
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description The updated Proposal Version and frozen Trip snapshot. */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content?: never
-        }
-        /** @description The Trip or Proposal Version was not found. */
-        404: {
-          headers: {
-            [name: string]: unknown
-          }
-          content?: never
-        }
-        /** @description The Trip or Proposal Version cannot be snapshotted. */
-        409: {
-          headers: {
-            [name: string]: unknown
-          }
-          content?: never
-        }
-      }
-    }
+    post: operations["postAdminTripsByEnvelopeIdProposalVersionsByProposalVersionIdSnapshot"]
     delete?: never
     options?: never
     head?: never
@@ -66,4 +32,40 @@ export interface components {
   pathItems: never
 }
 export type $defs = Record<string, never>
-export type operations = Record<string, never>
+export interface operations {
+  postAdminTripsByEnvelopeIdProposalVersionsByProposalVersionIdSnapshot: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        envelopeId: string
+        proposalVersionId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description The updated Proposal Version and frozen Trip snapshot. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description The Trip or Proposal Version was not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description The Trip or Proposal Version cannot be snapshotted. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+}

--- a/packages/admin-api-client/src/generated/public-api-keys.ts
+++ b/packages/admin-api-client/src/generated/public-api-keys.ts
@@ -11,8 +11,10 @@ export interface paths {
       path?: never
       cookie?: never
     }
+    /** GET /v1/admin/public-api-keys/keys */
     get: operations["listPublicApiKeys"]
     put?: never
+    /** POST /v1/admin/public-api-keys/keys */
     post: operations["issuePublicApiKey"]
     delete?: never
     options?: never
@@ -27,12 +29,15 @@ export interface paths {
       path?: never
       cookie?: never
     }
+    /** GET /v1/admin/public-api-keys/keys/{keyId} */
     get: operations["getPublicApiKey"]
     put?: never
     post?: never
+    /** DELETE /v1/admin/public-api-keys/keys/{keyId} */
     delete: operations["revokePublicApiKey"]
     options?: never
     head?: never
+    /** PATCH /v1/admin/public-api-keys/keys/{keyId} */
     patch: operations["updatePublicApiKey"]
     trace?: never
   }
@@ -45,6 +50,7 @@ export interface paths {
     }
     get?: never
     put?: never
+    /** POST /v1/admin/public-api-keys/keys/{keyId}/rotate */
     post: operations["rotatePublicApiKey"]
     delete?: never
     options?: never
@@ -73,8 +79,22 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description Issued public API keys. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
         headers: {
           [name: string]: unknown
         }
@@ -89,10 +109,45 @@ export interface operations {
       path?: never
       cookie?: never
     }
-    requestBody?: never
+    requestBody: {
+      content: {
+        "application/json": {
+          /** @enum {string} */
+          kind: "publishable" | "secret"
+          name?: string | null
+          allowedOrigins?: string[]
+          channelId?: string | null
+          hostOnlyCookies?: boolean
+          scopes?: {
+            [key: string]: string[]
+          } | null
+        }
+      }
+    }
     responses: {
-      /** @description Issued key, including its plaintext token exactly once. */
+      /** @description HTTP 201 */
       201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 400 */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
         headers: {
           [name: string]: unknown
         }
@@ -104,13 +159,36 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        keyId: string
+      }
       cookie?: never
     }
     requestBody?: never
     responses: {
-      /** @description One public API key. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 404 */
+      404: {
         headers: {
           [name: string]: unknown
         }
@@ -122,13 +200,36 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        keyId: string
+      }
       cookie?: never
     }
     requestBody?: never
     responses: {
-      /** @description Key revoked. */
+      /** @description HTTP 204 */
       204: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 404 */
+      404: {
         headers: {
           [name: string]: unknown
         }
@@ -140,13 +241,55 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        keyId: string
+      }
       cookie?: never
     }
-    requestBody?: never
+    requestBody: {
+      content: {
+        "application/json": {
+          name?: string | null
+          allowedOrigins?: string[]
+          channelId?: string | null
+          hostOnlyCookies?: boolean
+          scopes?: {
+            [key: string]: string[]
+          } | null
+        }
+      }
+    }
     responses: {
-      /** @description Updated public API key. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 400 */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 404 */
+      404: {
         headers: {
           [name: string]: unknown
         }
@@ -158,13 +301,43 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        keyId: string
+      }
       cookie?: never
     }
     requestBody?: never
     responses: {
-      /** @description Rotated key, including its new plaintext token exactly once. */
+      /** @description HTTP 201 */
       201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 400 */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 404 */
+      404: {
         headers: {
           [name: string]: unknown
         }

--- a/packages/admin-api-client/src/generated/team.ts
+++ b/packages/admin-api-client/src/generated/team.ts
@@ -11,6 +11,7 @@ export interface paths {
       path?: never
       cookie?: never
     }
+    /** GET /v1/admin/team/capabilities */
     get: operations["getTeamManagementCapabilities"]
     put?: never
     post?: never
@@ -27,6 +28,7 @@ export interface paths {
       path?: never
       cookie?: never
     }
+    /** GET /v1/admin/team/members */
     get: operations["listTeamMembers"]
     put?: never
     post?: never
@@ -43,6 +45,7 @@ export interface paths {
       path?: never
       cookie?: never
     }
+    /** GET /v1/admin/team/roles */
     get: operations["listTeamRoles"]
     put?: never
     post?: never
@@ -59,8 +62,10 @@ export interface paths {
       path?: never
       cookie?: never
     }
+    /** GET /v1/admin/team/invitations */
     get: operations["listTeamInvitations"]
     put?: never
+    /** POST /v1/admin/team/invitations */
     post: operations["createTeamInvitation"]
     delete?: never
     options?: never
@@ -78,6 +83,7 @@ export interface paths {
     get?: never
     put?: never
     post?: never
+    /** DELETE /v1/admin/team/invitations/{invitationId} */
     delete: operations["revokeTeamInvitation"]
     options?: never
     head?: never
@@ -92,6 +98,7 @@ export interface paths {
       cookie?: never
     }
     get?: never
+    /** PUT /v1/admin/team/members/{memberId}/role */
     put: operations["updateTeamMemberRole"]
     post?: never
     delete?: never
@@ -110,6 +117,7 @@ export interface paths {
     get?: never
     put?: never
     post?: never
+    /** DELETE /v1/admin/team/members/{memberId} */
     delete: operations["deactivateTeamMember"]
     options?: never
     head?: never
@@ -124,6 +132,7 @@ export interface paths {
       cookie?: never
     }
     get?: never
+    /** PUT /v1/admin/team/members/{memberId}/activation */
     put: operations["activateTeamMember"]
     post?: never
     delete?: never
@@ -153,8 +162,29 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description Team-management capabilities. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 501 */
+      501: {
         headers: {
           [name: string]: unknown
         }
@@ -171,8 +201,29 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description Team members. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 501 */
+      501: {
         headers: {
           [name: string]: unknown
         }
@@ -189,8 +240,29 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description Available team roles. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 501 */
+      501: {
         headers: {
           [name: string]: unknown
         }
@@ -207,8 +279,29 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description Team invitations. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 501 */
+      501: {
         headers: {
           [name: string]: unknown
         }
@@ -234,8 +327,50 @@ export interface operations {
       }
     }
     responses: {
-      /** @description Created team invitation. */
+      /** @description HTTP 201 */
       201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 400 */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 404 */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 409 */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 501 */
+      501: {
         headers: {
           [name: string]: unknown
         }
@@ -254,8 +389,36 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description Invitation revoked. */
+      /** @description HTTP 204 */
       204: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 404 */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 501 */
+      501: {
         headers: {
           [name: string]: unknown
         }
@@ -280,8 +443,50 @@ export interface operations {
       }
     }
     responses: {
-      /** @description Updated team member. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 400 */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 404 */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 409 */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 501 */
+      501: {
         headers: {
           [name: string]: unknown
         }
@@ -300,8 +505,43 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description Deactivated team member. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 404 */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 409 */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 501 */
+      501: {
         headers: {
           [name: string]: unknown
         }
@@ -320,8 +560,43 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description Activated team member. */
+      /** @description HTTP 200 */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 401 */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 403 */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 404 */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 409 */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description HTTP 501 */
+      501: {
         headers: {
           [name: string]: unknown
         }

--- a/packages/auth/openapi/admin/customer-accounts.json
+++ b/packages/auth/openapi/admin/customer-accounts.json
@@ -8,83 +8,271 @@
     "/v1/admin/customer-accounts/capabilities": {
       "get": {
         "operationId": "getCustomerAccountCapabilities",
-        "tags": ["Customer accounts"],
         "x-voyant-api-id": "@voyant-travel/auth#customer-accounts.api.admin",
         "responses": {
           "200": {
-            "description": "Customer-account capabilities for this deployment."
+            "description": "HTTP 200"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
           }
-        }
+        },
+        "summary": "GET /v1/admin/customer-accounts/capabilities",
+        "tags": ["Customer accounts"],
+        "x-voyant-module": "customer-accounts",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/customer-accounts/settings": {
       "get": {
         "operationId": "getCustomerAccountSettings",
-        "tags": ["Customer accounts"],
         "x-voyant-api-id": "@voyant-travel/auth#customer-accounts.api.admin",
         "responses": {
           "200": {
-            "description": "Deployment customer-account settings."
+            "description": "HTTP 200"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
           }
-        }
+        },
+        "summary": "GET /v1/admin/customer-accounts/settings",
+        "tags": ["Customer accounts"],
+        "x-voyant-module": "customer-accounts",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/customer-accounts/settings/methods": {
       "put": {
         "operationId": "updateCustomerAuthMethods",
-        "tags": ["Customer accounts"],
         "x-voyant-api-id": "@voyant-travel/auth#customer-accounts.api.admin",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "methods": {
+                    "type": "object",
+                    "properties": {
+                      "emailCode": {
+                        "type": "boolean"
+                      },
+                      "emailPassword": {
+                        "type": "boolean"
+                      },
+                      "google": {
+                        "type": "boolean"
+                      },
+                      "facebook": {
+                        "type": "boolean"
+                      },
+                      "apple": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": ["emailCode", "emailPassword", "google", "facebook", "apple"],
+                    "additionalProperties": false
+                  }
+                },
+                "required": ["methods"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "Updated sign-in methods."
+            "description": "HTTP 200"
+          },
+          "400": {
+            "description": "HTTP 400"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
           }
-        }
+        },
+        "summary": "PUT /v1/admin/customer-accounts/settings/methods",
+        "tags": ["Customer accounts"],
+        "x-voyant-module": "customer-accounts",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/customer-accounts/settings/account-policy": {
       "put": {
         "operationId": "updateCustomerAccountPolicy",
-        "tags": ["Customer accounts"],
         "x-voyant-api-id": "@voyant-travel/auth#customer-accounts.api.admin",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "accountPolicy": {
+                    "type": "object",
+                    "properties": {
+                      "allowedKinds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": ["personal", "business"]
+                        },
+                        "minItems": 1
+                      },
+                      "personalSignup": {
+                        "type": "string",
+                        "enum": ["open", "disabled"]
+                      },
+                      "businessOnboarding": {
+                        "type": "string",
+                        "enum": ["disabled", "open", "request", "invite-only"]
+                      }
+                    },
+                    "required": ["allowedKinds", "personalSignup", "businessOnboarding"],
+                    "additionalProperties": false
+                  }
+                },
+                "required": ["accountPolicy"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "Updated buyer-account policy."
+            "description": "HTTP 200"
+          },
+          "400": {
+            "description": "HTTP 400"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
           }
-        }
+        },
+        "summary": "PUT /v1/admin/customer-accounts/settings/account-policy",
+        "tags": ["Customer accounts"],
+        "x-voyant-module": "customer-accounts",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/customer-accounts/provider-credentials": {
       "get": {
         "operationId": "listCustomerProviderCredentials",
-        "tags": ["Customer accounts"],
         "x-voyant-api-id": "@voyant-travel/auth#customer-accounts.api.admin",
         "responses": {
           "200": {
-            "description": "Provider credential status, never the secrets."
+            "description": "HTTP 200"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
           }
-        }
+        },
+        "summary": "GET /v1/admin/customer-accounts/provider-credentials",
+        "tags": ["Customer accounts"],
+        "x-voyant-module": "customer-accounts",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/customer-accounts/provider-credentials/{provider}": {
       "put": {
         "operationId": "putCustomerProviderCredential",
-        "tags": ["Customer accounts"],
         "x-voyant-api-id": "@voyant-travel/auth#customer-accounts.api.admin",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["google", "facebook", "apple"]
+            },
+            "required": true,
+            "name": "provider",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "credentials": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                },
+                "required": ["credentials"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
         "responses": {
           "204": {
-            "description": "Credential stored."
+            "description": "HTTP 204"
+          },
+          "400": {
+            "description": "HTTP 400"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
           }
-        }
+        },
+        "summary": "PUT /v1/admin/customer-accounts/provider-credentials/{provider}",
+        "tags": ["Customer accounts"],
+        "x-voyant-module": "customer-accounts",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "operationId": "deleteCustomerProviderCredential",
-        "tags": ["Customer accounts"],
         "x-voyant-api-id": "@voyant-travel/auth#customer-accounts.api.admin",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["google", "facebook", "apple"]
+            },
+            "required": true,
+            "name": "provider",
+            "in": "path"
+          }
+        ],
         "responses": {
           "204": {
-            "description": "Credential removed."
+            "description": "HTTP 204"
+          },
+          "400": {
+            "description": "HTTP 400"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
           }
-        }
+        },
+        "summary": "DELETE /v1/admin/customer-accounts/provider-credentials/{provider}",
+        "tags": ["Customer accounts"],
+        "x-voyant-module": "customer-accounts",
+        "x-voyant-surface": "admin"
       }
     }
   }

--- a/packages/auth/openapi/admin/customer-business-accounts.json
+++ b/packages/auth/openapi/admin/customer-business-accounts.json
@@ -9,35 +9,264 @@
       "get": {
         "operationId": "getCustomerBusinessAccountCapabilities",
         "x-voyant-api-id": "@voyant-travel/auth#customer-business-accounts.api.admin",
-        "responses": { "200": { "description": "HTTP 200" } }
+        "responses": {
+          "200": {
+            "description": "HTTP 200"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          }
+        },
+        "summary": "GET /v1/admin/customer-business-accounts/capabilities",
+        "tags": ["customer-business-accounts"],
+        "x-voyant-module": "customer-business-accounts",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/customer-business-accounts/requests": {
       "get": {
         "operationId": "listCustomerBusinessAccountRequests",
         "x-voyant-api-id": "@voyant-travel/auth#customer-business-accounts.api.admin",
-        "responses": { "200": { "description": "HTTP 200" } }
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["pending", "approved", "rejected", "canceled"]
+            },
+            "required": false,
+            "name": "status",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "HTTP 200"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          }
+        },
+        "summary": "GET /v1/admin/customer-business-accounts/requests",
+        "tags": ["customer-business-accounts"],
+        "x-voyant-module": "customer-business-accounts",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/customer-business-accounts/requests/{requestId}/approve": {
       "post": {
         "operationId": "approveCustomerBusinessAccountRequest",
         "x-voyant-api-id": "@voyant-travel/auth#customer-business-accounts.api.admin",
-        "responses": { "200": { "description": "HTTP 200" } }
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "requestId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": ["string", "null"],
+                    "minLength": 1,
+                    "maxLength": 2000
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "HTTP 200"
+          },
+          "400": {
+            "description": "HTTP 400"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "404": {
+            "description": "HTTP 404"
+          },
+          "409": {
+            "description": "HTTP 409"
+          }
+        },
+        "summary": "POST /v1/admin/customer-business-accounts/requests/{requestId}/approve",
+        "tags": ["customer-business-accounts"],
+        "x-voyant-module": "customer-business-accounts",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/customer-business-accounts/requests/{requestId}/reject": {
       "post": {
         "operationId": "rejectCustomerBusinessAccountRequest",
         "x-voyant-api-id": "@voyant-travel/auth#customer-business-accounts.api.admin",
-        "responses": { "200": { "description": "HTTP 200" } }
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "requestId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": ["string", "null"],
+                    "minLength": 1,
+                    "maxLength": 2000
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "HTTP 200"
+          },
+          "400": {
+            "description": "HTTP 400"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "404": {
+            "description": "HTTP 404"
+          },
+          "409": {
+            "description": "HTTP 409"
+          }
+        },
+        "summary": "POST /v1/admin/customer-business-accounts/requests/{requestId}/reject",
+        "tags": ["customer-business-accounts"],
+        "x-voyant-module": "customer-business-accounts",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/customer-business-accounts/accounts": {
       "post": {
         "operationId": "provisionCustomerBusinessAccount",
         "x-voyant-api-id": "@voyant-travel/auth#customer-business-accounts.api.admin",
-        "responses": { "201": { "description": "HTTP 201" } }
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "idempotencyKey": {
+                    "type": "string",
+                    "minLength": 8,
+                    "maxLength": 200
+                  },
+                  "publicApiOrigin": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "owner": {
+                    "type": "object",
+                    "properties": {
+                      "userId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "email": {
+                        "type": "string",
+                        "format": "email"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "relationshipOrganizationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "profile": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 200
+                      },
+                      "legalName": {
+                        "type": ["string", "null"]
+                      },
+                      "taxId": {
+                        "type": ["string", "null"]
+                      },
+                      "website": {
+                        "type": ["string", "null"],
+                        "format": "uri"
+                      }
+                    },
+                    "required": ["name"],
+                    "additionalProperties": false
+                  }
+                },
+                "required": ["idempotencyKey", "publicApiOrigin", "owner"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "HTTP 201"
+          },
+          "400": {
+            "description": "HTTP 400"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "404": {
+            "description": "HTTP 404"
+          },
+          "409": {
+            "description": "HTTP 409"
+          }
+        },
+        "summary": "POST /v1/admin/customer-business-accounts/accounts",
+        "tags": ["customer-business-accounts"],
+        "x-voyant-module": "customer-business-accounts",
+        "x-voyant-surface": "admin"
       }
     }
   }

--- a/packages/auth/openapi/admin/invitations.json
+++ b/packages/auth/openapi/admin/invitations.json
@@ -8,22 +8,22 @@
     "/v1/admin/invitations": {
       "get": {
         "operationId": "listAuthInvitations",
-        "summary": "List user invitations",
-        "tags": ["Auth invitations"],
         "x-voyant-api-id": "@voyant-travel/auth#invitations.api.admin",
         "responses": {
           "200": {
-            "description": "The most recent user invitations."
+            "description": "HTTP 200"
           },
           "403": {
-            "description": "The caller is not a super administrator."
+            "description": "HTTP 403"
           }
-        }
+        },
+        "summary": "List user invitations",
+        "tags": ["Auth invitations"],
+        "x-voyant-module": "auth",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "operationId": "createAuthInvitation",
-        "summary": "Create a user invitation",
-        "tags": ["Auth invitations"],
         "x-voyant-api-id": "@voyant-travel/auth#invitations.api.admin",
         "requestBody": {
           "required": true,
@@ -31,58 +31,69 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["email"],
                 "properties": {
-                  "email": { "type": "string", "format": "email" },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
                   "expiresInHours": {
                     "type": "integer",
-                    "minimum": 1,
+                    "exclusiveMinimum": 0,
                     "maximum": 720
                   },
                   "metadata": {
                     "type": "object",
-                    "additionalProperties": true
+                    "additionalProperties": {}
                   }
-                }
+                },
+                "required": ["email"]
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "The invitation and its acceptance URL."
+            "description": "HTTP 200"
           },
           "403": {
-            "description": "The caller is not a super administrator."
+            "description": "HTTP 403"
           },
           "409": {
-            "description": "A user already exists for the email address."
+            "description": "HTTP 409"
           }
-        }
+        },
+        "summary": "Create a user invitation",
+        "tags": ["Auth invitations"],
+        "x-voyant-module": "auth",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/invitations/{id}": {
       "delete": {
         "operationId": "deleteAuthInvitation",
-        "summary": "Delete a user invitation",
-        "tags": ["Auth invitations"],
         "x-voyant-api-id": "@voyant-travel/auth#invitations.api.admin",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
+            "schema": {
+              "type": "string"
+            },
             "required": true,
-            "schema": { "type": "string" }
+            "name": "id",
+            "in": "path"
           }
         ],
         "responses": {
           "200": {
-            "description": "The deleted invitation identifier."
+            "description": "HTTP 200"
           },
           "403": {
-            "description": "The caller is not a super administrator."
+            "description": "HTTP 403"
           }
-        }
+        },
+        "summary": "Delete a user invitation",
+        "tags": ["Auth invitations"],
+        "x-voyant-module": "invitations",
+        "x-voyant-surface": "admin"
       }
     }
   }

--- a/packages/auth/openapi/admin/public-api-keys.json
+++ b/packages/auth/openapi/admin/public-api-keys.json
@@ -8,67 +8,273 @@
     "/v1/admin/public-api-keys/keys": {
       "get": {
         "operationId": "listPublicApiKeys",
-        "tags": ["Public API"],
         "x-voyant-api-id": "@voyant-travel/auth#public-api-keys.api.admin",
         "responses": {
           "200": {
-            "description": "Issued public API keys."
+            "description": "HTTP 200"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
           }
-        }
+        },
+        "summary": "GET /v1/admin/public-api-keys/keys",
+        "tags": ["Public API"],
+        "x-voyant-module": "public-api-keys",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "operationId": "issuePublicApiKey",
-        "tags": ["Public API"],
         "x-voyant-api-id": "@voyant-travel/auth#public-api-keys.api.admin",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": ["publishable", "secret"]
+                  },
+                  "name": {
+                    "type": ["string", "null"],
+                    "minLength": 1,
+                    "maxLength": 120
+                  },
+                  "allowedOrigins": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 255
+                    },
+                    "maxItems": 50
+                  },
+                  "channelId": {
+                    "type": ["string", "null"],
+                    "minLength": 1
+                  },
+                  "hostOnlyCookies": {
+                    "type": "boolean"
+                  },
+                  "scopes": {
+                    "type": ["object", "null"],
+                    "additionalProperties": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "required": ["kind"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
         "responses": {
           "201": {
-            "description": "Issued key, including its plaintext token exactly once."
+            "description": "HTTP 201"
+          },
+          "400": {
+            "description": "HTTP 400"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
           }
-        }
+        },
+        "summary": "POST /v1/admin/public-api-keys/keys",
+        "tags": ["Public API"],
+        "x-voyant-module": "public-api-keys",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/public-api-keys/keys/{keyId}": {
       "get": {
         "operationId": "getPublicApiKey",
-        "tags": ["Public API"],
         "x-voyant-api-id": "@voyant-travel/auth#public-api-keys.api.admin",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "keyId",
+            "in": "path"
+          }
+        ],
         "responses": {
           "200": {
-            "description": "One public API key."
+            "description": "HTTP 200"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "404": {
+            "description": "HTTP 404"
           }
-        }
+        },
+        "summary": "GET /v1/admin/public-api-keys/keys/{keyId}",
+        "tags": ["Public API"],
+        "x-voyant-module": "public-api-keys",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "operationId": "updatePublicApiKey",
-        "tags": ["Public API"],
         "x-voyant-api-id": "@voyant-travel/auth#public-api-keys.api.admin",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "keyId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": ["string", "null"],
+                    "minLength": 1,
+                    "maxLength": 120
+                  },
+                  "allowedOrigins": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 255
+                    },
+                    "maxItems": 50
+                  },
+                  "channelId": {
+                    "type": ["string", "null"],
+                    "minLength": 1
+                  },
+                  "hostOnlyCookies": {
+                    "type": "boolean"
+                  },
+                  "scopes": {
+                    "type": ["object", "null"],
+                    "additionalProperties": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "Updated public API key."
+            "description": "HTTP 200"
+          },
+          "400": {
+            "description": "HTTP 400"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "404": {
+            "description": "HTTP 404"
           }
-        }
+        },
+        "summary": "PATCH /v1/admin/public-api-keys/keys/{keyId}",
+        "tags": ["Public API"],
+        "x-voyant-module": "public-api-keys",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "operationId": "revokePublicApiKey",
-        "tags": ["Public API"],
         "x-voyant-api-id": "@voyant-travel/auth#public-api-keys.api.admin",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "keyId",
+            "in": "path"
+          }
+        ],
         "responses": {
           "204": {
-            "description": "Key revoked."
+            "description": "HTTP 204"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "404": {
+            "description": "HTTP 404"
           }
-        }
+        },
+        "summary": "DELETE /v1/admin/public-api-keys/keys/{keyId}",
+        "tags": ["Public API"],
+        "x-voyant-module": "public-api-keys",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/public-api-keys/keys/{keyId}/rotate": {
       "post": {
         "operationId": "rotatePublicApiKey",
-        "tags": ["Public API"],
         "x-voyant-api-id": "@voyant-travel/auth#public-api-keys.api.admin",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "keyId",
+            "in": "path"
+          }
+        ],
         "responses": {
           "201": {
-            "description": "Rotated key, including its new plaintext token exactly once."
+            "description": "HTTP 201"
+          },
+          "400": {
+            "description": "HTTP 400"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "404": {
+            "description": "HTTP 404"
           }
-        }
+        },
+        "summary": "POST /v1/admin/public-api-keys/keys/{keyId}/rotate",
+        "tags": ["Public API"],
+        "x-voyant-module": "public-api-keys",
+        "x-voyant-surface": "admin"
       }
     }
   }

--- a/packages/auth/openapi/admin/team.json
+++ b/packages/auth/openapi/admin/team.json
@@ -8,37 +8,100 @@
     "/v1/admin/team/capabilities": {
       "get": {
         "operationId": "getTeamManagementCapabilities",
-        "tags": ["Team"],
         "x-voyant-api-id": "@voyant-travel/auth#team.api.admin",
-        "responses": { "200": { "description": "Team-management capabilities." } }
+        "responses": {
+          "200": {
+            "description": "HTTP 200"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "501": {
+            "description": "HTTP 501"
+          }
+        },
+        "summary": "GET /v1/admin/team/capabilities",
+        "tags": ["Team"],
+        "x-voyant-module": "team",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/team/members": {
       "get": {
         "operationId": "listTeamMembers",
-        "tags": ["Team"],
         "x-voyant-api-id": "@voyant-travel/auth#team.api.admin",
-        "responses": { "200": { "description": "Team members." } }
+        "responses": {
+          "200": {
+            "description": "HTTP 200"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "501": {
+            "description": "HTTP 501"
+          }
+        },
+        "summary": "GET /v1/admin/team/members",
+        "tags": ["Team"],
+        "x-voyant-module": "team",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/team/roles": {
       "get": {
         "operationId": "listTeamRoles",
-        "tags": ["Team"],
         "x-voyant-api-id": "@voyant-travel/auth#team.api.admin",
-        "responses": { "200": { "description": "Available team roles." } }
+        "responses": {
+          "200": {
+            "description": "HTTP 200"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "501": {
+            "description": "HTTP 501"
+          }
+        },
+        "summary": "GET /v1/admin/team/roles",
+        "tags": ["Team"],
+        "x-voyant-module": "team",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/team/invitations": {
       "get": {
         "operationId": "listTeamInvitations",
-        "tags": ["Team"],
         "x-voyant-api-id": "@voyant-travel/auth#team.api.admin",
-        "responses": { "200": { "description": "Team invitations." } }
+        "responses": {
+          "200": {
+            "description": "HTTP 200"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "501": {
+            "description": "HTTP 501"
+          }
+        },
+        "summary": "GET /v1/admin/team/invitations",
+        "tags": ["Team"],
+        "x-voyant-module": "team",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "operationId": "createTeamInvitation",
-        "tags": ["Team"],
         "x-voyant-api-id": "@voyant-travel/auth#team.api.admin",
         "requestBody": {
           "required": true,
@@ -46,46 +109,105 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["email", "roleId"],
                 "properties": {
-                  "email": { "type": "string", "format": "email" },
-                  "roleId": { "type": "string", "minLength": 1, "maxLength": 120 },
-                  "expiresInDays": { "type": "integer", "minimum": 1, "maximum": 30 }
-                }
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "roleId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                  },
+                  "expiresInDays": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 30
+                  }
+                },
+                "required": ["email", "roleId"]
               }
             }
           }
         },
-        "responses": { "201": { "description": "Created team invitation." } }
+        "responses": {
+          "201": {
+            "description": "HTTP 201"
+          },
+          "400": {
+            "description": "HTTP 400"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "404": {
+            "description": "HTTP 404"
+          },
+          "409": {
+            "description": "HTTP 409"
+          },
+          "501": {
+            "description": "HTTP 501"
+          }
+        },
+        "summary": "POST /v1/admin/team/invitations",
+        "tags": ["Team"],
+        "x-voyant-module": "team",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/team/invitations/{invitationId}": {
       "delete": {
         "operationId": "revokeTeamInvitation",
-        "tags": ["Team"],
         "x-voyant-api-id": "@voyant-travel/auth#team.api.admin",
         "parameters": [
           {
-            "name": "invitationId",
-            "in": "path",
+            "schema": {
+              "type": "string"
+            },
             "required": true,
-            "schema": { "type": "string" }
+            "name": "invitationId",
+            "in": "path"
           }
         ],
-        "responses": { "204": { "description": "Invitation revoked." } }
+        "responses": {
+          "204": {
+            "description": "HTTP 204"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "404": {
+            "description": "HTTP 404"
+          },
+          "501": {
+            "description": "HTTP 501"
+          }
+        },
+        "summary": "DELETE /v1/admin/team/invitations/{invitationId}",
+        "tags": ["Team"],
+        "x-voyant-module": "team",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/team/members/{memberId}/role": {
       "put": {
         "operationId": "updateTeamMemberRole",
-        "tags": ["Team"],
         "x-voyant-api-id": "@voyant-travel/auth#team.api.admin",
         "parameters": [
           {
-            "name": "memberId",
-            "in": "path",
+            "schema": {
+              "type": "string"
+            },
             "required": true,
-            "schema": { "type": "string" }
+            "name": "memberId",
+            "in": "path"
           }
         ],
         "requestBody": {
@@ -94,45 +216,125 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["roleId"],
-                "properties": { "roleId": { "type": "string", "minLength": 1 } }
+                "properties": {
+                  "roleId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                  }
+                },
+                "required": ["roleId"]
               }
             }
           }
         },
-        "responses": { "200": { "description": "Updated team member." } }
+        "responses": {
+          "200": {
+            "description": "HTTP 200"
+          },
+          "400": {
+            "description": "HTTP 400"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "404": {
+            "description": "HTTP 404"
+          },
+          "409": {
+            "description": "HTTP 409"
+          },
+          "501": {
+            "description": "HTTP 501"
+          }
+        },
+        "summary": "PUT /v1/admin/team/members/{memberId}/role",
+        "tags": ["Team"],
+        "x-voyant-module": "team",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/team/members/{memberId}": {
       "delete": {
         "operationId": "deactivateTeamMember",
-        "tags": ["Team"],
         "x-voyant-api-id": "@voyant-travel/auth#team.api.admin",
         "parameters": [
           {
-            "name": "memberId",
-            "in": "path",
+            "schema": {
+              "type": "string"
+            },
             "required": true,
-            "schema": { "type": "string" }
+            "name": "memberId",
+            "in": "path"
           }
         ],
-        "responses": { "200": { "description": "Deactivated team member." } }
+        "responses": {
+          "200": {
+            "description": "HTTP 200"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "404": {
+            "description": "HTTP 404"
+          },
+          "409": {
+            "description": "HTTP 409"
+          },
+          "501": {
+            "description": "HTTP 501"
+          }
+        },
+        "summary": "DELETE /v1/admin/team/members/{memberId}",
+        "tags": ["Team"],
+        "x-voyant-module": "team",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/team/members/{memberId}/activation": {
       "put": {
         "operationId": "activateTeamMember",
-        "tags": ["Team"],
         "x-voyant-api-id": "@voyant-travel/auth#team.api.admin",
         "parameters": [
           {
-            "name": "memberId",
-            "in": "path",
+            "schema": {
+              "type": "string"
+            },
             "required": true,
-            "schema": { "type": "string" }
+            "name": "memberId",
+            "in": "path"
           }
         ],
-        "responses": { "200": { "description": "Activated team member." } }
+        "responses": {
+          "200": {
+            "description": "HTTP 200"
+          },
+          "401": {
+            "description": "HTTP 401"
+          },
+          "403": {
+            "description": "HTTP 403"
+          },
+          "404": {
+            "description": "HTTP 404"
+          },
+          "409": {
+            "description": "HTTP 409"
+          },
+          "501": {
+            "description": "HTTP 501"
+          }
+        },
+        "summary": "PUT /v1/admin/team/members/{memberId}/activation",
+        "tags": ["Team"],
+        "x-voyant-module": "team",
+        "x-voyant-surface": "admin"
       }
     }
   }

--- a/packages/auth/openapi/public-api/invitations.json
+++ b/packages/auth/openapi/public-api/invitations.json
@@ -8,42 +8,46 @@
     "/v1/public/invitations/{token}": {
       "get": {
         "operationId": "inspectAuthInvitation",
-        "summary": "Inspect a user invitation",
-        "tags": ["Auth invitations"],
         "x-voyant-api-id": "@voyant-travel/auth#invitations.api.public",
         "parameters": [
           {
-            "name": "token",
-            "in": "path",
+            "schema": {
+              "type": "string"
+            },
             "required": true,
-            "schema": { "type": "string" }
+            "name": "token",
+            "in": "path"
           }
         ],
         "responses": {
           "200": {
-            "description": "The invitation is valid."
+            "description": "HTTP 200"
           },
           "404": {
-            "description": "The invitation was not found."
+            "description": "HTTP 404"
           },
           "410": {
-            "description": "The invitation is expired or redeemed."
+            "description": "HTTP 410"
           }
-        }
+        },
+        "summary": "Inspect a user invitation",
+        "tags": ["Auth invitations"],
+        "x-voyant-module": "invitations",
+        "x-voyant-surface": "public-api"
       }
     },
     "/v1/public/invitations/{token}/redeem": {
       "post": {
         "operationId": "redeemAuthInvitation",
-        "summary": "Redeem a user invitation",
-        "tags": ["Auth invitations"],
         "x-voyant-api-id": "@voyant-travel/auth#invitations.api.public",
         "parameters": [
           {
-            "name": "token",
-            "in": "path",
+            "schema": {
+              "type": "string"
+            },
             "required": true,
-            "schema": { "type": "string" }
+            "name": "token",
+            "in": "path"
           }
         ],
         "requestBody": {
@@ -52,7 +56,6 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name", "password"],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -65,22 +68,27 @@
                     "maxLength": 128,
                     "writeOnly": true
                   }
-                }
+                },
+                "required": ["name", "password"]
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "The newly created user."
+            "description": "HTTP 200"
           },
           "409": {
-            "description": "A user already exists for the invitation email."
+            "description": "HTTP 409"
           },
           "410": {
-            "description": "The invitation is invalid, expired, or redeemed."
+            "description": "HTTP 410"
           }
-        }
+        },
+        "summary": "Redeem a user invitation",
+        "tags": ["Auth invitations"],
+        "x-voyant-module": "invitations",
+        "x-voyant-surface": "public-api"
       }
     }
   }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -291,10 +291,11 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "generate:openapi": "node --import tsx scripts/generate-team-openapi.ts && node --import tsx scripts/generate-business-accounts-openapi.ts && node --import tsx scripts/generate-invitations-openapi.ts && node --import tsx scripts/generate-invitations-public-openapi.ts && node --import tsx scripts/generate-public-api-keys-openapi.ts && node --import tsx scripts/generate-customer-accounts-openapi.ts && biome format --write openapi/admin/team.json openapi/admin/customer-business-accounts.json openapi/admin/invitations.json openapi/public-api/invitations.json openapi/admin/public-api-keys.json openapi/admin/customer-accounts.json",
     "lint": "biome check src/",
-    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "prepack": "pnpm run build",
     "test": "vitest run",
-    "prepack": "pnpm run build"
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@better-auth/api-key": "1.6.23",

--- a/packages/auth/scripts/generate-business-accounts-openapi.ts
+++ b/packages/auth/scripts/generate-business-accounts-openapi.ts
@@ -1,0 +1,113 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createCustomerBusinessAccountAdminRoutes } from "../src/customer-business-onboarding-routes.js"
+
+const PREFIX = "/v1/admin/customer-business-accounts"
+const MODULE = "auth"
+const artifactPath = resolve(
+  import.meta.dirname,
+  "..",
+  "openapi/admin/customer-business-accounts.json",
+)
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+/**
+ * The runtime providers are pure method interfaces — listMembers, issueApiKey and
+ * the like. None of them reaches the document, whose schemas come from static
+ * `createRoute` definitions, so this satisfies the constructor and is never
+ * called.
+ */
+const NEVER_RUN = {} as never
+
+const live = createCustomerBusinessAccountAdminRoutes(NEVER_RUN).getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+// Metadata the route declared itself, captured before stamping fills in
+// derived placeholders for anything it left out.
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+// Precedence: what the ROUTE declared, then what the document already said,
+// then what `stampModuleMetadata` derived.
+//
+// The derived values are placeholders — a summary of "GET /v1/admin/apps" where
+// a human wrote "List app registrations" — so they must not beat curated prose.
+// But copying the committed value unconditionally is worse: a route that changes
+// its own `operationId`, `summary`, `tags` or `x-voyant-api-id` would have the
+// change silently reverted, and `verify:openapi-drift` would then reproduce the
+// stale contract forever. So the route wins whenever it actually said something.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/auth/scripts/generate-customer-accounts-openapi.ts
+++ b/packages/auth/scripts/generate-customer-accounts-openapi.ts
@@ -1,0 +1,111 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createCustomerAccountsAdminRoutes } from "../src/public-api-routes.js"
+
+const PREFIX = "/v1/admin/customer-accounts"
+const MODULE = "auth"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/customer-accounts.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+/**
+ * The runtime providers are pure method interfaces — listMembers, issueApiKey and
+ * the like. None of them reaches the document, whose schemas come from static
+ * `createRoute` definitions, so this satisfies the constructor and is never
+ * called.
+ */
+const NEVER_RUN = {} as never
+
+const live = createCustomerAccountsAdminRoutes(NEVER_RUN, {
+  businessAccounts: true,
+}).getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+// Metadata the route declared itself, captured before stamping fills in
+// derived placeholders for anything it left out.
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+// Precedence: what the ROUTE declared, then what the document already said,
+// then what `stampModuleMetadata` derived.
+//
+// The derived values are placeholders — a summary of "GET /v1/admin/apps" where
+// a human wrote "List app registrations" — so they must not beat curated prose.
+// But copying the committed value unconditionally is worse: a route that changes
+// its own `operationId`, `summary`, `tags` or `x-voyant-api-id` would have the
+// change silently reverted, and `verify:openapi-drift` would then reproduce the
+// stale contract forever. So the route wins whenever it actually said something.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/auth/scripts/generate-invitations-openapi.ts
+++ b/packages/auth/scripts/generate-invitations-openapi.ts
@@ -1,0 +1,109 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createInvitationsAdminRoutes } from "../src/invitations-routes.js"
+
+const PREFIX = "/v1/admin/invitations"
+const MODULE = "auth"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/invitations.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+/**
+ * The runtime providers are pure method interfaces — listMembers, issueApiKey and
+ * the like. None of them reaches the document, whose schemas come from static
+ * `createRoute` definitions, so this satisfies the constructor and is never
+ * called.
+ */
+const NEVER_RUN = {} as never
+
+const live = createInvitationsAdminRoutes(NEVER_RUN).getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+// Metadata the route declared itself, captured before stamping fills in
+// derived placeholders for anything it left out.
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+// Precedence: what the ROUTE declared, then what the document already said,
+// then what `stampModuleMetadata` derived.
+//
+// The derived values are placeholders — a summary of "GET /v1/admin/apps" where
+// a human wrote "List app registrations" — so they must not beat curated prose.
+// But copying the committed value unconditionally is worse: a route that changes
+// its own `operationId`, `summary`, `tags` or `x-voyant-api-id` would have the
+// change silently reverted, and `verify:openapi-drift` would then reproduce the
+// stale contract forever. So the route wins whenever it actually said something.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/auth/scripts/generate-invitations-public-openapi.ts
+++ b/packages/auth/scripts/generate-invitations-public-openapi.ts
@@ -1,0 +1,101 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createInvitationsPublicRoutes } from "../src/invitations-routes.js"
+
+const PREFIX = "/v1/public/invitations"
+const MODULE = "auth"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/public-api/invitations.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+const live = createInvitationsPublicRoutes().getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+// Metadata the route declared itself, captured before stamping fills in
+// derived placeholders for anything it left out.
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+// Precedence: what the ROUTE declared, then what the document already said,
+// then what `stampModuleMetadata` derived.
+//
+// The derived values are placeholders — a summary of "GET /v1/admin/apps" where
+// a human wrote "List app registrations" — so they must not beat curated prose.
+// But copying the committed value unconditionally is worse: a route that changes
+// its own `operationId`, `summary`, `tags` or `x-voyant-api-id` would have the
+// change silently reverted, and `verify:openapi-drift` would then reproduce the
+// stale contract forever. So the route wins whenever it actually said something.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/auth/scripts/generate-public-api-keys-openapi.ts
+++ b/packages/auth/scripts/generate-public-api-keys-openapi.ts
@@ -1,0 +1,109 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createPublicApiAdminRoutes } from "../src/public-api-routes.js"
+
+const PREFIX = "/v1/admin/public-api-keys"
+const MODULE = "auth"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/public-api-keys.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+/**
+ * The runtime providers are pure method interfaces — listMembers, issueApiKey and
+ * the like. None of them reaches the document, whose schemas come from static
+ * `createRoute` definitions, so this satisfies the constructor and is never
+ * called.
+ */
+const NEVER_RUN = {} as never
+
+const live = createPublicApiAdminRoutes(NEVER_RUN).getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+// Metadata the route declared itself, captured before stamping fills in
+// derived placeholders for anything it left out.
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+// Precedence: what the ROUTE declared, then what the document already said,
+// then what `stampModuleMetadata` derived.
+//
+// The derived values are placeholders — a summary of "GET /v1/admin/apps" where
+// a human wrote "List app registrations" — so they must not beat curated prose.
+// But copying the committed value unconditionally is worse: a route that changes
+// its own `operationId`, `summary`, `tags` or `x-voyant-api-id` would have the
+// change silently reverted, and `verify:openapi-drift` would then reproduce the
+// stale contract forever. So the route wins whenever it actually said something.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/auth/scripts/generate-team-openapi.ts
+++ b/packages/auth/scripts/generate-team-openapi.ts
@@ -1,0 +1,109 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createTeamAdminRoutes } from "../src/team-routes.js"
+
+const PREFIX = "/v1/admin/team"
+const MODULE = "auth"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/team.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+/**
+ * The runtime providers are pure method interfaces — listMembers, issueApiKey and
+ * the like. None of them reaches the document, whose schemas come from static
+ * `createRoute` definitions, so this satisfies the constructor and is never
+ * called.
+ */
+const NEVER_RUN = {} as never
+
+const live = createTeamAdminRoutes(NEVER_RUN).getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+// Metadata the route declared itself, captured before stamping fills in
+// derived placeholders for anything it left out.
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+// Precedence: what the ROUTE declared, then what the document already said,
+// then what `stampModuleMetadata` derived.
+//
+// The derived values are placeholders — a summary of "GET /v1/admin/apps" where
+// a human wrote "List app registrations" — so they must not beat curated prose.
+// But copying the committed value unconditionally is worse: a route that changes
+// its own `operationId`, `summary`, `tags` or `x-voyant-api-id` would have the
+// change silently reverted, and `verify:openapi-drift` would then reproduce the
+// stale contract forever. So the route wins whenever it actually said something.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/auth/src/invitations-routes.ts
+++ b/packages/auth/src/invitations-routes.ts
@@ -33,7 +33,11 @@ const createInviteSchema = z.object({
 
 const redeemInviteSchema = z.object({
   name: z.string().min(1).max(200),
-  password: z.string().min(8).max(128),
+  // `writeOnly` is not decoration: it tells every consumer of this contract that
+  // the field is accepted and never returned. The published document carried it
+  // and the schema did not, so generating from the schema would have dropped a
+  // security-relevant statement about a password field.
+  password: z.string().min(8).max(128).openapi({ writeOnly: true }),
 })
 
 const invitationAdminApiId = "@voyant-travel/auth#invitations.api.admin"

--- a/packages/bookings/openapi/public-api/bookings.json
+++ b/packages/bookings/openapi/public-api/bookings.json
@@ -974,7 +974,12 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postPublicBookingsInquiries",
+        "summary": "POST /v1/public/bookings/inquiries",
+        "tags": ["bookings"],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "public-api"
       }
     },
     "/v1/public/bookings/overview": {
@@ -1402,7 +1407,12 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getPublicBookingsOverview",
+        "summary": "GET /v1/public/bookings/overview",
+        "tags": ["bookings"],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "public-api"
       }
     },
     "/v1/public/bookings/guest-lookup": {
@@ -1829,7 +1839,12 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postPublicBookingsGuestLookup",
+        "summary": "POST /v1/public/bookings/guest-lookup",
+        "tags": ["bookings"],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "public-api"
       }
     },
     "/v1/public/bookings/{bookingId}/amendments/traveler-corrections/preview": {
@@ -2025,7 +2040,12 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postPublicBookingsByBookingIdAmendmentsTravelerCorrectionsPreview",
+        "summary": "POST /v1/public/bookings/{bookingId}/amendments/traveler-corrections/preview",
+        "tags": ["bookings"],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "public-api"
       }
     },
     "/v1/public/bookings/{bookingId}/amendments/traveler-roster/preview": {
@@ -2275,7 +2295,12 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postPublicBookingsByBookingIdAmendmentsTravelerRosterPreview",
+        "summary": "POST /v1/public/bookings/{bookingId}/amendments/traveler-roster/preview",
+        "tags": ["bookings"],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "public-api"
       }
     },
     "/v1/public/bookings/{bookingId}/amendments": {
@@ -2337,7 +2362,12 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getPublicBookingsByBookingIdAmendments",
+        "summary": "GET /v1/public/bookings/{bookingId}/amendments",
+        "tags": ["bookings"],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "public-api"
       }
     },
     "/v1/public/bookings/{bookingId}/amendments/{amendmentId}": {
@@ -2430,7 +2460,12 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getPublicBookingsByBookingIdAmendmentsByAmendmentId",
+        "summary": "GET /v1/public/bookings/{bookingId}/amendments/{amendmentId}",
+        "tags": ["bookings"],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "public-api"
       }
     },
     "/v1/public/bookings/{bookingId}/amendments/{amendmentId}/accept": {
@@ -2592,7 +2627,12 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postPublicBookingsByBookingIdAmendmentsByAmendmentIdAccept",
+        "summary": "POST /v1/public/bookings/{bookingId}/amendments/{amendmentId}/accept",
+        "tags": ["bookings"],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "public-api"
       }
     },
     "/v1/public/bookings/{bookingId}/amendments/{amendmentId}/apply": {
@@ -2746,7 +2786,12 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postPublicBookingsByBookingIdAmendmentsByAmendmentIdApply",
+        "summary": "POST /v1/public/bookings/{bookingId}/amendments/{amendmentId}/apply",
+        "tags": ["bookings"],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "public-api"
       }
     },
     "/v1/public/bookings/{bookingId}/amendments/{amendmentId}/reconcile": {
@@ -2879,7 +2924,12 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postPublicBookingsByBookingIdAmendmentsByAmendmentIdReconcile",
+        "summary": "POST /v1/public/bookings/{bookingId}/amendments/{amendmentId}/reconcile",
+        "tags": ["bookings"],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "public-api"
       }
     },
     "/v1/public/bookings/{bookingId}/actions": {
@@ -3008,7 +3058,10 @@
           "501": {
             "description": "Booking action projection is not selected"
           }
-        }
+        },
+        "operationId": "getPublicBookingsByBookingIdActions",
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "public-api"
       }
     }
   },

--- a/packages/bookings/package.json
+++ b/packages/bookings/package.json
@@ -47,7 +47,7 @@
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=bookings_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
-    "generate:openapi": "node --import tsx scripts/generate-admin-openapi.ts && node --import tsx scripts/generate-extras-openapi.ts && node --import tsx scripts/generate-requirements-openapi.ts && node --import tsx scripts/generate-requirements-public-openapi.ts && biome format --write --files-max-size=8388608 openapi/admin/bookings.json openapi/admin/booking-extras.json openapi/admin/booking-requirements.json openapi/public-api/booking-requirements.json",
+    "generate:openapi": "node --import tsx scripts/generate-admin-openapi.ts && node --import tsx scripts/generate-public-openapi.ts && node --import tsx scripts/generate-extras-openapi.ts && node --import tsx scripts/generate-requirements-openapi.ts && node --import tsx scripts/generate-requirements-public-openapi.ts && biome format --write --files-max-size=8388608 openapi/admin/bookings.json openapi/admin/booking-extras.json openapi/admin/booking-requirements.json openapi/public-api/booking-requirements.json openapi/public-api/bookings.json",
     "lint": "biome check src/",
     "prepack": "pnpm run build",
     "test": "vitest run",

--- a/packages/bookings/scripts/generate-public-openapi.ts
+++ b/packages/bookings/scripts/generate-public-openapi.ts
@@ -1,0 +1,76 @@
+/**
+ * The public bookings document, composed from the four modules the API module
+ * itself composes: inquiries, the public booking reads, amendments, and the
+ * public booking actions.
+ *
+ * There is no single exported barrel for this surface — the composition lives
+ * inside `createBookingsApiModule` — so it is repeated here. Driving any one of
+ * them alone would delete the other three's paths, because the document is
+ * written from the live surface rather than merged into what was there.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { OpenAPIHono } from "@hono/zod-openapi"
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { bookingAmendmentPublicRoutes } from "../src/routes-amendments.js"
+import { bookingInquiryPublicRoutes } from "../src/routes-inquiries.js"
+import { publicBookingRoutes } from "../src/routes-public.js"
+import { createPublicBookingActionRoutes } from "../src/routes-public-booking-actions.js"
+
+const PREFIX = "/v1/public/bookings"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/public-api/bookings.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+const app = new OpenAPIHono()
+  .route("/", bookingInquiryPublicRoutes as never)
+  .route("/", publicBookingRoutes as never)
+  .route("/", bookingAmendmentPublicRoutes as never)
+  .route("/", createPublicBookingActionRoutes() as never)
+
+const live = app.getOpenAPI31Document({ openapi: artifact.openapi, info: artifact.info })
+
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, "bookings"]]))
+
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/catalog/openapi/admin/catalog.json
+++ b/packages/catalog/openapi/admin/catalog.json
@@ -127,6 +127,393 @@
     "parameters": {}
   },
   "paths": {
+    "/v1/admin/catalog/package-offers": {
+      "post": {
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Live dated offers for one accommodation (+ hero fields), or a soft fallback",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "product": {},
+                    "offers": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "retryable": {
+                      "type": "boolean"
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["offers"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request — body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminCatalogPackageOffers",
+        "summary": "POST /v1/admin/catalog/package-offers",
+        "tags": ["catalog"],
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/catalog/package-detail": {
+      "post": {
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Full accommodation detail + live offers + resolved provenance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "product": {},
+                    "offers": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "retryable": {
+                      "type": "boolean"
+                    },
+                    "source": {
+                      "type": "object",
+                      "properties": {
+                        "connectionId": {
+                          "type": "string"
+                        },
+                        "ref": {
+                          "type": ["string", "null"]
+                        }
+                      },
+                      "required": ["connectionId", "ref"]
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["offers"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request — body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminCatalogPackageDetail",
+        "summary": "POST /v1/admin/catalog/package-detail",
+        "tags": ["catalog"],
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/catalog/package-search": {
+      "post": {
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cheapest live offer per (hotel, date, origin) across a destination",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "offers": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "departureAirports": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "label": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["code", "label"]
+                      }
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "sampledHotels": {
+                      "type": "number"
+                    },
+                    "retryable": {
+                      "type": "boolean"
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["offers"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request — body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminCatalogPackageSearch",
+        "summary": "POST /v1/admin/catalog/package-search",
+        "tags": ["catalog"],
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/catalog/departure-airports": {
+      "post": {
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Distinct departure airports for a destination (soft-empty on any failure)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "departureAirports": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "label": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["code", "label"]
+                      }
+                    }
+                  },
+                  "required": ["departureAirports"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminCatalogDepartureAirports",
+        "summary": "POST /v1/admin/catalog/departure-airports",
+        "tags": ["catalog"],
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/catalog/cruise-price": {
+      "post": {
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cruise-level from-price from the Connect summary (nulls when unavailable)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fromAmountMinor": {
+                      "type": ["number", "null"]
+                    },
+                    "currency": {
+                      "type": ["string", "null"]
+                    }
+                  },
+                  "required": ["fromAmountMinor", "currency"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request — body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminCatalogCruisePrice",
+        "summary": "POST /v1/admin/catalog/cruise-price",
+        "tags": ["catalog"],
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/catalog/cruise-sailing-pricing": {
+      "post": {
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cheapest available price per cabin for one sailing in a single currency",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "cabins": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "fromAmountMinor": {
+                            "type": "number"
+                          },
+                          "available": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": ["code", "fromAmountMinor", "available"]
+                      }
+                    },
+                    "currency": {
+                      "type": ["string", "null"]
+                    },
+                    "retryable": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["cabins", "currency"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request — body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminCatalogCruiseSailingPricing",
+        "summary": "POST /v1/admin/catalog/cruise-sailing-pricing",
+        "tags": ["catalog"],
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
+      }
+    },
     "/v1/admin/catalog/search": {
       "post": {
         "requestBody": {
@@ -524,7 +911,33 @@
                     },
                     "reason": {
                       "type": "string",
-                      "const": "not_independently_sellable"
+                      "enum": ["not_independently_sellable"]
+                    },
+                    "vertical": {
+                      "type": "string"
+                    },
+                    "ownedBy": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Public storefront channel context is missing or inactive",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string",
+                      "enum": ["not_independently_sellable"]
                     },
                     "vertical": {
                       "type": "string"
@@ -550,7 +963,7 @@
                     },
                     "reason": {
                       "type": "string",
-                      "const": "not_independently_sellable"
+                      "enum": ["not_independently_sellable"]
                     },
                     "vertical": {
                       "type": "string"
@@ -576,7 +989,7 @@
                     },
                     "reason": {
                       "type": "string",
-                      "const": "not_independently_sellable"
+                      "enum": ["not_independently_sellable"]
                     },
                     "vertical": {
                       "type": "string"
@@ -593,393 +1006,6 @@
         },
         "operationId": "postAdminCatalogSearch",
         "summary": "POST /v1/admin/catalog/search",
-        "tags": ["catalog"],
-        "x-voyant-module": "catalog",
-        "x-voyant-surface": "admin"
-      }
-    },
-    "/v1/admin/catalog/package-offers": {
-      "post": {
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {}
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Live dated offers for one accommodation (+ hero fields), or a soft fallback",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "product": {},
-                    "offers": {
-                      "type": "array",
-                      "items": {}
-                    },
-                    "retryable": {
-                      "type": "boolean"
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": ["offers"]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "invalid_request — body failed validation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  },
-                  "required": ["error"]
-                }
-              }
-            }
-          }
-        },
-        "operationId": "postAdminCatalogPackageOffers",
-        "summary": "POST /v1/admin/catalog/package-offers",
-        "tags": ["catalog"],
-        "x-voyant-module": "catalog",
-        "x-voyant-surface": "admin"
-      }
-    },
-    "/v1/admin/catalog/package-detail": {
-      "post": {
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {}
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Full accommodation detail + live offers + resolved provenance",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "product": {},
-                    "offers": {
-                      "type": "array",
-                      "items": {}
-                    },
-                    "retryable": {
-                      "type": "boolean"
-                    },
-                    "source": {
-                      "type": "object",
-                      "properties": {
-                        "connectionId": {
-                          "type": "string"
-                        },
-                        "ref": {
-                          "type": ["string", "null"]
-                        }
-                      },
-                      "required": ["connectionId", "ref"]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": ["offers"]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "invalid_request — body failed validation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  },
-                  "required": ["error"]
-                }
-              }
-            }
-          }
-        },
-        "operationId": "postAdminCatalogPackageDetail",
-        "summary": "POST /v1/admin/catalog/package-detail",
-        "tags": ["catalog"],
-        "x-voyant-module": "catalog",
-        "x-voyant-surface": "admin"
-      }
-    },
-    "/v1/admin/catalog/package-search": {
-      "post": {
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {}
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Cheapest live offer per (hotel, date, origin) across a destination",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "offers": {
-                      "type": "array",
-                      "items": {}
-                    },
-                    "departureAirports": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "code": {
-                            "type": "string"
-                          },
-                          "label": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["code", "label"]
-                      }
-                    },
-                    "currency": {
-                      "type": "string"
-                    },
-                    "sampledHotels": {
-                      "type": "number"
-                    },
-                    "retryable": {
-                      "type": "boolean"
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": ["offers"]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "invalid_request — body failed validation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  },
-                  "required": ["error"]
-                }
-              }
-            }
-          }
-        },
-        "operationId": "postAdminCatalogPackageSearch",
-        "summary": "POST /v1/admin/catalog/package-search",
-        "tags": ["catalog"],
-        "x-voyant-module": "catalog",
-        "x-voyant-surface": "admin"
-      }
-    },
-    "/v1/admin/catalog/departure-airports": {
-      "post": {
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {}
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Distinct departure airports for a destination (soft-empty on any failure)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "departureAirports": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "code": {
-                            "type": "string"
-                          },
-                          "label": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["code", "label"]
-                      }
-                    }
-                  },
-                  "required": ["departureAirports"]
-                }
-              }
-            }
-          }
-        },
-        "operationId": "postAdminCatalogDepartureAirports",
-        "summary": "POST /v1/admin/catalog/departure-airports",
-        "tags": ["catalog"],
-        "x-voyant-module": "catalog",
-        "x-voyant-surface": "admin"
-      }
-    },
-    "/v1/admin/catalog/cruise-price": {
-      "post": {
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {}
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Cruise-level from-price from the Connect summary (nulls when unavailable)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "fromAmountMinor": {
-                      "type": ["number", "null"]
-                    },
-                    "currency": {
-                      "type": ["string", "null"]
-                    }
-                  },
-                  "required": ["fromAmountMinor", "currency"]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "invalid_request — body failed validation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  },
-                  "required": ["error"]
-                }
-              }
-            }
-          }
-        },
-        "operationId": "postAdminCatalogCruisePrice",
-        "summary": "POST /v1/admin/catalog/cruise-price",
-        "tags": ["catalog"],
-        "x-voyant-module": "catalog",
-        "x-voyant-surface": "admin"
-      }
-    },
-    "/v1/admin/catalog/cruise-sailing-pricing": {
-      "post": {
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {}
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Cheapest available price per cabin for one sailing in a single currency",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "cabins": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "code": {
-                            "type": "string"
-                          },
-                          "fromAmountMinor": {
-                            "type": "number"
-                          },
-                          "available": {
-                            "type": "boolean"
-                          }
-                        },
-                        "required": ["code", "fromAmountMinor", "available"]
-                      }
-                    },
-                    "currency": {
-                      "type": ["string", "null"]
-                    },
-                    "retryable": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": ["cabins", "currency"]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "invalid_request — body failed validation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  },
-                  "required": ["error"]
-                }
-              }
-            }
-          }
-        },
-        "operationId": "postAdminCatalogCruiseSailingPricing",
-        "summary": "POST /v1/admin/catalog/cruise-sailing-pricing",
         "tags": ["catalog"],
         "x-voyant-module": "catalog",
         "x-voyant-surface": "admin"

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -101,7 +101,7 @@
     "test": "vitest run",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
-    "generate:openapi": "tsx scripts/generate-booking-openapi.ts && biome format --write openapi/admin/catalog-booking.json openapi/public-api/catalog-booking.json",
+    "generate:openapi": "tsx scripts/generate-booking-openapi.ts && node --import tsx scripts/generate-offers-openapi.ts && biome format --write openapi/admin/catalog.json openapi/admin/catalog-booking.json openapi/public-api/catalog-booking.json",
     "prepack": "pnpm run build",
     "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=catalog_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations"
   },

--- a/packages/catalog/scripts/generate-offers-openapi.ts
+++ b/packages/catalog/scripts/generate-offers-openapi.ts
@@ -1,0 +1,124 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { OpenAPIHono } from "@hono/zod-openapi"
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createCatalogOffersAdminRoutes } from "../src/offers/operator-routes.js"
+import { createCatalogSearchRoutes } from "../src/search/routes.js"
+
+const PREFIX = "/v1/admin/catalog"
+const MODULE = "catalog"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/catalog.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+/**
+ * Runtime resolvers that never reach the document — every path comes from a
+ * static `createRoute` definition.
+ */
+const NEVER_RUN = {
+  resolveConnectClient: () => ({}),
+  fetchIndexFields: async () => [],
+  resolveDynamicHotelIds: async () => [],
+  resolveAirportLabels: async () => ({}),
+} as never
+
+// TWO modules feed this document: the offers routes produce six of the seven
+// paths and `/search` comes from the search routes. Driving only the first
+// deleted `/search`, because the document is written from the live surface
+// rather than merged into what was there.
+const app = new OpenAPIHono()
+  .route("/", createCatalogOffersAdminRoutes(NEVER_RUN) as never)
+  .route(
+    "/",
+    createCatalogSearchRoutes({ resolveRuntime: () => ({}), surface: "admin" } as never) as never,
+  )
+
+const live = app.getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+// Metadata the route declared itself, captured before stamping fills in
+// derived placeholders for anything it left out.
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+// Precedence: what the ROUTE declared, then what the document already said,
+// then what `stampModuleMetadata` derived.
+//
+// The derived values are placeholders — a summary of "GET /v1/admin/apps" where
+// a human wrote "List app registrations" — so they must not beat curated prose.
+// But copying the committed value unconditionally is worse: a route that changes
+// its own `operationId`, `summary`, `tags` or `x-voyant-api-id` would have the
+// change silently reverted, and `verify:openapi-drift` would then reproduce the
+// stale contract forever. So the route wins whenever it actually said something.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/distribution/openapi/admin/distribution-booking.json
+++ b/packages/distribution/openapi/admin/distribution-booking.json
@@ -6,54 +6,222 @@
   },
   "paths": {
     "/v1/admin/bookings/{bookingId}/distribution-details": {
-      "parameters": [
-        {
-          "name": "bookingId",
-          "in": "path",
-          "required": true,
-          "schema": { "type": "string" }
-        }
-      ],
       "get": {
-        "summary": "Get distribution details for a booking",
         "x-voyant-api-id": "@voyant-travel/distribution#extension.api",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "bookingId",
+            "in": "path"
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Distribution details, or null when none are recorded",
+            "description": "Booking distribution details",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["data"],
                   "properties": {
-                    "data": { "$ref": "#/components/schemas/BookingDistributionDetails" }
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "bookingId": {
+                          "type": "string"
+                        },
+                        "marketId": {
+                          "type": ["string", "null"]
+                        },
+                        "sourceChannelId": {
+                          "type": ["string", "null"]
+                        },
+                        "fxRateSetId": {
+                          "type": ["string", "null"]
+                        },
+                        "paymentOwner": {
+                          "type": "string",
+                          "enum": ["operator", "channel", "split"]
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "bookingId",
+                        "marketId",
+                        "sourceChannelId",
+                        "fxRateSetId",
+                        "paymentOwner",
+                        "createdAt",
+                        "updatedAt"
+                      ]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminBookingsByBookingIdDistributionDetails",
+        "summary": "Get distribution details for a booking",
+        "tags": ["bookings"],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
+      },
+      "put": {
+        "x-voyant-api-id": "@voyant-travel/distribution#extension.api",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "bookingId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "marketId": {
+                    "type": ["string", "null"]
+                  },
+                  "sourceChannelId": {
+                    "type": ["string", "null"]
+                  },
+                  "fxRateSetId": {
+                    "type": ["string", "null"]
+                  },
+                  "paymentOwner": {
+                    "type": "string",
+                    "enum": ["operator", "channel", "split"],
+                    "default": "operator"
                   }
                 }
               }
             }
           }
-        }
-      },
-      "put": {
-        "summary": "Create or replace distribution details for a booking",
-        "x-voyant-api-id": "@voyant-travel/distribution#extension.api",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/BookingDistributionDetailsInput" }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated booking distribution details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "bookingId": {
+                          "type": "string"
+                        },
+                        "marketId": {
+                          "type": ["string", "null"]
+                        },
+                        "sourceChannelId": {
+                          "type": ["string", "null"]
+                        },
+                        "fxRateSetId": {
+                          "type": ["string", "null"]
+                        },
+                        "paymentOwner": {
+                          "type": "string",
+                          "enum": ["operator", "channel", "split"]
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "bookingId",
+                        "marketId",
+                        "sourceChannelId",
+                        "fxRateSetId",
+                        "paymentOwner",
+                        "createdAt",
+                        "updatedAt"
+                      ]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
             }
           }
         },
-        "responses": { "200": { "description": "Distribution details were stored" } }
+        "operationId": "putAdminBookingsByBookingIdDistributionDetails",
+        "summary": "Create or replace distribution details for a booking",
+        "tags": ["bookings"],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "delete": {
-        "summary": "Remove distribution details from a booking",
         "x-voyant-api-id": "@voyant-travel/distribution#extension.api",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "bookingId",
+            "in": "path"
+          }
+        ],
         "responses": {
-          "200": { "description": "Distribution details were removed" },
-          "404": { "description": "No distribution details exist for the booking" }
-        }
+          "200": {
+            "description": "Booking distribution details deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [true]
+                    }
+                  },
+                  "required": ["success"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Booking distribution details not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "deleteAdminBookingsByBookingIdDistributionDetails",
+        "summary": "Remove distribution details from a booking",
+        "tags": ["bookings"],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     }
   },
@@ -62,9 +230,15 @@
       "BookingDistributionDetailsInput": {
         "type": "object",
         "properties": {
-          "marketId": { "type": ["string", "null"] },
-          "sourceChannelId": { "type": ["string", "null"] },
-          "fxRateSetId": { "type": ["string", "null"] },
+          "marketId": {
+            "type": ["string", "null"]
+          },
+          "sourceChannelId": {
+            "type": ["string", "null"]
+          },
+          "fxRateSetId": {
+            "type": ["string", "null"]
+          },
           "paymentOwner": {
             "type": "string",
             "enum": ["operator", "channel", "split"],
@@ -74,17 +248,29 @@
       },
       "BookingDistributionDetails": {
         "anyOf": [
-          { "type": "null" },
+          {
+            "type": "null"
+          },
           {
             "allOf": [
-              { "$ref": "#/components/schemas/BookingDistributionDetailsInput" },
+              {
+                "$ref": "#/components/schemas/BookingDistributionDetailsInput"
+              },
               {
                 "type": "object",
                 "required": ["bookingId", "paymentOwner", "createdAt", "updatedAt"],
                 "properties": {
-                  "bookingId": { "type": "string" },
-                  "createdAt": { "type": "string", "format": "date-time" },
-                  "updatedAt": { "type": "string", "format": "date-time" }
+                  "bookingId": {
+                    "type": "string"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
                 }
               }
             ]

--- a/packages/distribution/package.json
+++ b/packages/distribution/package.json
@@ -33,7 +33,7 @@
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=distribution_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
-    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && node --import tsx scripts/generate-suppliers-openapi.ts && node --import tsx scripts/generate-external-refs-openapi.ts && node --import tsx scripts/generate-channel-push-openapi.ts && biome format --write --files-max-size=8388608 openapi/admin/distribution.json openapi/admin/suppliers.json openapi/admin/external-refs.json openapi/admin/distribution-channel-push.json",
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && node --import tsx scripts/generate-suppliers-openapi.ts && node --import tsx scripts/generate-external-refs-openapi.ts && node --import tsx scripts/generate-channel-push-openapi.ts && node --import tsx scripts/generate-booking-extension-openapi.ts && biome format --write openapi/admin/distribution-booking.json --files-max-size=8388608 openapi/admin/distribution.json openapi/admin/suppliers.json openapi/admin/external-refs.json openapi/admin/distribution-channel-push.json",
     "lint": "biome check src/",
     "prepack": "pnpm run build",
     "test": "vitest run",

--- a/packages/distribution/scripts/generate-booking-extension-openapi.ts
+++ b/packages/distribution/scripts/generate-booking-extension-openapi.ts
@@ -1,0 +1,101 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { distributionBookingExtension } from "../src/booking-extension.js"
+
+const PREFIX = "/v1/admin/bookings"
+const MODULE = "distribution"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/distribution-booking.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+const live = distributionBookingExtension.adminRoutes.getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+// Metadata the route declared itself, captured before stamping fills in
+// derived placeholders for anything it left out.
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+// Precedence: what the ROUTE declared, then what the document already said,
+// then what `stampModuleMetadata` derived.
+//
+// The derived values are placeholders — a summary of "GET /v1/admin/apps" where
+// a human wrote "List app registrations" — so they must not beat curated prose.
+// But copying the committed value unconditionally is worse: a route that changes
+// its own `operationId`, `summary`, `tags` or `x-voyant-api-id` would have the
+// change silently reverted, and `verify:openapi-drift` would then reproduce the
+// stale contract forever. So the route wins whenever it actually said something.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/finance/openapi/public-api/payment-link.json
+++ b/packages/finance/openapi/public-api/payment-link.json
@@ -140,6 +140,9 @@
                     "data": {
                       "type": "object",
                       "properties": {
+                        "paymentLinkUrlTemplate": {
+                          "type": ["string", "null"]
+                        },
                         "publicCheckoutBaseUrl": {
                           "type": ["string", "null"]
                         },
@@ -157,9 +160,23 @@
                             }
                           },
                           "required": ["beneficiary", "iban"]
+                        },
+                        "cardPayments": {
+                          "type": "object",
+                          "properties": {
+                            "available": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": ["available"]
                         }
                       },
-                      "required": ["publicCheckoutBaseUrl", "bankTransfer"]
+                      "required": [
+                        "paymentLinkUrlTemplate",
+                        "publicCheckoutBaseUrl",
+                        "bankTransfer",
+                        "cardPayments"
+                      ]
                     }
                   },
                   "required": ["data"]
@@ -410,21 +427,17 @@
                     "type": "string",
                     "minLength": 1
                   },
-                  "returnUrl": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "cancelUrl": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "metadata": {
-                    "type": "object",
-                    "additionalProperties": {}
-                  },
                   "shipping": {
                     "type": "object",
                     "additionalProperties": {}
+                  },
+                  "acceptedCheckoutHandoffs": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": ["redirect", "embedded"]
+                    },
+                    "minItems": 1
                   }
                 },
                 "additionalProperties": false
@@ -434,7 +447,7 @@
         },
         "responses": {
           "200": {
-            "description": "The card-provider redirect URL for the session",
+            "description": "The card-provider handoff for the session",
             "content": {
               "application/json": {
                 "schema": {
@@ -445,6 +458,51 @@
                       "properties": {
                         "redirectUrl": {
                           "type": ["string", "null"]
+                        },
+                        "checkout": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["hosted_checkout", "redirect"]
+                                },
+                                "url": {
+                                  "type": "string"
+                                },
+                                "expiresAt": {
+                                  "type": ["string", "null"]
+                                }
+                              },
+                              "required": ["kind", "url"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["embedded"]
+                                },
+                                "clientSecret": {
+                                  "type": "string"
+                                },
+                                "publishableKey": {
+                                  "type": "string"
+                                },
+                                "providerAccountId": {
+                                  "type": ["string", "null"]
+                                },
+                                "expiresAt": {
+                                  "type": ["string", "null"]
+                                }
+                              },
+                              "required": ["kind", "clientSecret", "publishableKey"]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
                         },
                         "session": {
                           "type": "object",
@@ -463,12 +521,64 @@
                             },
                             "redirectUrl": {
                               "type": ["string", "null"]
+                            },
+                            "checkout": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["hosted_checkout", "redirect"]
+                                    },
+                                    "url": {
+                                      "type": "string"
+                                    },
+                                    "expiresAt": {
+                                      "type": ["string", "null"]
+                                    }
+                                  },
+                                  "required": ["kind", "url"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["embedded"]
+                                    },
+                                    "clientSecret": {
+                                      "type": "string"
+                                    },
+                                    "publishableKey": {
+                                      "type": "string"
+                                    },
+                                    "providerAccountId": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "expiresAt": {
+                                      "type": ["string", "null"]
+                                    }
+                                  },
+                                  "required": ["kind", "clientSecret", "publishableKey"]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             }
                           },
-                          "required": ["id", "status", "amountCents", "currency", "redirectUrl"]
+                          "required": [
+                            "id",
+                            "status",
+                            "amountCents",
+                            "currency",
+                            "redirectUrl",
+                            "checkout"
+                          ]
                         }
                       },
-                      "required": ["redirectUrl"]
+                      "required": ["redirectUrl", "checkout"]
                     }
                   },
                   "required": ["data"]

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -52,7 +52,7 @@
     "build": "NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
-    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && node --import tsx scripts/generate-booking-tax-settings-openapi.ts && node --import tsx scripts/generate-booking-tax-preview-openapi.ts && biome format --write openapi/admin/booking-tax-settings.json openapi/admin/booking-tax-preview.json openapi/public-api/finance.json",
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && node --import tsx scripts/generate-booking-tax-settings-openapi.ts && node --import tsx scripts/generate-booking-tax-preview-openapi.ts && node --import tsx scripts/generate-payment-link-openapi.ts && biome format --write openapi/public-api/payment-link.json openapi/admin/booking-tax-settings.json openapi/admin/booking-tax-preview.json openapi/public-api/finance.json",
     "migrate:travel-credits": "node --experimental-strip-types --experimental-transform-types scripts/migrate-travel-credits.ts",
     "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=finance_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations"
   },

--- a/packages/finance/scripts/generate-payment-link-openapi.ts
+++ b/packages/finance/scripts/generate-payment-link-openapi.ts
@@ -1,0 +1,112 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createPaymentLinkRoutes } from "../src/payment-link-routes.js"
+
+const PREFIX = "/v1/public"
+const MODULE = "finance"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/public-api/payment-link.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+/**
+ * Runtime resolvers that never reach the document — the seven paths come from
+ * static `createRoute` definitions and declare absolute paths themselves.
+ */
+const NEVER_RUN = {
+  resolveBankTransferDetails: () => null,
+  resolvePublicCheckoutBaseUrl: () => "https://example.invalid",
+  startCardPayment: async () => ({}),
+  resolveTripData: async () => null,
+} as never
+
+const live = createPaymentLinkRoutes(NEVER_RUN).getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+// Metadata the route declared itself, captured before stamping fills in
+// derived placeholders for anything it left out.
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+// Precedence: what the ROUTE declared, then what the document already said,
+// then what `stampModuleMetadata` derived.
+//
+// The derived values are placeholders — a summary of "GET /v1/admin/apps" where
+// a human wrote "List app registrations" — so they must not beat curated prose.
+// But copying the committed value unconditionally is worse: a route that changes
+// its own `operationId`, `summary`, `tags` or `x-voyant-api-id` would have the
+// change silently reverted, and `verify:openapi-drift` would then reproduce the
+// stale contract forever. So the route wins whenever it actually said something.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/finance/src/payment-link-routes.ts
+++ b/packages/finance/src/payment-link-routes.ts
@@ -453,7 +453,17 @@ const resolvePaymentLinkRoute = createRoute({
 const startCardPaymentLinkRoute = createRoute({
   method: "post",
   path: "/v1/public/payment-link/{sessionId}/start-card",
-  request: { params: sessionParamsSchema },
+  // The handler parses `startCardPaymentBodySchema`, and the published document
+  // described that body, but the route definition did not declare it — so
+  // generating the document from the routes would have dropped a request body
+  // the endpoint really accepts.
+  request: {
+    params: sessionParamsSchema,
+    body: {
+      required: false,
+      content: { "application/json": { schema: startCardPaymentBodySchema } },
+    },
+  },
   responses: {
     200: {
       description: "The card-provider handoff for the session",

--- a/packages/legal/openapi/public-api/legal.json
+++ b/packages/legal/openapi/public-api/legal.json
@@ -129,7 +129,6 @@
   "paths": {
     "/v1/public/legal/contracts/templates/default": {
       "get": {
-        "x-voyant-api-id": "@voyant-travel/legal#api.public",
         "parameters": [
           {
             "schema": {
@@ -264,12 +263,12 @@
         "summary": "GET /v1/public/legal/contracts/templates/default",
         "tags": ["legal"],
         "x-voyant-module": "legal",
-        "x-voyant-surface": "public-api"
+        "x-voyant-surface": "public-api",
+        "x-voyant-api-id": "@voyant-travel/legal#api.public"
       }
     },
     "/v1/public/legal/contracts/templates/{id}/preview": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/legal#api.public",
         "parameters": [
           {
             "schema": {
@@ -352,12 +351,12 @@
         "summary": "POST /v1/public/legal/contracts/templates/{id}/preview",
         "tags": ["legal"],
         "x-voyant-module": "legal",
-        "x-voyant-surface": "public-api"
+        "x-voyant-surface": "public-api",
+        "x-voyant-api-id": "@voyant-travel/legal#api.public"
       }
     },
     "/v1/public/legal/contracts/templates/{id}/render-preview": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/legal#api.public",
         "parameters": [
           {
             "schema": {
@@ -440,12 +439,12 @@
         "summary": "POST /v1/public/legal/contracts/templates/{id}/render-preview",
         "tags": ["legal"],
         "x-voyant-module": "legal",
-        "x-voyant-surface": "public-api"
+        "x-voyant-surface": "public-api",
+        "x-voyant-api-id": "@voyant-travel/legal#api.public"
       }
     },
     "/v1/public/legal/contracts/templates/by-slug/{slug}/preview": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/legal#api.public",
         "parameters": [
           {
             "schema": {
@@ -528,12 +527,12 @@
         "summary": "POST /v1/public/legal/contracts/templates/by-slug/{slug}/preview",
         "tags": ["legal"],
         "x-voyant-module": "legal",
-        "x-voyant-surface": "public-api"
+        "x-voyant-surface": "public-api",
+        "x-voyant-api-id": "@voyant-travel/legal#api.public"
       }
     },
     "/v1/public/legal/contracts/templates/by-slug/{slug}/render-preview": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/legal#api.public",
         "parameters": [
           {
             "schema": {
@@ -616,12 +615,12 @@
         "summary": "POST /v1/public/legal/contracts/templates/by-slug/{slug}/render-preview",
         "tags": ["legal"],
         "x-voyant-module": "legal",
-        "x-voyant-surface": "public-api"
+        "x-voyant-surface": "public-api",
+        "x-voyant-api-id": "@voyant-travel/legal#api.public"
       }
     },
     "/v1/public/legal/contracts/{id}": {
       "get": {
-        "x-voyant-api-id": "@voyant-travel/legal#api.public",
         "parameters": [
           {
             "schema": {
@@ -757,12 +756,12 @@
         "summary": "GET /v1/public/legal/contracts/{id}",
         "tags": ["legal"],
         "x-voyant-module": "legal",
-        "x-voyant-surface": "public-api"
+        "x-voyant-surface": "public-api",
+        "x-voyant-api-id": "@voyant-travel/legal#api.public"
       }
     },
     "/v1/public/legal/contracts/{id}/sign": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/legal#api.public",
         "parameters": [
           {
             "schema": {
@@ -932,12 +931,12 @@
         "summary": "POST /v1/public/legal/contracts/{id}/sign",
         "tags": ["legal"],
         "x-voyant-module": "legal",
-        "x-voyant-surface": "public-api"
+        "x-voyant-surface": "public-api",
+        "x-voyant-api-id": "@voyant-travel/legal#api.public"
       }
     },
     "/v1/public/legal/policies/{slug}": {
       "get": {
-        "x-voyant-api-id": "@voyant-travel/legal#api.public",
         "parameters": [
           {
             "schema": {
@@ -1096,12 +1095,12 @@
         "summary": "GET /v1/public/legal/policies/{slug}",
         "tags": ["legal"],
         "x-voyant-module": "legal",
-        "x-voyant-surface": "public-api"
+        "x-voyant-surface": "public-api",
+        "x-voyant-api-id": "@voyant-travel/legal#api.public"
       }
     },
     "/v1/public/legal/policies/{id}/accept": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/legal#api.public",
         "parameters": [
           {
             "schema": {
@@ -1360,12 +1359,12 @@
         "summary": "POST /v1/public/legal/policies/{id}/accept",
         "tags": ["legal"],
         "x-voyant-module": "legal",
-        "x-voyant-surface": "public-api"
+        "x-voyant-surface": "public-api",
+        "x-voyant-api-id": "@voyant-travel/legal#api.public"
       }
     },
     "/v1/public/legal/terms": {
       "get": {
-        "x-voyant-api-id": "@voyant-travel/legal#api.public",
         "parameters": [
           {
             "schema": {
@@ -1471,6 +1470,9 @@
                 "payment",
                 "pricing",
                 "commission",
+                "insurer_product_information",
+                "insurer_terms",
+                "demands_and_needs",
                 "other"
               ]
             },
@@ -1485,6 +1487,14 @@
             },
             "required": false,
             "name": "acceptanceStatus",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "sourceVersionId",
             "in": "query"
           }
         ],
@@ -1547,6 +1557,9 @@
                               "payment",
                               "pricing",
                               "commission",
+                              "insurer_product_information",
+                              "insurer_terms",
+                              "demands_and_needs",
                               "other"
                             ]
                           },
@@ -1573,6 +1586,15 @@
                             "type": ["string", "null"]
                           },
                           "acceptedBy": {
+                            "type": ["string", "null"]
+                          },
+                          "sourceVersionId": {
+                            "type": ["string", "null"]
+                          },
+                          "archivedStorageKey": {
+                            "type": ["string", "null"]
+                          },
+                          "archivedChecksum": {
                             "type": ["string", "null"]
                           },
                           "metadata": {},
@@ -1602,6 +1624,9 @@
                           "acceptanceStatus",
                           "acceptedAt",
                           "acceptedBy",
+                          "sourceVersionId",
+                          "archivedStorageKey",
+                          "archivedChecksum",
                           "createdAt",
                           "updatedAt"
                         ]
@@ -1627,12 +1652,12 @@
         "summary": "GET /v1/public/legal/terms",
         "tags": ["legal"],
         "x-voyant-module": "legal",
-        "x-voyant-surface": "public-api"
+        "x-voyant-surface": "public-api",
+        "x-voyant-api-id": "@voyant-travel/legal#api.public"
       }
     },
     "/v1/public/legal/terms/{id}": {
       "get": {
-        "x-voyant-api-id": "@voyant-travel/legal#api.public",
         "parameters": [
           {
             "schema": {
@@ -1700,6 +1725,9 @@
                             "payment",
                             "pricing",
                             "commission",
+                            "insurer_product_information",
+                            "insurer_terms",
+                            "demands_and_needs",
                             "other"
                           ]
                         },
@@ -1726,6 +1754,15 @@
                           "type": ["string", "null"]
                         },
                         "acceptedBy": {
+                          "type": ["string", "null"]
+                        },
+                        "sourceVersionId": {
+                          "type": ["string", "null"]
+                        },
+                        "archivedStorageKey": {
+                          "type": ["string", "null"]
+                        },
+                        "archivedChecksum": {
                           "type": ["string", "null"]
                         },
                         "metadata": {},
@@ -1755,6 +1792,9 @@
                         "acceptanceStatus",
                         "acceptedAt",
                         "acceptedBy",
+                        "sourceVersionId",
+                        "archivedStorageKey",
+                        "archivedChecksum",
                         "createdAt",
                         "updatedAt"
                       ]
@@ -1786,7 +1826,8 @@
         "summary": "GET /v1/public/legal/terms/{id}",
         "tags": ["legal"],
         "x-voyant-module": "legal",
-        "x-voyant-surface": "public-api"
+        "x-voyant-surface": "public-api",
+        "x-voyant-api-id": "@voyant-travel/legal#api.public"
       }
     }
   },

--- a/packages/legal/package.json
+++ b/packages/legal/package.json
@@ -44,7 +44,7 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=legal_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
-    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && biome format --write openapi/admin/legal.json"
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && node --import tsx scripts/generate-public-openapi.ts && biome format --write openapi/admin/legal.json openapi/public-api/legal.json"
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",

--- a/packages/legal/scripts/generate-public-openapi.ts
+++ b/packages/legal/scripts/generate-public-openapi.ts
@@ -1,0 +1,80 @@
+/**
+ * Regenerates this package's published public OpenAPI document from the live
+ * route modules.
+ *
+ * Three surfaces feed it — contracts, policies and terms — exactly as the admin
+ * document does. Driving one alone would delete the others' paths, because the
+ * document is written from the live surfaces rather than merged into what was
+ * already there.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { contractsPublicRoutes } from "../src/contracts/routes.js"
+import { policiesPublicRoutes } from "../src/policies/routes.js"
+import { legalTermsPublicRoutes } from "../src/terms/routes.js"
+
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/public-api/legal.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+const surfaces = [
+  { prefix: "/v1/public/legal/contracts", routes: contractsPublicRoutes },
+  { prefix: "/v1/public/legal/policies", routes: policiesPublicRoutes },
+  { prefix: "/v1/public/legal/terms", routes: legalTermsPublicRoutes },
+]
+
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+
+for (const surface of surfaces) {
+  const live = surface.routes.getOpenAPI31Document({
+    openapi: artifact.openapi,
+    info: artifact.info,
+  })
+  const absolutise = (path: string) =>
+    path === "/" ? surface.prefix : path.startsWith("/v1/") ? path : `${surface.prefix}${path}`
+  const prefixed = {
+    ...live,
+    paths: Object.fromEntries(
+      Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+    ),
+  }
+
+  const declared = new Map<string, Record<string, unknown>>()
+  for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+    if (!item || typeof item !== "object") continue
+    for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+      if (operation && typeof operation === "object") {
+        declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+      }
+    }
+  }
+
+  const stamped = stampModuleMetadata(prefixed, new Map([[surface.prefix, "legal"]]))
+
+  for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+    if (!item || typeof item !== "object") continue
+    if (path in paths) {
+      throw new Error(`legal generate:openapi: ${path} is produced by two surfaces`)
+    }
+    const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+    for (const method of OPERATION_METHODS) {
+      const operation = (item as Record<string, unknown>)[method] as
+        | Record<string, unknown>
+        | undefined
+      if (!operation) continue
+      const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+      for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+        if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+        if (routeDeclared[key] !== undefined) continue
+        operation[key] = value
+      }
+    }
+    paths[path] = item
+  }
+}
+
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/mcp/openapi/admin/mcp.json
+++ b/packages/mcp/openapi/admin/mcp.json
@@ -5,11 +5,24 @@
     "version": "1.0.0"
   },
   "paths": {
+    "/v1/admin/mcp/manifest": {
+      "get": {
+        "operationId": "getMcpManifest",
+        "x-voyant-api-id": "@voyant-travel/mcp#api.admin",
+        "responses": {
+          "200": {
+            "description": "The contract-versioned tools visible to the caller."
+          }
+        },
+        "summary": "Get the authorized MCP tool manifest",
+        "tags": ["MCP"],
+        "x-voyant-module": "mcp",
+        "x-voyant-surface": "admin"
+      }
+    },
     "/v1/admin/mcp": {
       "post": {
         "operationId": "callMcp",
-        "summary": "Send an MCP JSON-RPC request",
-        "tags": ["MCP"],
         "x-voyant-api-id": "@voyant-travel/mcp#api.admin",
         "requestBody": {
           "required": true,
@@ -17,35 +30,49 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["jsonrpc", "method"],
                 "properties": {
-                  "jsonrpc": { "type": "string", "const": "2.0" },
-                  "id": { "type": ["string", "number", "null"] },
-                  "method": { "type": "string" },
-                  "params": { "type": "object", "additionalProperties": true }
-                }
+                  "jsonrpc": {
+                    "type": "string",
+                    "enum": ["2.0"]
+                  },
+                  "id": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "method": {
+                    "type": "string"
+                  },
+                  "params": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                },
+                "required": ["jsonrpc", "method"]
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "The MCP JSON-RPC response."
+            "description": "The MCP JSON-RPC response"
+          },
+          "204": {
+            "description": "The MCP notification was accepted"
           }
-        }
-      }
-    },
-    "/v1/admin/mcp/manifest": {
-      "get": {
-        "operationId": "getMcpManifest",
-        "summary": "Get the authorized MCP tool manifest",
+        },
+        "summary": "Send an MCP JSON-RPC request",
         "tags": ["MCP"],
-        "x-voyant-api-id": "@voyant-travel/mcp#api.admin",
-        "responses": {
-          "200": {
-            "description": "The contract-versioned tools visible to the caller."
-          }
-        }
+        "x-voyant-module": "mcp",
+        "x-voyant-surface": "admin"
       }
     }
   }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -53,12 +53,13 @@
     "types": "./dist/index.d.ts"
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.typecheck.json",
-    "lint": "biome check src/",
-    "test": "vitest run",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
-    "prepack": "pnpm run build"
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && biome format --write openapi/admin/mcp.json",
+    "lint": "biome check src/",
+    "prepack": "pnpm run build",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hono/mcp": "^0.3.0",

--- a/packages/mcp/scripts/generate-openapi.ts
+++ b/packages/mcp/scripts/generate-openapi.ts
@@ -1,0 +1,114 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createMcpApiRoutes } from "../src/server.js"
+
+const PREFIX = "/v1/admin/mcp"
+const MODULE = "mcp"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/mcp.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+/**
+ * The registry, context builder and access catalog are runtime concerns that
+ * never reach the document — both paths come from static `createRoute`
+ * definitions. `rateLimit: false` matters: the constructor otherwise builds a
+ * rate limiter over the registry, which a stub cannot satisfy.
+ */
+const NEVER_RUN = {
+  registry: { list: () => [], get: () => undefined },
+  buildContext: () => ({}),
+  accessCatalog: { actions: [] },
+  rateLimit: false,
+} as never
+
+const live = createMcpApiRoutes(NEVER_RUN).getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+// Metadata the route declared itself, captured before stamping fills in
+// derived placeholders for anything it left out.
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+// Precedence: what the ROUTE declared, then what the document already said,
+// then what `stampModuleMetadata` derived.
+//
+// The derived values are placeholders — a summary of "GET /v1/admin/apps" where
+// a human wrote "List app registrations" — so they must not beat curated prose.
+// But copying the committed value unconditionally is worse: a route that changes
+// its own `operationId`, `summary`, `tags` or `x-voyant-api-id` would have the
+// change silently reverted, and `verify:openapi-drift` would then reproduce the
+// stale contract forever. So the route wins whenever it actually said something.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -75,7 +75,7 @@ const getManifestRoute = createRoute({
   path: "/manifest",
   operationId: "getMcpManifest",
   "x-voyant-api-id": mcpAdminApiId,
-  responses: { 200: { description: "The authorized MCP tool manifest" } },
+  responses: { 200: { description: "The contract-versioned tools visible to the caller." } },
 })
 const callMcpRoute = createRoute({
   method: "post",

--- a/packages/proposals/openapi/admin/proposal-version-snapshot.json
+++ b/packages/proposals/openapi/admin/proposal-version-snapshot.json
@@ -8,26 +8,40 @@
     "/v1/admin/trips/{envelopeId}/proposal-versions/{proposalVersionId}/snapshot": {
       "post": {
         "summary": "Freeze a Trip snapshot into a Proposal Version",
+        "x-voyant-api-id": "@voyant-travel/proposals#proposal-version-snapshot-extension.api",
         "parameters": [
           {
-            "name": "envelopeId",
-            "in": "path",
+            "schema": {
+              "type": "string"
+            },
             "required": true,
-            "schema": { "type": "string" }
+            "name": "envelopeId",
+            "in": "path"
           },
           {
-            "name": "proposalVersionId",
-            "in": "path",
+            "schema": {
+              "type": "string"
+            },
             "required": true,
-            "schema": { "type": "string" }
+            "name": "proposalVersionId",
+            "in": "path"
           }
         ],
         "responses": {
-          "200": { "description": "The updated Proposal Version and frozen Trip snapshot." },
-          "404": { "description": "The Trip or Proposal Version was not found." },
-          "409": { "description": "The Trip or Proposal Version cannot be snapshotted." }
+          "200": {
+            "description": "The updated Proposal Version and frozen Trip snapshot."
+          },
+          "404": {
+            "description": "The Trip or Proposal Version was not found."
+          },
+          "409": {
+            "description": "The Trip or Proposal Version cannot be snapshotted."
+          }
         },
-        "x-voyant-api-id": "@voyant-travel/proposals#proposal-version-snapshot-extension.api"
+        "operationId": "postAdminTripsByEnvelopeIdProposalVersionsByProposalVersionIdSnapshot",
+        "tags": ["trips"],
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     }
   }

--- a/packages/proposals/package.json
+++ b/packages/proposals/package.json
@@ -24,7 +24,7 @@
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=proposals_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
-    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && node --import tsx scripts/generate-booking-openapi.ts && biome format --write openapi/admin/proposals.json openapi/admin/proposals-booking.json",
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && node --import tsx scripts/generate-booking-openapi.ts && node --import tsx scripts/generate-public-openapi.ts && node --import tsx scripts/generate-snapshot-openapi.ts && biome format --write openapi/admin/proposals.json openapi/admin/proposals-booking.json openapi/public-api/proposals-public.json openapi/admin/proposal-version-snapshot.json",
     "lint": "biome check src/",
     "prepack": "pnpm run build",
     "test": "vitest run",

--- a/packages/proposals/scripts/generate-public-openapi.ts
+++ b/packages/proposals/scripts/generate-public-openapi.ts
@@ -1,0 +1,113 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createProposalPresentationPublicRoutes } from "../src/proposal-routes.js"
+
+const PREFIX = "/v1/public/proposals"
+const MODULE = "proposals"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/public-api/proposals-public.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+/**
+ * Runtime resolvers that never reach the document — every path here is declared
+ * through `openAPIRegistry.registerPath`, which is static. These satisfy the
+ * constructor and are never called.
+ */
+const NEVER_RUN = {
+  resolveDb: () => ({}),
+  resolvePublicProposalBaseUrl: () => "https://example.invalid",
+  resolveOperatorProfile: async () => ({}),
+  seedAcceptedProposalBookingSession: async () => ({}),
+} as never
+
+const live = createProposalPresentationPublicRoutes(NEVER_RUN).getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+// Metadata the route declared itself, captured before stamping fills in
+// derived placeholders for anything it left out.
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+// Precedence: what the ROUTE declared, then what the document already said,
+// then what `stampModuleMetadata` derived.
+//
+// The derived values are placeholders — a summary of "GET /v1/admin/apps" where
+// a human wrote "List app registrations" — so they must not beat curated prose.
+// But copying the committed value unconditionally is worse: a route that changes
+// its own `operationId`, `summary`, `tags` or `x-voyant-api-id` would have the
+// change silently reverted, and `verify:openapi-drift` would then reproduce the
+// stale contract forever. So the route wins whenever it actually said something.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/proposals/scripts/generate-snapshot-openapi.ts
+++ b/packages/proposals/scripts/generate-snapshot-openapi.ts
@@ -1,0 +1,117 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * The document was hand-written with nothing regenerating it, so it could
+ * describe a surface the deployment no longer has. Every document brought under
+ * generation so far had drifted.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree, and
+ * `verify:openapi-path-ownership` fails if a path appears here that the routes
+ * do not produce.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createProposalVersionSnapshotRoutes } from "../src/proposal-routes.js"
+
+const PREFIX = "/v1/admin/trips"
+const MODULE = "proposals"
+const artifactPath = resolve(
+  import.meta.dirname,
+  "..",
+  "openapi/admin/proposal-version-snapshot.json",
+)
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+/**
+ * Runtime resolvers that never reach the document — every path here is declared
+ * through `openAPIRegistry.registerPath`, which is static. These satisfy the
+ * constructor and are never called.
+ */
+const NEVER_RUN = {
+  resolveDb: () => ({}),
+  resolvePublicProposalBaseUrl: () => "https://example.invalid",
+  resolveOperatorProfile: async () => ({}),
+  seedAcceptedProposalBookingSession: async () => ({}),
+} as never
+
+const live = createProposalVersionSnapshotRoutes(NEVER_RUN).getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// Route modules use both conventions: some mount at `/` and declare
+// prefix-relative paths, others declare the absolute path themselves. Prefixing
+// unconditionally double-prefixes the second kind — `/v1/admin/x/v1/admin/x` —
+// which reads as a wholesale path rename rather than the mistake it is. The
+// published document is absolute either way, and `stampModuleMetadata` derives
+// ids from the absolute path, so normalise before stamping, not after.
+const absolutise = (path: string) =>
+  path === "/" ? PREFIX : path.startsWith("/v1/") ? path : `${PREFIX}${path}`
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [absolutise(path), item]),
+  ),
+}
+// Metadata the route declared itself, captured before stamping fills in
+// derived placeholders for anything it left out.
+const declared = new Map<string, Record<string, unknown>>()
+for (const [path, item] of Object.entries(prefixed.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  for (const [method, operation] of Object.entries(item as Record<string, unknown>)) {
+    if (operation && typeof operation === "object") {
+      declared.set(`${method} ${path}`, { ...(operation as Record<string, unknown>) })
+    }
+  }
+}
+
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, MODULE]]))
+
+// Schemas come from the routes; prose does not. `stampModuleMetadata` derives a
+// placeholder summary ("GET /v1/admin/apps") where a human wrote "List app
+// registrations", and the `x-voyant-*` graph stamps say which bundle an
+// operation belongs to — neither is recoverable from the route definitions.
+//
+// So these keys are carried forward from the committed operation when it has
+// them, exactly as the finance generator does. Which of them a document carries
+// varies: some have the full set of stamps, some one key, some none, and some
+// have curated summaries where others have nothing.
+// Precedence: what the ROUTE declared, then what the document already said,
+// then what `stampModuleMetadata` derived.
+//
+// The derived values are placeholders — a summary of "GET /v1/admin/apps" where
+// a human wrote "List app registrations" — so they must not beat curated prose.
+// But copying the committed value unconditionally is worse: a route that changes
+// its own `operationId`, `summary`, `tags` or `x-voyant-api-id` would have the
+// change silently reverted, and `verify:openapi-drift` would then reproduce the
+// stale contract forever. So the route wins whenever it actually said something.
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  if (!item || typeof item !== "object") continue
+  const previous = artifact.paths?.[path] as Record<string, Record<string, unknown>> | undefined
+  for (const method of OPERATION_METHODS) {
+    const operation = (item as Record<string, unknown>)[method] as
+      | Record<string, unknown>
+      | undefined
+    if (!operation) continue
+    const routeDeclared = declared.get(`${method} ${path}`) ?? {}
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (routeDeclared[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+  paths[path] = item
+}
+
+// Built from the live surface alone, never merged into what the artifact held:
+// merging only ever adds, so a path the surface stopped serving would survive
+// forever with nothing regenerating or comparing it.
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/proposals/src/proposal-routes.ts
+++ b/packages/proposals/src/proposal-routes.ts
@@ -400,11 +400,24 @@ export function createProposalVersionSnapshotRoutes(
   app.post("/:envelopeId/proposal-versions/:proposalVersionId/snapshot", (c) =>
     handleFreezeProposalVersionSnapshot(c, options),
   )
+  // The path parameters and the 404/409 the handler can return were described in
+  // the published document and not here, so generating the document from this
+  // registration would have dropped them. The registration is the source now.
   app.openAPIRegistry.registerPath({
     method: "post",
     path: "/{envelopeId}/proposal-versions/{proposalVersionId}/snapshot",
     summary: "Freeze a Trip snapshot into a Proposal Version",
-    responses: { 200: { description: "The updated Proposal Version and frozen Trip snapshot." } },
+    request: {
+      params: z.object({
+        envelopeId: z.string(),
+        proposalVersionId: z.string(),
+      }),
+    },
+    responses: {
+      200: { description: "The updated Proposal Version and frozen Trip snapshot." },
+      404: { description: "The Trip or Proposal Version was not found." },
+      409: { description: "The Trip or Proposal Version cannot be snapshotted." },
+    },
     "x-voyant-api-id": PROPOSAL_VERSION_SNAPSHOT_OPENAPI_API_ID,
   })
   return app

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -22,12 +22,13 @@
     "./openapi/admin/video-upload-ticket": "./openapi/admin/storage-video-upload-ticket.json"
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.typecheck.json",
-    "lint": "biome check src/",
-    "test": "vitest run",
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig*.tsbuildinfo",
-    "prepack": "pnpm run build"
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && biome format --write openapi/admin/storage-uploads.json openapi/admin/storage-video-upload-ticket.json openapi/admin/storage-media.json",
+    "lint": "biome check src/",
+    "prepack": "pnpm run build",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "files": [
     "dist",

--- a/packages/storage/scripts/generate-openapi.ts
+++ b/packages/storage/scripts/generate-openapi.ts
@@ -1,0 +1,71 @@
+/**
+ * Regenerates this package's three published admin OpenAPI documents from the
+ * live route module.
+ *
+ * One route module produces all three paths, and each path is published as its
+ * own document, so the metadata carried forward for a path must come from *that
+ * path's* document — reading one artifact and writing three drops the
+ * operationId, tags and graph stamps of the other two.
+ *
+ * No `stampModuleMetadata`: this package does not depend on `@voyant-travel/hono`,
+ * and adding a dependency for a build script would be the tail wagging the dog.
+ * The operations carry their own `x-voyant-api-id` from `STORAGE_OPENAPI_API_IDS`,
+ * and the rest is carried forward from each document.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { createMediaRoutes } from "../src/routes.js"
+
+/**
+ * Satisfies the constructor and is never called. The document comes from static
+ * `openAPIRegistry.registerPath` declarations; `resolveStorage` returning null is
+ * exactly what an unconfigured deployment does, and signing a ticket is a runtime
+ * concern the schema never sees.
+ */
+const NEVER_RUN = {
+  resolveStorage: () => null,
+  signVideoUploadTicket: async () => ({}),
+} as never
+
+/** Each published document owns exactly one of the module's paths. */
+const BY_DOCUMENT: Record<string, string> = {
+  "/v1/admin/uploads": "openapi/admin/storage-uploads.json",
+  "/v1/admin/uploads/video": "openapi/admin/storage-video-upload-ticket.json",
+  "/v1/admin/media/{key}": "openapi/admin/storage-media.json",
+}
+
+const CARRIED = ["operationId", "summary", "tags"]
+const OPERATION_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+
+const first = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, "..", BY_DOCUMENT["/v1/admin/uploads"]), "utf8"),
+)
+const live = createMediaRoutes(NEVER_RUN).getOpenAPI31Document({
+  openapi: first.openapi,
+  info: first.info,
+})
+
+for (const [route, file] of Object.entries(BY_DOCUMENT)) {
+  const produced = (live.paths ?? {})[route] as Record<string, unknown> | undefined
+  if (!produced) throw new Error(`storage generate:openapi: routes no longer produce ${route}`)
+
+  const target = resolve(import.meta.dirname, "..", file)
+  const document = JSON.parse(readFileSync(target, "utf8"))
+  const previous = document.paths?.[route] as Record<string, Record<string, unknown>> | undefined
+
+  for (const method of OPERATION_METHODS) {
+    const operation = produced[method] as Record<string, unknown> | undefined
+    if (!operation) continue
+    for (const [key, value] of Object.entries(previous?.[method] ?? {})) {
+      if (!(key.startsWith("x-voyant-") || CARRIED.includes(key))) continue
+      if (operation[key] !== undefined) continue
+      operation[key] = value
+    }
+  }
+
+  writeFileSync(
+    target,
+    `${JSON.stringify({ ...document, paths: { [route]: produced } }, null, 2)}\n`,
+  )
+}

--- a/scripts/check-openapi-path-ownership.mjs
+++ b/scripts/check-openapi-path-ownership.mjs
@@ -30,12 +30,19 @@
  * on SIGINT/SIGTERM, because a run killed midway must not leave an emptied
  * document behind for `git add -A` to commit. Everything it touches is tracked,
  * so `git checkout -- packages` recovers regardless.
+ *
+ * Probes whose generators cannot write the same file run concurrently; see
+ * `checks/openapi/generator-groups.mjs` for why the partition is over files.
  */
-import { execSync } from "node:child_process"
+import { execFile } from "node:child_process"
 import { readFileSync, writeFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
 
+import { CONCURRENCY, commandGroups, inParallel } from "./checks/openapi/generator-groups.mjs"
+
+const run = promisify(execFile)
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 const specsPath = path.join(root, "scripts/checks/openapi/generated-specs.json")
 const baselinePath = path.join(root, "scripts/checks/openapi/path-ownership-baseline.json")
@@ -66,7 +73,18 @@ for (const generator of generators) {
 }
 const targets = [...byFile].map(([file, commands]) => ({ file, commands }))
 
-/** Original bytes, so a killed run cannot leave an emptied document behind. */
+/** Every file a command writes, so the whole blast radius can be put back. */
+const writtenBy = new Map(generators.map((generator) => [generator.command, generator.files]))
+
+/**
+ * Original bytes, so a killed run cannot leave an emptied document behind.
+ *
+ * Keyed by every file the running command *writes*, not only the one being
+ * probed. A generator normally emits several documents and rewrites all of them
+ * on every invocation, so a run killed midway used to leave the probed file
+ * restored and its siblings half-written — observed on a SIGTERM here, which
+ * left six unrelated documents modified while reporting a clean restore.
+ */
 const held = new Map()
 const restoreAll = () => {
   for (const [file, bytes] of held) writeFileSync(path.join(root, file), bytes)
@@ -82,19 +100,27 @@ for (const signal of ["SIGINT", "SIGTERM"]) {
 const pathsOf = (file) => Object.keys(JSON.parse(readFileSync(file, "utf8")).paths ?? {})
 
 /** What the generator puts back into an emptied document is what it owns. */
-function ownedPaths(file, command) {
+async function ownedPaths(file, command) {
   const absolute = path.join(root, file)
-  const original = readFileSync(absolute)
-  held.set(file, original)
+  const touched = new Set([file, ...(writtenBy.get(command) ?? [])])
+  const originals = new Map()
+  for (const name of touched) {
+    const bytes = readFileSync(path.join(root, name))
+    originals.set(name, bytes)
+    held.set(name, bytes)
+  }
   try {
-    const document = JSON.parse(original.toString("utf8"))
+    const document = JSON.parse(originals.get(file).toString("utf8"))
     document.paths = {}
     writeFileSync(absolute, `${JSON.stringify(document, null, 2)}\n`)
-    execSync(command, { cwd: root, stdio: "ignore" })
+    const [binary, ...args] = command.split(" ")
+    await run(binary, args, { cwd: root })
     return new Set(pathsOf(absolute))
   } finally {
-    writeFileSync(absolute, original)
-    held.delete(file)
+    for (const [name, bytes] of originals) {
+      writeFileSync(path.join(root, name), bytes)
+      held.delete(name)
+    }
   }
 }
 
@@ -103,13 +129,35 @@ const improved = []
 let ownedTotal = 0
 let pathTotal = 0
 
-try {
-  for (const target of targets) {
+/**
+ * Probes that could write the same file must not overlap.
+ *
+ * A probe empties one document and reads back what the generator put there, but
+ * a generator normally emits several documents — so an overlapping command
+ * running concurrently would refill the file mid-probe and the read-back would
+ * report paths as owned that this generator never produced. Grouping is computed
+ * over every generator, including the api-client ones excluded from `targets`,
+ * because a coarser partition is only ever safer.
+ */
+const groupOf = new Map()
+commandGroups(generators).forEach((group, index) => {
+  for (const command of group) groupOf.set(command, index)
+})
+const buckets = new Map()
+for (const target of targets) {
+  const index = groupOf.get(target.commands[0])
+  const bucket = buckets.get(index) ?? []
+  bucket.push(target)
+  buckets.set(index, bucket)
+}
+
+async function probe(target) {
+  {
     const declared = pathsOf(path.join(root, target.file))
     const owned = new Set()
 
     for (const command of target.commands) {
-      const produced = ownedPaths(target.file, command)
+      const produced = await ownedPaths(target.file, command)
       for (const route of produced) owned.add(route)
 
       // A command registered for a document it does not write. `verify:openapi-drift`
@@ -143,9 +191,21 @@ try {
       improved.push(`${target.file}: ${allowed} -> ${unowned.length}`)
     }
   }
+}
+
+try {
+  await inParallel([...buckets.values()], async (bucket) => {
+    // Sequential within a bucket: these probes can write the same file.
+    for (const target of bucket) await probe(target)
+  })
 } finally {
   restoreAll()
 }
+
+// Probes finish in whatever order the workers free up, so sort before reporting.
+// A checker whose output reorders between runs is one nobody can diff.
+violations.sort()
+improved.sort()
 
 for (const file of Object.keys(baseline)) {
   if (!targets.some((target) => target.file === file)) {
@@ -169,5 +229,6 @@ const unownedTotal = pathTotal - ownedTotal
 console.log(
   `check-openapi-path-ownership: ${ownedTotal}/${pathTotal} paths in registered documents are ` +
     `produced by their generator` +
-    (unownedTotal > 0 ? ` (${unownedTotal} carried through unchecked)` : ""),
+    (unownedTotal > 0 ? ` (${unownedTotal} carried through unchecked)` : "") +
+    ` — ${targets.length} documents probed, ${CONCURRENCY} at a time.`,
 )

--- a/scripts/check-openapi-path-ownership.mjs
+++ b/scripts/check-openapi-path-ownership.mjs
@@ -43,14 +43,28 @@ const baselinePath = path.join(root, "scripts/checks/openapi/path-ownership-base
 const { generators } = JSON.parse(readFileSync(specsPath, "utf8"))
 const baseline = JSON.parse(readFileSync(baselinePath, "utf8")).unownedPaths
 
-/** Documents to probe: the OpenAPI artifacts, not the generated clients. */
-const targets = generators
-  .filter((generator) => !generator.command.includes("generate:api-client"))
-  .flatMap((generator) =>
-    generator.files
-      .filter((file) => file.endsWith(".json"))
-      .map((file) => ({ file, command: generator.command })),
-  )
+/**
+ * Documents to probe: the OpenAPI artifacts, not the generated clients.
+ *
+ * Grouped by FILE, because a document may legitimately be registered under more
+ * than one command — one artifact fed by two packages' route modules. Ownership
+ * is then the union over its commands: a path is owned if any generator that
+ * claims the file puts it back.
+ *
+ * Probing per (file, command) pair instead reported every path of a two-command
+ * document as unowned, because emptying it and running one of the two returns
+ * only that one's paths.
+ */
+const byFile = new Map()
+for (const generator of generators) {
+  if (generator.command.includes("generate:api-client")) continue
+  for (const file of generator.files) {
+    if (!file.endsWith(".json")) continue
+    if (!byFile.has(file)) byFile.set(file, [])
+    byFile.get(file).push(generator.command)
+  }
+}
+const targets = [...byFile].map(([file, commands]) => ({ file, commands }))
 
 /** Original bytes, so a killed run cannot leave an emptied document behind. */
 const held = new Map()
@@ -68,7 +82,7 @@ for (const signal of ["SIGINT", "SIGTERM"]) {
 const pathsOf = (file) => Object.keys(JSON.parse(readFileSync(file, "utf8")).paths ?? {})
 
 /** What the generator puts back into an emptied document is what it owns. */
-function ownedPaths({ file, command }) {
+function ownedPaths(file, command) {
   const absolute = path.join(root, file)
   const original = readFileSync(absolute)
   held.set(file, original)
@@ -92,7 +106,24 @@ let pathTotal = 0
 try {
   for (const target of targets) {
     const declared = pathsOf(path.join(root, target.file))
-    const owned = ownedPaths(target)
+    const owned = new Set()
+
+    for (const command of target.commands) {
+      const produced = ownedPaths(target.file, command)
+      for (const route of produced) owned.add(route)
+
+      // A command registered for a document it does not write. `verify:openapi-drift`
+      // regenerates and diffs the files each command lists, so such a pair diffs a
+      // file that command never touches — it always matches, and the document looks
+      // checked by one more generator than actually checks it.
+      if (produced.size === 0 && declared.length > 0) {
+        violations.push(
+          `generated-specs.json registers ${target.file} under \`${command}\`, which produces ` +
+            `none of its paths. Drift diffs it there against a generator that never writes it.`,
+        )
+      }
+    }
+
     const unowned = declared.filter((route) => !owned.has(route))
 
     pathTotal += declared.length

--- a/scripts/checks/openapi/generated-specs.json
+++ b/scripts/checks/openapi/generated-specs.json
@@ -9,6 +9,13 @@
   ],
   "generators": [
     {
+      "command": "pnpm --filter @voyant-travel/accommodations generate:openapi",
+      "files": [
+        "packages/accommodations/openapi/admin/accommodations.json",
+        "packages/accommodations/openapi/public-api/accommodations-content-public.json"
+      ]
+    },
+    {
       "command": "pnpm --filter @voyant-travel/action-ledger generate:openapi",
       "files": [
         "packages/action-ledger/openapi/admin/action-ledger.json",
@@ -16,12 +23,19 @@
       ]
     },
     {
-      "command": "pnpm --filter @voyant-travel/accommodations generate:openapi",
-      "files": ["packages/accommodations/openapi/admin/accommodations.json"]
-    },
-    {
       "command": "pnpm --filter @voyant-travel/apps generate:openapi",
       "files": ["packages/apps/openapi/admin/apps.json"]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/auth generate:openapi",
+      "files": [
+        "packages/auth/openapi/admin/team.json",
+        "packages/auth/openapi/admin/customer-business-accounts.json",
+        "packages/auth/openapi/admin/invitations.json",
+        "packages/auth/openapi/admin/public-api-keys.json",
+        "packages/auth/openapi/admin/customer-accounts.json",
+        "packages/auth/openapi/public-api/invitations.json"
+      ]
     },
     {
       "command": "pnpm --filter @voyant-travel/bookings generate:openapi",
@@ -29,14 +43,16 @@
         "packages/bookings/openapi/admin/bookings.json",
         "packages/bookings/openapi/admin/booking-extras.json",
         "packages/bookings/openapi/admin/booking-requirements.json",
-        "packages/bookings/openapi/public-api/booking-requirements.json"
+        "packages/bookings/openapi/public-api/booking-requirements.json",
+        "packages/bookings/openapi/public-api/bookings.json"
       ]
     },
     {
       "command": "pnpm --filter @voyant-travel/catalog generate:openapi",
       "files": [
         "packages/catalog/openapi/admin/catalog-booking.json",
-        "packages/catalog/openapi/public-api/catalog-booking.json"
+        "packages/catalog/openapi/public-api/catalog-booking.json",
+        "packages/catalog/openapi/admin/catalog.json"
       ]
     },
     {
@@ -45,14 +61,6 @@
         "packages/charters/openapi/admin/charters.json",
         "packages/charters/openapi/public-api/charters.json"
       ]
-    },
-    {
-      "command": "pnpm --filter @voyant-travel/custom-fields generate:openapi",
-      "files": ["packages/custom-fields/openapi/admin/custom-fields.json"]
-    },
-    {
-      "command": "pnpm --filter @voyant-travel/event-catalog generate:openapi",
-      "files": ["packages/event-catalog/openapi/admin/event-catalog.json"]
     },
     {
       "command": "pnpm --filter @voyant-travel/commerce generate:openapi",
@@ -73,13 +81,22 @@
       ]
     },
     {
+      "command": "pnpm --filter @voyant-travel/custom-fields generate:openapi",
+      "files": ["packages/custom-fields/openapi/admin/custom-fields.json"]
+    },
+    {
       "command": "pnpm --filter @voyant-travel/distribution generate:openapi",
       "files": [
         "packages/distribution/openapi/admin/distribution.json",
         "packages/distribution/openapi/admin/suppliers.json",
         "packages/distribution/openapi/admin/external-refs.json",
-        "packages/distribution/openapi/admin/distribution-channel-push.json"
+        "packages/distribution/openapi/admin/distribution-channel-push.json",
+        "packages/distribution/openapi/admin/distribution-booking.json"
       ]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/event-catalog generate:openapi",
+      "files": ["packages/event-catalog/openapi/admin/event-catalog.json"]
     },
     {
       "command": "pnpm --filter @voyant-travel/finance generate:openapi",
@@ -87,7 +104,8 @@
         "packages/finance/openapi/admin/finance.json",
         "packages/finance/openapi/public-api/finance.json",
         "packages/finance/openapi/admin/booking-tax-settings.json",
-        "packages/finance/openapi/admin/booking-tax-preview.json"
+        "packages/finance/openapi/admin/booking-tax-preview.json",
+        "packages/finance/openapi/public-api/payment-link.json"
       ]
     },
     {
@@ -117,7 +135,14 @@
     },
     {
       "command": "pnpm --filter @voyant-travel/legal generate:openapi",
-      "files": ["packages/legal/openapi/admin/legal.json"]
+      "files": [
+        "packages/legal/openapi/admin/legal.json",
+        "packages/legal/openapi/public-api/legal.json"
+      ]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/mcp generate:openapi",
+      "files": ["packages/mcp/openapi/admin/mcp.json"]
     },
     {
       "command": "pnpm --filter @voyant-travel/media generate:openapi",
@@ -150,7 +175,9 @@
       "command": "pnpm --filter @voyant-travel/proposals generate:openapi",
       "files": [
         "packages/proposals/openapi/admin/proposals.json",
-        "packages/proposals/openapi/admin/proposals-booking.json"
+        "packages/proposals/openapi/admin/proposals-booking.json",
+        "packages/proposals/openapi/public-api/proposals-public.json",
+        "packages/proposals/openapi/admin/proposal-version-snapshot.json"
       ]
     },
     {
@@ -181,6 +208,14 @@
     {
       "command": "pnpm --filter @voyant-travel/setup generate:openapi",
       "files": ["packages/setup/openapi/admin/setup.json"]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/storage generate:openapi",
+      "files": [
+        "packages/storage/openapi/admin/storage-uploads.json",
+        "packages/storage/openapi/admin/storage-video-upload-ticket.json",
+        "packages/storage/openapi/admin/storage-media.json"
+      ]
     },
     {
       "command": "pnpm --filter @voyant-travel/trips generate:openapi",

--- a/scripts/checks/openapi/generator-groups.mjs
+++ b/scripts/checks/openapi/generator-groups.mjs
@@ -1,0 +1,100 @@
+/**
+ * Which generator commands may run at the same time, and how many at once.
+ *
+ * `verify:openapi-drift` and `verify:openapi-path-ownership` both drive the real
+ * generators — deliberately, because a reimplementation inside a checker would
+ * drift from the generator exactly the way the documents drifted from the routes.
+ * The cost is therefore in *how many processes are started*, not in what they do:
+ * together the two checks were spending nine minutes locally on ~71 sequential
+ * `pnpm --filter <pkg> generate:openapi` runs, each paying pnpm startup plus a
+ * `tsx` compile before doing any work. That put the `architecture` CI job, which
+ * has a ten-minute budget, over the line (voyant#4855).
+ *
+ * Running them concurrently is safe only between commands that cannot write the
+ * same file. Two that can must stay in order, and the reason is specific rather
+ * than theoretical: both checks work by writing an artifact and reading back what
+ * a generator put there. A generator usually emits *several* documents, so a
+ * concurrent run of an overlapping command would rewrite the file the other one
+ * is mid-probe on, and the read-back would report paths that the probe had just
+ * emptied — a false pass, in the direction that matters.
+ *
+ * So commands are partitioned into connected components over the files they
+ * write. Components run in parallel; the commands inside one run in sequence.
+ */
+import { availableParallelism } from "node:os"
+
+/**
+ * Commands partitioned so that no two groups write a file in common.
+ *
+ * @param {ReadonlyArray<{ command: string, files: ReadonlyArray<string> }>} generators
+ * @returns {string[][]} each group is a list of commands that must run in sequence
+ */
+export function commandGroups(generators) {
+  const parent = new Map()
+  const find = (command) => {
+    let node = command
+    while (parent.get(node) !== node) {
+      parent.set(node, parent.get(parent.get(node)))
+      node = parent.get(node)
+    }
+    return node
+  }
+  const union = (a, b) => {
+    const rootA = find(a)
+    const rootB = find(b)
+    if (rootA !== rootB) parent.set(rootA, rootB)
+  }
+
+  for (const { command } of generators) {
+    if (!parent.has(command)) parent.set(command, command)
+  }
+
+  const writtenBy = new Map()
+  for (const { command, files } of generators) {
+    for (const file of files) {
+      const existing = writtenBy.get(file)
+      if (existing === undefined) writtenBy.set(file, command)
+      else union(existing, command)
+    }
+  }
+
+  const groups = new Map()
+  for (const { command } of generators) {
+    const root = find(command)
+    const members = groups.get(root) ?? []
+    if (!members.includes(command)) members.push(command)
+    groups.set(root, members)
+  }
+  return [...groups.values()]
+}
+
+/**
+ * How many groups to run at once.
+ *
+ * Capped low on purpose. Each worker is a full `pnpm` + `tsx` process tree, so
+ * the limit is memory and I/O rather than cores, and a CI runner with four vCPUs
+ * is the machine that has to stay under the budget.
+ */
+export const CONCURRENCY = Math.max(1, Math.min(4, availableParallelism()))
+
+/**
+ * Run `worker` over `items`, at most `limit` at a time, preserving input order in
+ * the results.
+ *
+ * @template T, R
+ * @param {ReadonlyArray<T>} items
+ * @param {(item: T, index: number) => Promise<R>} worker
+ * @param {number} limit
+ * @returns {Promise<R[]>}
+ */
+export async function inParallel(items, worker, limit = CONCURRENCY) {
+  const results = new Array(items.length)
+  let next = 0
+  const lanes = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, async () => {
+    for (let index = next++; index < items.length; index = next++) {
+      results[index] = await worker(items[index], index)
+    }
+  })
+  await Promise.all(lanes)
+  return results
+}

--- a/scripts/checks/openapi/index.mjs
+++ b/scripts/checks/openapi/index.mjs
@@ -16,17 +16,23 @@
  * drift from the real generator exactly the way the specs drifted from the
  * routes.
  *
+ * Generators that cannot write the same file run concurrently — see
+ * `generator-groups.mjs` for why the grouping is by file rather than by package.
+ *
  * The originals are restored in a `finally`, and again on SIGINT/SIGTERM, so
  * neither a failing run nor a killed one leaves the tree different from how it
  * found it.
  */
-import { execFileSync } from "node:child_process"
+import { execFile } from "node:child_process"
 import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
 
 import { driftedFiles } from "./assertions.mjs"
+import { CONCURRENCY, commandGroups, inParallel } from "./generator-groups.mjs"
 
+const run = promisify(execFile)
 const here = dirname(fileURLToPath(import.meta.url))
 const { generators } = JSON.parse(readFileSync(join(here, "generated-specs.json"), "utf8"))
 
@@ -35,20 +41,21 @@ const read = (file) => (existsSync(file) ? readFileSync(file) : null)
 const failures = []
 
 /**
- * The originals of the generator currently running.
+ * Originals of every generator currently running, keyed by file.
  *
  * The `finally` below covers a generator that throws, but not a process that is
  * killed — Ctrl-C, a CI cancellation, an OOM inside a generator. Without this
  * the regenerated documents are left in the tree, and because the run also
  * *looks* like it just failed, the natural next step is to inspect a tree that
- * has quietly been modified.
+ * has quietly been modified. It is a map rather than a list because several
+ * generators are in flight at once.
  */
-let inFlight = []
+const inFlight = new Map()
 const restoreInFlight = () => {
-  for (const { file, bytes } of inFlight) {
+  for (const [file, bytes] of inFlight) {
     if (bytes !== null) writeFileSync(file, bytes)
   }
-  inFlight = []
+  inFlight.clear()
 }
 for (const signal of ["SIGINT", "SIGTERM"]) {
   process.on(signal, () => {
@@ -57,17 +64,15 @@ for (const signal of ["SIGINT", "SIGTERM"]) {
   })
 }
 
-for (const generator of generators) {
+const byCommand = new Map(generators.map((generator) => [generator.command, generator]))
+
+async function checkGenerator(generator) {
   const before = generator.files.map((file) => ({ file, bytes: read(file) }))
-  inFlight = before
+  for (const { file, bytes } of before) inFlight.set(file, bytes)
   try {
     const [command, ...args] = generator.command.split(" ")
-    execFileSync(command, args, { stdio: "pipe" })
-    const snapshots = before.map(({ file, bytes }) => ({
-      file,
-      before: bytes,
-      after: read(file),
-    }))
+    await run(command, args)
+    const snapshots = before.map(({ file, bytes }) => ({ file, before: bytes, after: read(file) }))
     const drifted = driftedFiles(snapshots)
     if (drifted.length > 0) {
       failures.push(...drifted, `    fix with: ${generator.command}`)
@@ -77,9 +82,18 @@ for (const generator of generators) {
   } finally {
     for (const { file, bytes } of before) {
       if (bytes !== null) writeFileSync(file, bytes)
+      inFlight.delete(file)
     }
-    inFlight = []
   }
+}
+
+try {
+  await inParallel(commandGroups(generators), async (group) => {
+    // Sequential within a group: these commands can write the same file.
+    for (const command of group) await checkGenerator(byCommand.get(command))
+  })
+} finally {
+  restoreInFlight()
 }
 
 if (failures.length > 0) {
@@ -89,4 +103,7 @@ if (failures.length > 0) {
 }
 
 const count = generators.reduce((total, generator) => total + generator.files.length, 0)
-console.log(`verify:openapi-drift: ${count} generated OpenAPI document(s) match their routes.`)
+console.log(
+  `verify:openapi-drift: ${count} generated OpenAPI document(s) match their routes ` +
+    `(${generators.length} generators, ${CONCURRENCY} at a time).`,
+)

--- a/scripts/checks/openapi/index.mjs
+++ b/scripts/checks/openapi/index.mjs
@@ -16,8 +16,9 @@
  * drift from the real generator exactly the way the specs drifted from the
  * routes.
  *
- * The originals are restored in a `finally`, so a failing run leaves the tree
- * exactly as it found it.
+ * The originals are restored in a `finally`, and again on SIGINT/SIGTERM, so
+ * neither a failing run nor a killed one leaves the tree different from how it
+ * found it.
  */
 import { execFileSync } from "node:child_process"
 import { existsSync, readFileSync, writeFileSync } from "node:fs"
@@ -33,8 +34,32 @@ const read = (file) => (existsSync(file) ? readFileSync(file) : null)
 
 const failures = []
 
+/**
+ * The originals of the generator currently running.
+ *
+ * The `finally` below covers a generator that throws, but not a process that is
+ * killed — Ctrl-C, a CI cancellation, an OOM inside a generator. Without this
+ * the regenerated documents are left in the tree, and because the run also
+ * *looks* like it just failed, the natural next step is to inspect a tree that
+ * has quietly been modified.
+ */
+let inFlight = []
+const restoreInFlight = () => {
+  for (const { file, bytes } of inFlight) {
+    if (bytes !== null) writeFileSync(file, bytes)
+  }
+  inFlight = []
+}
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    restoreInFlight()
+    process.exit(130)
+  })
+}
+
 for (const generator of generators) {
   const before = generator.files.map((file) => ({ file, bytes: read(file) }))
+  inFlight = before
   try {
     const [command, ...args] = generator.command.split(" ")
     execFileSync(command, args, { stdio: "pipe" })
@@ -53,6 +78,7 @@ for (const generator of generators) {
     for (const { file, bytes } of before) {
       if (bytes !== null) writeFileSync(file, bytes)
     }
+    inFlight = []
   }
 }
 

--- a/scripts/tests/openapi-generator-groups.test.mjs
+++ b/scripts/tests/openapi-generator-groups.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+import { CONCURRENCY, commandGroups, inParallel } from "../checks/openapi/generator-groups.mjs"
+
+test("commands that share no file are independent", () => {
+  const groups = commandGroups([
+    { command: "a", files: ["one.json"] },
+    { command: "b", files: ["two.json"] },
+  ])
+  assert.equal(groups.length, 2)
+  assert.deepEqual(groups.map((group) => group.sort()).sort(), [["a"], ["b"]])
+})
+
+test("commands that write the same file stay in one group, so they cannot overlap", () => {
+  const groups = commandGroups([
+    { command: "a", files: ["shared.json"] },
+    { command: "b", files: ["shared.json"] },
+  ])
+  assert.deepEqual(groups, [["a", "b"]])
+})
+
+// The case the union-find is for: a and c never touch the same file, but b
+// bridges them, so all three have to be serialised.
+test("sharing is transitive", () => {
+  const groups = commandGroups([
+    { command: "a", files: ["one.json"] },
+    { command: "b", files: ["one.json", "two.json"] },
+    { command: "c", files: ["two.json"] },
+  ])
+  assert.equal(groups.length, 1)
+  assert.deepEqual(groups[0].sort(), ["a", "b", "c"])
+})
+
+test("every command appears in exactly one group", () => {
+  const { generators } = JSON.parse(
+    readFileSync(new URL("../checks/openapi/generated-specs.json", import.meta.url), "utf8"),
+  )
+  const groups = commandGroups(generators)
+  const flat = groups.flat()
+  assert.equal(flat.length, new Set(flat).size, "a command appears twice")
+  assert.deepEqual(
+    [...new Set(flat)].sort(),
+    [...new Set(generators.map((generator) => generator.command))].sort(),
+  )
+})
+
+// The property the whole parallelisation rests on: if two groups could write the
+// same file, a concurrent probe would read back paths another generator wrote.
+test("no file is written by two different groups", () => {
+  const { generators } = JSON.parse(
+    readFileSync(new URL("../checks/openapi/generated-specs.json", import.meta.url), "utf8"),
+  )
+  const groupOf = new Map()
+  commandGroups(generators).forEach((group, index) => {
+    for (const command of group) groupOf.set(command, index)
+  })
+
+  const owner = new Map()
+  for (const { command, files } of generators) {
+    for (const file of files) {
+      const index = groupOf.get(command)
+      const existing = owner.get(file)
+      assert.ok(
+        existing === undefined || existing === index,
+        `${file} is written by groups ${existing} and ${index}`,
+      )
+      owner.set(file, index)
+    }
+  }
+})
+
+test("inParallel preserves input order regardless of completion order", async () => {
+  const delays = [30, 1, 20, 2]
+  const results = await inParallel(
+    delays,
+    (ms, index) => new Promise((resolve) => setTimeout(() => resolve(index), ms)),
+    4,
+  )
+  assert.deepEqual(results, [0, 1, 2, 3])
+})
+
+test("inParallel runs no more than the limit at once", async () => {
+  let live = 0
+  let peak = 0
+  await inParallel(
+    Array.from({ length: 20 }, (_, index) => index),
+    async () => {
+      live += 1
+      peak = Math.max(peak, live)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      live -= 1
+    },
+    3,
+  )
+  assert.equal(peak, 3)
+})
+
+test("concurrency is bounded, because each lane is a whole pnpm process tree", () => {
+  assert.ok(CONCURRENCY >= 1 && CONCURRENCY <= 4, `unexpected concurrency ${CONCURRENCY}`)
+})

--- a/scripts/tests/tracked-tree-scan.test.mjs
+++ b/scripts/tests/tracked-tree-scan.test.mjs
@@ -202,12 +202,15 @@ test("retail-spine-closure still goes red on a tracked violation", () => {
   // The pair that makes the assertions above mean something: a checker that
   // ignored everything would pass them all.
   const manifest = path.join(repoRoot, "packages", "catalog", "package.json")
-  const original = execFileSync("git", ["show", "HEAD:packages/catalog/package.json"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-  })
+  // The WORKING-TREE bytes, not `git show HEAD:`. Restoring from HEAD discards
+  // whatever uncommitted change the manifest was carrying, so running
+  // `verify:architecture` with work in progress on this one file silently
+  // reverted it — and the chain then went green against a tree the developer no
+  // longer had. It is invisible in CI, where the file is committed and the two
+  // agree.
+  const original = readFileSync(manifest)
   try {
-    const parsed = JSON.parse(original)
+    const parsed = JSON.parse(original.toString("utf8"))
     parsed.voyant.requiresSchemas = ["@voyant-travel/db", "@voyant-travel/operations"]
     writeFileSync(manifest, `${JSON.stringify(parsed, null, 2)}\n`)
     const result = run("scripts/check-retail-spine-closure.mjs")


### PR DESCRIPTION
Eighteen more documents are generated from their routes, taking the registered set
from 60 to **78 of the 82 tracked documents**. With this,
`verify:openapi-path-ownership` reports **1131/1131 paths produced by a generator** —
every path in every registered document.

The four that remain are tracked in #4852, and they are not one thing:

- `reporting/openapi/admin/reporting.json` (7 paths) and
  `mice/openapi/admin/mice-booking.json` (1) are blocked on route authoring — no
  `createRoute` in either, so there is no schema to emit. `mice` mounts an
  `OpenAPIHono` app but registers plain `.get/.put/.delete` handlers.
- `legal/openapi/admin/contract-document.json` declares no paths at all, and should
  probably be deleted rather than generated.
- `catalog/openapi/public-api/catalog.json` is **generatable and simply not done
  yet** — its two paths come from two different packages, `catalog`'s search route
  and `commerce`'s `/checkout/start` (whose docblock says "mount at
  `/v1/public/catalog`"). Both carry full schemas. `commerce` depends on `catalog`,
  so a commerce-side generator can compose them. That is the next PR, along with a
  closure checker so a document in neither registry stops being silent.

## Newly generated

`accommodations-content-public`, `auth` × 6 (customer-accounts,
customer-business-accounts, invitations admin + public, public-api-keys, team),
`bookings` public, `catalog` admin, `distribution-booking`, `finance` payment-link
public, `legal` public, `mcp`, `proposals` public + version-snapshot, `storage` × 3
(media, uploads, video-upload-ticket).

## Four places the document was right and the code was wrong

Generating from the routes only preserves what the routes declare. In four cases the
published document carried something the route definition did not, so generating
would have silently dropped it. The fix is to move the information into the source,
not to special-case the generator:

- **`auth/src/invitations-routes.ts`** — `password` is `writeOnly` in the document
  and was not in the schema. That is a security-relevant statement (accepted, never
  returned), not decoration.
- **`finance/src/payment-link-routes.ts`** — the handler parses
  `startCardPaymentBodySchema` and the document described that body, but the route
  never declared a `request.body`. Generating would have published an endpoint that
  takes no body.
- **`proposals/src/proposal-routes.ts`** — the snapshot route's path parameters and
  its 404/409 responses existed only in the document.
- **`mcp/src/server.ts`** — the manifest response had no description.

## `verify:openapi-path-ownership` now handles a document with two generators

The check probes a document by emptying its `paths`, running its generator, and
seeing what comes back. It probed per *(file, command)* pair, so a document
registered under two commands reported every path as unowned — emptying it and
running one of the two returns only that one's paths. It now groups by file and
takes the union over its commands.

That surfaced a real defect rather than only a false positive:
`generated-specs.json` registered `packages/catalog/openapi/admin/catalog.json`
under the **event-catalog** generator, which writes only `event-catalog.json`
(a single `writeFileSync`, to its own artifact). So `verify:openapi-drift` was
diffing that document against a generator that never writes it — it always matched,
and the document looked checked by one more generator than actually checked it.

The stale registration is removed, and the check now fails on that shape directly:

```
generated-specs.json registers <file> under `<command>`, which produces none of
its paths. Drift diffs it there against a generator that never writes it.
```

Confirmed red by re-injecting the registration, and confirmed the probe restores
both fixture files byte-for-byte afterwards.

## Two checkers that were quietly modifying the tree

Both were found by asserting the working tree is byte-identical before and after
`verify:architecture`, which is worth doing more often than it is.

**`verify:tracked-tree-scan` silently reverted `packages/catalog/package.json`.** Its
"retail-spine-closure still goes red on a tracked violation" test injects a forbidden
edge into that manifest and restores it in a `finally` — but it took the restore
baseline from `git show HEAD:packages/catalog/package.json`, so it wrote *HEAD* back
and discarded whatever uncommitted change the file was carrying. That is exactly how
this branch lost its catalog generator registration mid-chain: the chain then went
green against a tree that no longer had the change in it.

It is invisible in CI, where the file is committed and HEAD matches the working tree,
so it could only ever bite someone running the chain locally with work in progress on
that one file. It now reads the working-tree bytes — which its sibling analytics test
already did, with a comment explaining why.

**`verify:openapi-drift` did not restore if it was killed.** Its `finally` covers a
generator that throws but not Ctrl-C, a CI cancellation, or an OOM; those left the
regenerated documents behind while the run merely looked like it had failed. It now
restores on `SIGINT`/`SIGTERM` as well, matching what
`check-openapi-path-ownership.mjs` already did.

## The `architecture` CI job had stopped passing, and it did not look like it

This is the part worth reviewing carefully, because it is a regression the previous
batch shipped and nobody could see.

`verify:architecture` runs under `timeout-minutes: 10`. Driving the real generators
costs ~71 sequential `pnpm --filter <pkg> generate:openapi` processes (#4855), and
the previous batch pushed that past the budget. Measured here:

| | before | after |
|---|---:|---:|
| `verify:openapi-drift` | 193s | **81s** |
| `verify:openapi-path-ownership` | 341s | **115s** |

Nine minutes of a ten-minute budget, for two of 102 links.

What made it invisible is the failure *mode*. A job that exceeds
`timeout-minutes` is **cancelled**, not failed — so the run has no failing step
under it, and the only red marks are the `checks` and `db-checks` aggregates,
which is indistinguishable from the concurrency cancellations that genuinely are
flakes. `main` is red right now for exactly this reason (run `32105388979`,
`architecture` cancelled at 10:16), and it read as a flake for two runs, including
one I re-ran. `gh run rerun --failed` does not help: the job is *cancelled*, not
*failed*, so it is not among the jobs that get re-run.

**Independent generators now run concurrently**, partitioned into connected
components over the files they write. The partition is over files rather than
packages for a specific reason: a generator normally emits several documents, so
two commands that can touch one file must stay ordered, or a concurrent run would
refill a document while the other is mid-probe and the read-back would report
paths as owned that this generator never produced — a false pass, in the direction
that matters. `scripts/tests/openapi-generator-groups.test.mjs` asserts that no
file is written by two different groups, which is the property the whole thing
rests on.

Concurrency is capped at 4: each lane is a full `pnpm` + `tsx` process tree, so
the limit is memory and I/O, and a four-vCPU runner is the machine that has to
stay under budget.

Two things came out of doing this:

- **the probe's restore was too narrow.** `check-openapi-path-ownership.mjs` held
  only the document it emptied, but running the generator rewrites all of that
  package's documents — so a run killed midway restored one file and left its
  siblings modified. Observed directly: a `SIGTERM` left six unrelated documents
  dirty. It now holds every file the command writes.
- **`timeout-minutes` is raised to 25.** The chain has gone from 62 links to 102;
  the parallelisation brings the two checks back under where they were before the
  previous batch, but sitting one minute under a hard cliff is what produced a red
  `main` that read as noise.

## Verification

- `pnpm verify:architecture` — full chain green, tree byte-identical before and after
- ownership proved red by injecting an unowned path (`/v1/admin/mcp/__fake__`) — it
  fails, names the path, and leaves the tree clean afterwards
- `verify:openapi-path-ownership` — 1131/1131
- `verify:openapi-dialect` — 82 documents declare 3.1.x, 0 `nullable` remaining
- `npx biome check .` — 0 errors
- Tests pass for every touched package

Spot-checked that regeneration preserved the curated content it was supposed to:
`writeOnly` survives in the invitations document, and the snapshot route still
publishes 200/404/409.
