### PR TITLE
Keep paid booking returns readable after settlement

### DIFF
--- a/.changeset/bright-payments-return.md
+++ b/.changeset/bright-payments-return.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Keep the redacted payment-session bearer endpoint readable after settlement attaches a booking, so processor returns can observe the completed payment and booking without requiring the original storefront channel context.

--- a/packages/finance/openapi/public-api/finance.json
+++ b/packages/finance/openapi/public-api/finance.json
@@ -1657,22 +1657,6 @@
               }
             }
           },
-          "403": {
-            "description": "Missing or mismatched active storefront channel context",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": ["error"]
-                }
-              }
-            }
-          },
           "404": {
             "description": "Payment session not found",
             "content": {

--- a/packages/finance/src/routes-public.ts
+++ b/packages/finance/src/routes-public.ts
@@ -290,10 +290,6 @@ const paymentSessionByIdRoute = createRoute({
       description: "A redacted public payment-session projection",
       content: { "application/json": { schema: z.object({ data: publicPaymentSessionSchema }) } },
     },
-    403: {
-      description: "Missing or mismatched active storefront channel context",
-      content: { "application/json": { schema: errorResponseSchema } },
-    },
     404: {
       description: "Payment session not found",
       content: { "application/json": { schema: errorResponseSchema } },
@@ -490,13 +486,11 @@ export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {
         : notFound(c, "Booking payment options not found")
     })
     .openapi(paymentSessionByIdRoute, async (c) => {
-      // No capability check: the session id is itself the bearer
-      // credential — anyone the operator shared `/pay/:sessionId` with
-      // needs to read it, and the projection is already redacted
-      // (no PII beyond payerEmail/payerName which the operator chose
-      // to share when issuing the link). Trip-issued sessions already
-      // worked this way (no bookingId attached → no check); admin-
-      // initiated booking sessions need the same access.
+      // The high-entropy session id is the bearer credential for this redacted
+      // projection. Do not add a checkout-capability or channel-origin check:
+      // processor returns and forwarded `/pay/:sessionId` links must remain
+      // readable after settlement attaches a booking, including when the payer
+      // no longer has the channel context that originally created it.
       const paymentSessionId = c.req.valid("param").sessionId
       if (options.refreshPaymentSessionStatus) {
         try {
@@ -513,21 +507,6 @@ export function createPublicFinanceRoutes(options: PublicFinanceRouteOptions = {
       }
 
       const session = await publicFinanceService.getPaymentSession(c.get("db"), paymentSessionId)
-      if (session?.bookingId) {
-        const denied = await requireBookingPublicApiOrigin(c, session.bookingId)
-        if (denied) return denied
-      }
-      if (!session?.bookingId && session?.invoiceId) {
-        const bookingId = await publicFinanceService.getInvoiceBookingId(
-          c.get("db"),
-          session.invoiceId,
-        )
-        if (bookingId) {
-          const denied = await requireBookingPublicApiOrigin(c, bookingId)
-          if (denied) return denied
-        }
-      }
-
       return session ? c.json({ data: session }, 200) : notFound(c, "Payment session not found")
     })
 

--- a/packages/finance/tests/integration/public-routes.test.ts
+++ b/packages/finance/tests/integration/public-routes.test.ts
@@ -18,6 +18,7 @@ import {
   travelCreditRedemptions,
   travelCredits,
 } from "../../src/schema.js"
+import { publicPaymentSessionSchema } from "../../src/validation-public.js"
 
 const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
 const ORIGINAL_TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
@@ -720,6 +721,95 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
       .from(paymentSessions)
       .where(eq(paymentSessions.id, created.id))
     expect(sessionRow?.bookingId).toBe(booking.id)
+  })
+
+  it("reads a booking-linked payment session without channel context", async () => {
+    const booking = await seedBooking()
+    const [session] = await db
+      .insert(paymentSessions)
+      .values({
+        bookingId: booking.id,
+        amountCents: 5310,
+        currency: "EUR",
+        status: "paid",
+        provider: "stripe",
+      })
+      .returning()
+    if (!session) throw new Error("Payment session seed failed")
+
+    const bearerApp = new Hono()
+    bearerApp.onError(handleApiError)
+    bearerApp.use("*", async (c, next) => {
+      c.set("db" as never, db)
+      await next()
+    })
+    bearerApp.route("/", publicFinanceRoutes)
+
+    const response = await bearerApp.request(`/payment-sessions/${session.id}`)
+
+    expect(response.status).toBe(200)
+    expect(publicPaymentSessionSchema.safeParse((await response.json()).data).success).toBe(true)
+  })
+
+  it("reads a booking-linked payment session from a different active channel", async () => {
+    const booking = await seedBooking()
+    const [session] = await db
+      .insert(paymentSessions)
+      .values({
+        bookingId: booking.id,
+        amountCents: 5310,
+        currency: "EUR",
+        status: "paid",
+        provider: "stripe",
+      })
+      .returning()
+    if (!session) throw new Error("Payment session seed failed")
+
+    const bearerApp = new Hono()
+    bearerApp.onError(handleApiError)
+    bearerApp.use("*", async (c, next) => {
+      c.set("db" as never, db)
+      c.set("publicChannel" as never, {
+        channelId: "chan_different_payment_return",
+        channelStatus: "active",
+      })
+      await next()
+    })
+    bearerApp.route("/", publicFinanceRoutes)
+
+    const response = await bearerApp.request(`/payment-sessions/${session.id}`)
+
+    expect(response.status).toBe(200)
+    expect(publicPaymentSessionSchema.safeParse((await response.json()).data).success).toBe(true)
+  })
+
+  it("reads an invoice-linked payment session without channel context", async () => {
+    const booking = await seedBooking()
+    const invoice = await seedInvoice(booking.id)
+    const [session] = await db
+      .insert(paymentSessions)
+      .values({
+        invoiceId: invoice.id,
+        amountCents: 5310,
+        currency: "EUR",
+        status: "paid",
+        provider: "stripe",
+      })
+      .returning()
+    if (!session) throw new Error("Payment session seed failed")
+
+    const bearerApp = new Hono()
+    bearerApp.onError(handleApiError)
+    bearerApp.use("*", async (c, next) => {
+      c.set("db" as never, db)
+      await next()
+    })
+    bearerApp.route("/", publicFinanceRoutes)
+
+    const response = await bearerApp.request(`/payment-sessions/${session.id}`)
+
+    expect(response.status).toBe(200)
+    expect(publicPaymentSessionSchema.safeParse((await response.json()).data).success).toBe(true)
   })
 
   it("refreshes provider status before returning a public payment session", async () => {


### PR DESCRIPTION
## What changed

- keep `GET /v1/public/finance/payment-sessions/{sessionId}` bearer-readable after settlement attaches a booking
- preserve channel and checkout-capability guards on booking resources, invoices, documents, and payment mutations
- add real-Postgres regressions for missing channel context, mismatched active channel, and invoice-linked sessions
- regenerate the public Finance OpenAPI document and add release metadata

## Root cause

The payment-session id is the documented high-entropy bearer credential for the redacted public projection. A later channel-origin guard ran only after settlement populated `bookingId`, so the exact same processor-return URL changed from readable to HTTP 403 as soon as payment succeeded. The booking engine could never observe the authoritative booking id and remained on payment confirmation.

## Impact

Paid processor returns can observe the completed session and hand the customer to the existing booking without attempting another quote, hold, or commit.

## Validation

- live sandbox trace reproduced repeated HTTP 403 reads after a successful paid settlement
- real Postgres: 24/24 focused Finance route and contract tests passed
- OpenAPI drift: passed
- OpenAPI key-kind authority: passed
- Biome on changed source, test, and generated API files: passed
- full local monorepo hook was not usable from the filtered worktree because unrelated React packages were not installed; GitHub CI is the authoritative full gate
