### PR TITLE
Fix paid booking settlement composition

### DIFF
--- a/.changeset/quiet-cats-settle.md
+++ b/.changeset/quiet-cats-settle.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/catalog": patch
+---
+
+Resolve the Relationships runtime lazily when managed Booking Session payments settle.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
     # against a hang rather than a budget the lane is already spending.
     #
     # Raised again to 30 for the same reason, with the arithmetic spelled out so
-    # the next person does not have to rediscover it: the lane now names 54
+    # the next person does not have to rediscover it: the lane now names 57
     # files, each paying its own process start and database setup, and the
     # insurance work (voyant#4750, voyant#4756) added four. At 20 it was being
     # cancelled mid-suite with every test passing — a budget, not a backstop.
@@ -324,19 +324,19 @@ jobs:
       TURBO_API: ${{ vars.TURBO_API }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TEST_DATABASE_URL: postgresql://voyant:voyant@localhost:5432/voyant_test
-      DATABASE_URL: postgresql://voyant:voyant@localhost:5432/voyant_test
+      TEST_DATABASE_URL: postgresql://test:test@localhost:5432/voyant_test
+      DATABASE_URL: postgresql://test:test@localhost:5432/voyant_test
     services:
-      postgres:
+      test-db:
         image: ${{ matrix.postgres_image }}
         env:
-          POSTGRES_USER: voyant
-          POSTGRES_PASSWORD: voyant
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
           POSTGRES_DB: voyant_test
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U voyant -d voyant_test"
+          --health-cmd "pg_isready -U test -d voyant_test"
           --health-interval 1s
           --health-timeout 1s
           --health-retries 30
@@ -372,6 +372,8 @@ jobs:
                 tests/integration/postgres-indexer.test.ts
               pnpm --filter @voyant-travel/catalog exec vitest run \
                 tests/integration/postgres-pgtrgm-indexer.test.ts
+              pnpm --filter @voyant-travel/catalog exec vitest run \
+                tests/integration/booking-sessions-v1.test.ts
               pnpm --filter @voyant-travel/commerce exec vitest run \
                 tests/integration/promotion-created-command.test.ts
               pnpm --filter @voyant-travel/commerce exec vitest run \
@@ -396,6 +398,10 @@ jobs:
                 tests/integration/mcp-lookup.test.ts
               pnpm --filter @voyant-travel/inventory exec vitest run \
                 tests/integration/catalog-plane-pricing-occupancy.test.ts
+              pnpm --filter @voyant-travel/finance exec vitest run \
+                tests/integration/booking-session-payment.test.ts
+              pnpm --filter @voyant-travel/finance exec vitest run \
+                tests/integration/payment-adapter-initiation.test.ts
               pnpm --filter @voyant-travel/finance exec vitest run \
                 tests/integration/booking-create.test.ts
               pnpm --filter @voyant-travel/finance exec vitest run \

--- a/apps/operator/Dockerfile
+++ b/apps/operator/Dockerfile
@@ -24,12 +24,14 @@ WORKDIR /repo
 FROM base AS build
 ARG IMAGE_REVISION="unknown"
 ARG IMAGE_VERSION="development"
+ARG BUILD_CONCURRENCY=4
+ARG BUILD_NODE_MAX_OLD_SPACE_SIZE=8192
 ENV VOYANT_IMAGE_REVISION=$IMAGE_REVISION \
     VOYANT_IMAGE_VERSION=$IMAGE_VERSION
 # tsc needs more than the default ~2GB V8 old-space for the larger packages;
 # CI sets the same flag on every job. Without it `@voyant-travel/identity-react`
 # dies with "Ineffective mark-compacts near heap limit".
-ENV NODE_OPTIONS=--max-old-space-size=8192
+ENV NODE_OPTIONS=--max-old-space-size=${BUILD_NODE_MAX_OLD_SPACE_SIZE}
 COPY . .
 RUN pnpm install --frozen-lockfile
 # The workspace packages are built and INSTALLED rather than inlined from
@@ -37,7 +39,7 @@ RUN pnpm install --frozen-lockfile
 # pruned production install then lacks every dependency reached only through an
 # inlined package — 36 of them, which is why the image never booted
 # (voyant#3994). Building them costs ~7 minutes and ~80MB, once per release.
-RUN pnpm build --concurrency=4
+RUN pnpm build --concurrency=${BUILD_CONCURRENCY}
 # Emits dist/client + dist/server/server.js, with installed runtime package
 # imports external so the deployed install supplies them.
 RUN pnpm --filter operator build

--- a/packages/catalog/src/booking-engine/sessions-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.test.ts
@@ -672,13 +672,25 @@ describe("production Booking Session ports", () => {
     // voyant#4615 end to end: the code reaches the evaluator at all, the quote
     // total drops, and the amount the booking is created at follows the quote
     // rather than the undiscounted catalogue price.
-    const evaluated: Record<string, unknown>[] = []
+    const evaluated: Array<{
+      productId: string
+      code: string | null | undefined
+      basePriceCents: number
+      baseCurrency: string
+      pax: number | undefined
+    }> = []
     const module = createCommittableProductionModule(
       { productId: "prod_1" },
       undefined,
       undefined,
       () => async (input) => {
-        evaluated.push(input as unknown as Record<string, unknown>)
+        evaluated.push({
+          productId: input.productId,
+          code: input.code,
+          basePriceCents: input.basePriceCents,
+          baseCurrency: input.baseCurrency,
+          pax: input.pax,
+        })
         return {
           applied: [
             {
@@ -985,6 +997,56 @@ describe("production Booking Session ports", () => {
       }),
       { source: "booking-session-v1", sourceRef: created.session.id },
     )
+  })
+
+  it("returns incomplete_draft when the optional Relationships runtime is absent", async () => {
+    const module = createCommittableProductionModule({}, undefined, null)
+    const access = {
+      actorKind: "anonymous" as const,
+      capability: TEST_CAPABILITY,
+      ...PUBLIC_API_ACCESS,
+    }
+    const created = await module.createSession(
+      {
+        idempotencyKey: "create_without_relationships",
+        target: PRODUCT_TARGET,
+        selection: {
+          configure: { pax: { adult: 1 }, departureSlotId: "slot_1" },
+          billing: {
+            buyerType: "B2C",
+            contact: { firstName: "Valid", lastName: "Buyer", email: "buyer@example.test" },
+          },
+        },
+      },
+      access,
+    )
+    if (created.kind !== "session_created") throw new Error("session not created")
+    const prepared = await quoteAndHoldForCommit(
+      module,
+      created.session.id,
+      created.session.revision,
+      access,
+      "without_relationships",
+    )
+
+    const committed = await module.commitSession(
+      created.session.id,
+      {
+        expectedRevision: created.session.revision,
+        ...prepared,
+        idempotencyKey: "commit_without_relationships",
+      },
+      access,
+    )
+
+    expect(committed).toEqual({
+      kind: "rejected",
+      error: {
+        kind: "commit_rejected",
+        reason: "incomplete_draft",
+        nextAction: "update_selection",
+      },
+    })
   })
 
   it.each([
@@ -1529,9 +1591,9 @@ describe("production Booking Session ports", () => {
 function createCommittableProductionModule(
   command: Record<string, unknown> = {},
   upstreamPayload?: Record<string, unknown>,
-  upsertPersonFromContact: NonNullable<
-    ProductionBookingSessionModuleDeps["relationships"]
-  >["upsertPersonFromContact"] = async () => ({ id: "per_buyer" }) as never,
+  upsertPersonFromContact:
+    | NonNullable<ProductionBookingSessionModuleDeps["relationships"]>["upsertPersonFromContact"]
+    | null = async () => ({ id: "per_buyer" }) as never,
   resolvePromotionEvaluator?: ProductionBookingSessionModuleDeps["resolvePromotionEvaluator"],
 ) {
   const repository = createInMemoryBookingSessionRepository()
@@ -1573,9 +1635,7 @@ function createCommittableProductionModule(
     repository,
     resolveOwnedHandlers: () => handlers,
     resolveSourceRegistry: () => createSourceAdapterRegistry(),
-    relationships: {
-      upsertPersonFromContact,
-    } as never,
+    ...(upsertPersonFromContact ? { relationships: { upsertPersonFromContact } as never } : {}),
     ...(resolvePromotionEvaluator ? { resolvePromotionEvaluator } : {}),
   })
 }

--- a/packages/catalog/src/runtime-contributor-settlement.test.ts
+++ b/packages/catalog/src/runtime-contributor-settlement.test.ts
@@ -95,16 +95,18 @@ describe("managed Booking Session settlement composition", () => {
       [catalogLegalRuntimeExtensionPort.id]: {},
       [catalogOperationsRuntimeExtensionPort.id]: { listAvailabilitySlots: vi.fn() },
       [financeOperatorSettingsRuntimePort.id]: {},
-      [bookingsRelationshipsRuntimePort.id]: relationships,
     }
     const contribution = createCatalogRuntimePortContribution({
       primitives: {
         env: () => ({}),
         database: { resolve: () => db },
       } as never,
-      hasRuntimePort: (port) => port.id === bookingsRelationshipsRuntimePort.id,
+      hasRuntimePort: (port) => Object.hasOwn(extensions, port.id),
       getRuntimePort: (port) => extensions[port.id] as never,
     })
+    // Generated contributors are installed in package-name order. Catalog is
+    // constructed before Relationships, which contributes this port later.
+    extensions[bookingsRelationshipsRuntimePort.id] = relationships
     const settlement = contribution[catalogBookingSessionSettlementRuntimePort.id] as {
       commitPaidSession(input: {
         bookingSessionId: string
@@ -137,11 +139,24 @@ describe("managed Booking Session settlement composition", () => {
     )
   })
 
-  it("preserves an absent optional Relationships runtime", async () => {
+  it("keeps an absent optional Relationships runtime non-throwing", async () => {
     const db = { source: "managed" }
     productionModuleFactory.mockImplementation((deps: ProductionBookingSessionModuleDeps) => ({
       async commitPaidSession(): Promise<{ bookingId: string }> {
-        expect(deps.relationships).toBeUndefined()
+        expect(deps.relationships).toBeDefined()
+        await expect(
+          deps.relationships?.upsertPersonFromContact(
+            db as never,
+            {
+              firstName: "No",
+              lastName: "Runtime",
+              email: "missing@example.test",
+              phone: null,
+              preferredLanguage: null,
+            },
+            { source: "booking-session-v1", sourceRef: "bses_without_relationships" },
+          ),
+        ).resolves.toBeNull()
         expect(deps.financeRuntime).toEqual({})
         return { bookingId: "book_without_relationships" }
       },

--- a/packages/catalog/src/runtime-contributor.ts
+++ b/packages/catalog/src/runtime-contributor.ts
@@ -168,15 +168,13 @@ export function createCatalogRuntimePortContribution(
       ? createDeferredAnalytics(Promise.resolve(host.getRuntimePort<AnalyticsPort>(analyticsPort)))
       : undefined
   const bookingSessionServiceRuntimes = {
-    ...(host.hasRuntimePort?.(bookingsRelationshipsRuntimePort) === true
-      ? {
-          async resolveBookingsRelationshipsRuntime() {
-            return host.getRuntimePort<BookingsRelationshipsRuntime>(
-              bookingsRelationshipsRuntimePort,
-            )
-          },
-        }
-      : {}),
+    // An optional provider may be contributed after Catalog is constructed.
+    // Availability must be read when a Session needs the port, not snapshotted
+    // while Catalog contributes its own ports.
+    async resolveBookingsRelationshipsRuntime() {
+      if (host.hasRuntimePort?.(bookingsRelationshipsRuntimePort) !== true) return null
+      return host.getRuntimePort<BookingsRelationshipsRuntime>(bookingsRelationshipsRuntimePort)
+    },
     resolveFinanceServiceRuntime(context: unknown) {
       const eventBus = (context as { var?: { eventBus?: unknown } } | undefined)?.var?.eventBus
       return eventBus ? { eventBus: eventBus as never } : {}

--- a/packages/catalog/src/runtime/booking-runtime.ts
+++ b/packages/catalog/src/runtime/booking-runtime.ts
@@ -35,28 +35,28 @@ export function createBookingSessionServiceRuntimes<ContextValue>(
   context: ContextValue,
 ): Pick<ProductionBookingSessionModuleDeps, "relationships" | "financeRuntime"> {
   return {
-    // Runtime ports may still be promises when Catalog contributes its ports,
-    // so keep Relationships lazy until a Session actually needs it. Preserve
-    // the absent dependency when the optional port is not installed: the
-    // production module uses that absence to return a typed incomplete_draft.
+    // Runtime ports may still be promises (or not yet contributed) when
+    // Catalog contributes its ports, so keep Relationships lazy until a
+    // Session actually needs it. A resolver that still finds no optional port
+    // answers null through this facade, preserving the typed incomplete_draft.
     ...(options.resolveBookingsRelationshipsRuntime
       ? {
           relationships: {
             async loadPersonTravelSnapshot(...args) {
-              const runtime = await requireRelationshipsRuntime(options)
-              return runtime.loadPersonTravelSnapshot(...args)
+              const runtime = await options.resolveBookingsRelationshipsRuntime?.()
+              return runtime?.loadPersonTravelSnapshot(...args) ?? null
             },
             async upsertPersonFromContact(...args) {
-              const runtime = await requireRelationshipsRuntime(options)
-              return runtime.upsertPersonFromContact(...args)
+              const runtime = await options.resolveBookingsRelationshipsRuntime?.()
+              return runtime?.upsertPersonFromContact(...args) ?? null
             },
             async getPersonById(...args) {
-              const runtime = await requireRelationshipsRuntime(options)
-              return runtime.getPersonById(...args)
+              const runtime = await options.resolveBookingsRelationshipsRuntime?.()
+              return runtime?.getPersonById(...args) ?? null
             },
             async getOrganizationById(...args) {
-              const runtime = await requireRelationshipsRuntime(options)
-              return runtime.getOrganizationById(...args)
+              const runtime = await options.resolveBookingsRelationshipsRuntime?.()
+              return runtime?.getOrganizationById(...args) ?? null
             },
           },
         }
@@ -158,14 +158,4 @@ function bookingSessionStaffScope(c: Context): string {
     return "catalog:booking-session-retention"
   }
   return c.req.method === "GET" ? "catalog:booking-session-read" : "catalog:booking-session-write"
-}
-
-async function requireRelationshipsRuntime(options: {
-  resolveBookingsRelationshipsRuntime?: () => Promise<BookingsRelationshipsRuntime | null>
-}): Promise<BookingsRelationshipsRuntime> {
-  const runtime = await options.resolveBookingsRelationshipsRuntime?.()
-  if (!runtime) {
-    throw new Error("booking_session_relationships_runtime_required")
-  }
-  return runtime
 }

--- a/packages/catalog/tests/integration/booking-sessions-v1.test.ts
+++ b/packages/catalog/tests/integration/booking-sessions-v1.test.ts
@@ -375,7 +375,7 @@ describe.skipIf(!DB_AVAILABLE)("Booking Session v1 PostgreSQL invariants", () =>
 
     expect(outcomes.filter(isCommitted)).toHaveLength(1)
     expect(outcomes.filter(isReplay)).toHaveLength(1)
-    const [booking] = await db.select().from(bookings)
+    const [booking] = await db.select().from(bookingsRef)
     await expect(db.select().from(paymentSessions)).resolves.toEqual([
       expect.objectContaining({
         id: payment.id,

--- a/packages/finance/tests/integration/payment-adapter-initiation.test.ts
+++ b/packages/finance/tests/integration/payment-adapter-initiation.test.ts
@@ -218,10 +218,11 @@ describe.skipIf(!DB_AVAILABLE)("payment adapter initiation", () => {
           },
           { context: { env: {} } },
         ),
-      ).resolves.toEqual({ redirectUrl: null })
+      ).resolves.toEqual({ redirectUrl: null, checkout: null })
       releaseInitiation?.()
       await expect(firstStart).resolves.toEqual({
         redirectUrl: "https://pay.example.com/continue",
+        checkout: { kind: "redirect", url: "https://pay.example.com/continue" },
       })
     })
 
@@ -325,7 +326,10 @@ describe.skipIf(!DB_AVAILABLE)("payment adapter initiation", () => {
 
     await expect(
       startPaymentAdapterCardPayment(adapter, args, { context: { env: {} } }),
-    ).resolves.toEqual({ redirectUrl: "https://pay.example.com/retry" })
+    ).resolves.toEqual({
+      redirectUrl: "https://pay.example.com/retry",
+      checkout: { kind: "redirect", url: "https://pay.example.com/retry" },
+    })
     expect(initiate).toHaveBeenCalledTimes(2)
     expect(initiate.mock.calls[0]?.[1].idempotencyKey).toBe(`payment:${session.id}`)
     expect(initiate.mock.calls[1]?.[1].idempotencyKey).toBe(`payment:${session.id}`)
@@ -423,7 +427,7 @@ describe.skipIf(!DB_AVAILABLE)("payment adapter initiation", () => {
 
     await expect(
       startPaymentAdapterCardPayment(adapter, args, { context: { env: {} } }),
-    ).resolves.toEqual({ redirectUrl: null })
+    ).resolves.toEqual({ redirectUrl: null, checkout: null })
     expect(initiate).toHaveBeenCalledOnce()
   })
 

--- a/scripts/lib/operator-image-acceptance.sh
+++ b/scripts/lib/operator-image-acceptance.sh
@@ -7,6 +7,33 @@
 # the boot assertions live here once. A binding added for one stage and not the
 # other is exactly how an acceptance lane stops resembling a deployment.
 
+operator_image_is_docker_desktop() {
+  [[ "$(docker info --format '{{.OperatingSystem}}' 2>/dev/null)" == "Docker Desktop" ]]
+}
+
+operator_image_database_host() {
+  if operator_image_is_docker_desktop; then
+    printf '%s\n' "host.docker.internal"
+    return
+  fi
+  printf '%s\n' "localhost"
+}
+
+# Linux CI can share the host network directly. Docker Desktop keeps that
+# capability opt-in, so local acceptance publishes only the tested port rather
+# than requiring developers to widen the VM's network access.
+operator_image_prepare_network_args() {
+  local port="${1:-}"
+  if operator_image_is_docker_desktop; then
+    OPERATOR_IMAGE_NETWORK_ARGS=(--network bridge)
+    if [[ -n "$port" ]]; then
+      OPERATOR_IMAGE_NETWORK_ARGS=(--publish "127.0.0.1:$port:$port")
+    fi
+    return
+  fi
+  OPERATOR_IMAGE_NETWORK_ARGS=(--network host)
+}
+
 operator_image_pull() {
   local image_ref="$1"
   if docker image inspect "$image_ref" >/dev/null 2>&1; then
@@ -70,14 +97,15 @@ operator_image_configure() {
 operator_image_migrate() {
   local image_ref="$1"
   local log_path="${2:-}"
+  operator_image_prepare_network_args
 
   if [[ -z "$log_path" ]]; then
-    docker run --rm --network host "${OPERATOR_IMAGE_ENV_ARGS[@]}" "$image_ref" \
+    docker run --rm "${OPERATOR_IMAGE_NETWORK_ARGS[@]}" "${OPERATOR_IMAGE_ENV_ARGS[@]}" "$image_ref" \
       node run-generated-migrations.mjs
     return
   fi
 
-  docker run --rm --network host "${OPERATOR_IMAGE_ENV_ARGS[@]}" "$image_ref" \
+  docker run --rm "${OPERATOR_IMAGE_NETWORK_ARGS[@]}" "${OPERATOR_IMAGE_ENV_ARGS[@]}" "$image_ref" \
     node run-generated-migrations.mjs 2>&1 | tee "$log_path"
 }
 
@@ -85,8 +113,9 @@ operator_image_boot_and_assert() {
   local image_ref="$1"
   local container="$2"
   local port="$3"
+  operator_image_prepare_network_args "$port"
 
-  docker run --detach --name "$container" --network host \
+  docker run --detach --name "$container" "${OPERATOR_IMAGE_NETWORK_ARGS[@]}" \
     "${OPERATOR_IMAGE_ENV_ARGS[@]}" "$image_ref" >/dev/null
 
   local _
@@ -118,8 +147,9 @@ operator_image_boot_api_only_and_assert() {
   local image_ref="$1"
   local container="$2"
   local port="$3"
+  operator_image_prepare_network_args "$port"
 
-  docker run --detach --name "$container" --network host \
+  docker run --detach --name "$container" "${OPERATOR_IMAGE_NETWORK_ARGS[@]}" \
     "${OPERATOR_IMAGE_ENV_ARGS[@]}" "$image_ref" node start-api-only.mjs >/dev/null
 
   local _

--- a/scripts/smoke-operator-image.sh
+++ b/scripts/smoke-operator-image.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 image_ref="${1:?usage: smoke-operator-image.sh <image-ref>}"
-database_url="${DATABASE_URL:-postgresql://voyant:voyant@localhost:5432/voyant_starter_acceptance}"
 port="${VOYANT_IMAGE_SMOKE_PORT:-8080}"
 container="voyant-operator-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
 api_only_container="${container}-api-only"
@@ -10,15 +9,30 @@ api_only_container="${container}-api-only"
 # shellcheck source=scripts/lib/operator-image-acceptance.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/operator-image-acceptance.sh"
 
+database_host="$(operator_image_database_host)"
+database_name="${VOYANT_SMOKE_DATABASE:-voyant_starter_acceptance}"
+admin_url="${VOYANT_SMOKE_ADMIN_URL:-postgresql://voyant:voyant@$database_host:5432/postgres}"
+database_url="${VOYANT_SMOKE_DATABASE_URL:-${DATABASE_URL:-postgresql://voyant:voyant@$database_host:5432/$database_name}}"
+
+if [[ "$database_name" != "voyant_starter_acceptance" && "$database_name" != voyant_smoke_* ]]; then
+  echo "Refusing to recreate non-smoke database: $database_name"
+  exit 1
+fi
+if [[ "${database_url%%\?*}" != */"$database_name" ]]; then
+  echo "Smoke database URL does not target guarded database $database_name."
+  exit 1
+fi
+
 cleanup() {
   status=$?
+  trap - EXIT
   if ((status != 0)); then
     docker logs "$container" 2>/dev/null || true
     docker logs "$api_only_container" 2>/dev/null || true
   fi
   docker rm -f "$container" >/dev/null 2>&1 || true
   docker rm -f "$api_only_container" >/dev/null 2>&1 || true
-  return "$status"
+  exit "$status"
 }
 trap cleanup EXIT
 
@@ -32,6 +46,17 @@ trap cleanup EXIT
 operator_image_pull "$image_ref"
 
 operator_image_configure "$port" "$database_url"
+
+# The install lane must be deterministic on rerun. Recreate only the guarded
+# smoke database so stale partial migration state can never masquerade as a
+# candidate failure or success.
+for statement in \
+  "DROP DATABASE IF EXISTS \"$database_name\" WITH (FORCE)" \
+  "CREATE DATABASE \"$database_name\""; do
+  operator_image_prepare_network_args
+  docker run --rm "${OPERATOR_IMAGE_NETWORK_ARGS[@]}" postgres:16 \
+    psql "$admin_url" --set ON_ERROR_STOP=1 --quiet -c "$statement"
+done
 
 operator_image_migrate "$image_ref"
 

--- a/scripts/upgrade-operator-image.sh
+++ b/scripts/upgrade-operator-image.sh
@@ -26,24 +26,26 @@ port="${VOYANT_IMAGE_UPGRADE_PORT:-8081}"
 container="voyant-operator-upgrade-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
 log_dir="$(mktemp -d)"
 
-# A dedicated database: the fresh-database stage shares this Postgres service
-# and has usually already migrated the acceptance database with the candidate,
-# which would make an older image's plan meaningless here.
-admin_url="${VOYANT_UPGRADE_ADMIN_URL:-postgresql://voyant:voyant@localhost:5432/postgres}"
-database_name="${VOYANT_UPGRADE_DATABASE:-voyant_starter_upgrade}"
-database_url="${VOYANT_UPGRADE_DATABASE_URL:-postgresql://voyant:voyant@localhost:5432/$database_name}"
-
 # shellcheck source=scripts/lib/operator-image-acceptance.sh
 source "$root/scripts/lib/operator-image-acceptance.sh"
 
+# A dedicated database: the fresh-database stage shares this Postgres service
+# and has usually already migrated the acceptance database with the candidate,
+# which would make an older image's plan meaningless here.
+database_host="$(operator_image_database_host)"
+admin_url="${VOYANT_UPGRADE_ADMIN_URL:-postgresql://voyant:voyant@$database_host:5432/postgres}"
+database_name="${VOYANT_UPGRADE_DATABASE:-voyant_starter_upgrade}"
+database_url="${VOYANT_UPGRADE_DATABASE_URL:-postgresql://voyant:voyant@$database_host:5432/$database_name}"
+
 cleanup() {
   status=$?
+  trap - EXIT
   if ((status != 0)); then
     docker logs "$container" 2>/dev/null || true
   fi
   docker rm -f "$container" >/dev/null 2>&1 || true
   rm -rf "$log_dir"
-  return "$status"
+  exit "$status"
 }
 trap cleanup EXIT
 
@@ -95,7 +97,8 @@ operator_image_pull "$candidate_ref"
 for statement in \
   "DROP DATABASE IF EXISTS \"$database_name\" WITH (FORCE)" \
   "CREATE DATABASE \"$database_name\""; do
-  docker run --rm --network host postgres:16 \
+  operator_image_prepare_network_args
+  docker run --rm "${OPERATOR_IMAGE_NETWORK_ARGS[@]}" postgres:16 \
     psql "$admin_url" --set ON_ERROR_STOP=1 --quiet -c "$statement"
 done
 


### PR DESCRIPTION
## What changed

- resolve Catalog's optional Relationships runtime when a settlement operation executes instead of snapshotting contributor construction order
- preserve typed `commit_rejected:incomplete_draft` when Relationships is genuinely unavailable
- add generated-order and real production-module settlement regressions
- make booking/payment/invoice/contract real-Postgres suites mandatory in CI
- make the operator image build concurrency and heap ceiling configurable without changing runtime artifacts
- make image acceptance deterministic and portable on Docker Desktop, including guarded fresh-database recreation

## Root cause

The generated deployment host invokes runtime contributors in lexical order. Catalog ran before Relationships and permanently captured the Relationships port as absent. The final runtime record later contained the port, so existing presence probes passed while paid server-side settlement failed with `commit_rejected:incomplete_draft`.

## Validation

- exact RED on unpatched main: generated Catalog-before-Relationships regression failed
- Catalog settlement/production suite: 126 tests passed
- real PostgreSQL: booking sessions 7/7, payment lifecycle 7/7, payment initiation 28/28, invoice fulfilment 11/11, contract confirmation 8/8
- complete native arm64 runtime image built locally: `sha256:de223be93c899b3d8585e916302524b8087eba93b89f555c3eb0b8d238f1e5e4`
- fresh image migration/boot/API/admin-shell smoke passed twice consecutively
- downstream managed runtime harness against that exact image: 114 files and 1,081 tests passed; server/client typechecks passed
- publication checker, shell syntax, formatting, and package typechecks passed

## Rollout dependency

Publish the OSS package/image first. The platform PR must admit the resulting immutable digest and pass its exact-image runtime gate before sandbox deployment.
