### PR TITLE
Fix booking item pricing and departure capacity accounting

### DIFF
--- a/.changeset/fair-departure-capacity.md
+++ b/.changeset/fair-departure-capacity.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/bookings-react": patch
+"@voyant-travel/finance": patch
+---
+
+Count departure capacity once per booking instead of once per priced item, preserve that claim when items move or are deleted, and render item-addition prices from minor currency units correctly.

--- a/packages/bookings-react/src/components/booking-item-addition-dialog.tsx
+++ b/packages/bookings-react/src/components/booking-item-addition-dialog.tsx
@@ -42,6 +42,14 @@ export interface BookingItemAdditionDialogProps {
 
 const UNIT_NONE = "__none__"
 
+export function formatMinorCurrency(
+  formatCurrency: (amount: number, currency: string) => string,
+  amountCents: number,
+  currency: string,
+) {
+  return formatCurrency(amountCents / 100, currency)
+}
+
 /**
  * Add a catalog service to a booking that already exists — the extra
  * excursion or transfer a customer asks for mid-trip.
@@ -303,14 +311,19 @@ export function BookingItemAdditionDialog({
               <div className="flex items-baseline justify-between">
                 <span className="font-medium text-sm">{messages.quote.title}</span>
                 <span className="font-semibold text-lg">
-                  {formatCurrency(quoted.priceDelta.amountCents, quoted.priceDelta.currency)}
+                  {formatMinorCurrency(
+                    formatCurrency,
+                    quoted.priceDelta.amountCents,
+                    quoted.priceDelta.currency,
+                  )}
                 </span>
               </div>
               {quoted.priceDelta.collectionAmountCents > 0 ? (
                 <p className="text-muted-foreground text-xs">
                   {messages.quote.collect.replace(
                     "{amount}",
-                    formatCurrency(
+                    formatMinorCurrency(
+                      formatCurrency,
                       quoted.priceDelta.collectionAmountCents,
                       quoted.priceDelta.currency,
                     ),

--- a/packages/bookings-react/tests/unit/booking-item-addition-money.test.ts
+++ b/packages/bookings-react/tests/unit/booking-item-addition-money.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { formatMinorCurrency } from "../../src/components/booking-item-addition-dialog.js"
+
+describe("booking item addition money", () => {
+  it("converts the amendment's minor-unit amount before formatting it", () => {
+    const formatCurrency = vi.fn((amount: number, currency: string) => `${currency} ${amount}`)
+
+    expect(formatMinorCurrency(formatCurrency, 49_500, "EUR")).toBe("EUR 495")
+    expect(formatCurrency).toHaveBeenCalledWith(495, "EUR")
+  })
+})

--- a/packages/bookings/src/schema-amendments.ts
+++ b/packages/bookings/src/schema-amendments.ts
@@ -122,6 +122,12 @@ export interface BookingAmendmentItemAddPlan {
   optionId: string | null
   optionUnitId: string | null
   availabilitySlotId: string | null
+  /**
+   * Passenger-denominated claim this Booking should hold on the departure.
+   * Commercial line quantity is not capacity: several priced lines can
+   * describe the same travelers on the same departure.
+   */
+  capacityClaimQuantity: number
   quantity: number
   title: string
   sellCurrency: string
@@ -155,6 +161,12 @@ export interface BookingAmendmentItemMovePlan {
    */
   allocationId: string
   quantity: number
+  /** Passenger capacity released from the old departure by this move. */
+  fromCapacityQuantity: number
+  /** Passenger capacity claimed on the target departure by this move. */
+  toCapacityQuantity: number
+  /** Existing source allocation that carries the claim when this line leaves. */
+  sourceClaimCarrierAllocationId: string | null
   productId: string | null
   /** Departure the item is leaving. Null when it was never scheduled. */
   fromAvailabilitySlotId: string | null

--- a/packages/bookings/src/service-amendments.ts
+++ b/packages/bookings/src/service-amendments.ts
@@ -13,6 +13,10 @@ import type {
   PreviewTravelerRosterChangeInput,
   TravelerCorrectionPatch,
 } from "@voyant-travel/bookings-contracts"
+import {
+  ACTIVE_BOOKING_ALLOCATION_STATUSES,
+  isActiveBookingAllocationStatus,
+} from "@voyant-travel/bookings-contracts"
 import { newId } from "@voyant-travel/db/lib/typeid"
 import { and, asc, eq, inArray, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -528,7 +532,7 @@ async function buildRosterPlans(
       )
     }
     const allocation = activeAllocations[0]!
-    if (allocation.quantity + quantityDelta < 0) {
+    if (!allocation.availabilitySlotId && allocation.quantity + quantityDelta < 0) {
       throw new RosterPlanError(
         "unsupported_configuration",
         "Allocation quantity cannot become negative",
@@ -825,8 +829,24 @@ async function buildItemAddPlan(
     )
   }
 
+  const capacityClaimQuantity = Math.max(booking.pax ?? addition.quantity, 0)
   if (slot) {
-    const room = slot.unlimited || (slot.remainingPax ?? 0) >= addition.quantity
+    const existingAllocations = await db
+      .select({ quantity: bookingAllocations.quantity })
+      .from(bookingAllocations)
+      .where(
+        and(
+          eq(bookingAllocations.bookingId, booking.id),
+          eq(bookingAllocations.availabilitySlotId, slot.id),
+          inArray(bookingAllocations.status, ACTIVE_BOOKING_ALLOCATION_STATUSES),
+        ),
+      )
+    const existingClaim = existingAllocations.reduce(
+      (sum, allocation) => sum + allocation.quantity,
+      0,
+    )
+    const additionalClaim = Math.max(capacityClaimQuantity - existingClaim, 0)
+    const room = slot.unlimited || (slot.remainingPax ?? 0) >= additionalClaim
     if (slot.status !== "open" || slot.pastCutoff || slot.tooEarly || !room) {
       throw new RosterPlanError("availability_changed", "Departure cannot take this addition")
     }
@@ -849,6 +869,7 @@ async function buildItemAddPlan(
     optionId: addition.optionId ?? option?.id ?? null,
     optionUnitId: addition.optionUnitId ?? null,
     availabilitySlotId: addition.availabilitySlotId ?? null,
+    capacityClaimQuantity,
     quantity,
     title: addition.title ?? unitName ?? option?.name ?? product.name,
     sellCurrency: booking.sellCurrency,
@@ -928,7 +949,20 @@ async function buildItemMovePlan(
   // slot looked up by id alone lets a caller move onto another product's
   // departure, which would decrement capacity nobody is travelling on.
   const target = await loadAdditionSlot(db, move.availabilitySlotId, item.productId)
-  const room = target.unlimited || (target.remainingPax ?? 0) >= item.quantity
+  const capacityClaimQuantity = Math.max(booking.pax ?? item.quantity, 0)
+  const sourceClaimPeers = state.allocations.filter(
+    (allocation) =>
+      allocation.bookingItemId !== item.id &&
+      allocation.availabilitySlotId === item.availabilitySlotId &&
+      isActiveBookingAllocationStatus(allocation.status),
+  )
+  const targetClaimPeers = state.allocations.filter(
+    (allocation) =>
+      allocation.availabilitySlotId === move.availabilitySlotId &&
+      isActiveBookingAllocationStatus(allocation.status),
+  )
+  const toCapacityQuantity = targetClaimPeers.length === 0 ? capacityClaimQuantity : 0
+  const room = target.unlimited || (target.remainingPax ?? 0) >= toCapacityQuantity
   if (target.status !== "open" || target.pastCutoff || target.tooEarly || !room) {
     throw new RosterPlanError(
       "availability_changed",
@@ -1053,6 +1087,9 @@ async function buildItemMovePlan(
     bookingItemId: item.id,
     allocationId: allocation.id,
     quantity: item.quantity,
+    fromCapacityQuantity: sourceClaimPeers.length === 0 ? capacityClaimQuantity : 0,
+    toCapacityQuantity,
+    sourceClaimCarrierAllocationId: sourceClaimPeers[0]?.id ?? null,
     productId: item.productId,
     fromAvailabilitySlotId: item.availabilitySlotId ?? null,
     toAvailabilitySlotId: move.availabilitySlotId,
@@ -2207,7 +2244,7 @@ async function finalizeRosterApply(
       const rosterPlans = amendment.operationPlan.filter(
         (plan): plan is BookingAmendmentRosterItemPlan => !isItemAddPlan(plan),
       )
-      await applyCapacityAndAllocationPlan(tx, rosterPlans, now)
+      await applyCapacityAndAllocationPlan(tx, rosterPlans, booking.pax, now)
       const amendmentTravelerId = requireAmendmentTravelerId(amendment)
       const requested = amendment.requestedChange
       if (requested.type === "traveler_add") {
@@ -2386,46 +2423,49 @@ async function finalizeItemMoveApply(
       if (!plan) return { status: "invalid_state" as const }
 
       const now = dependencies.now?.() ?? new Date()
+      const toCapacityQuantity = plan.toCapacityQuantity ?? plan.quantity
+      const fromCapacityQuantity = plan.fromCapacityQuantity ?? plan.quantity
 
       // Take the new departure's capacity first. If this fails there is
       // nothing to undo, whereas releasing first and failing here would
       // leave the booking holding no seat at all.
-      const [claimed] = await tx
-        .update(availabilitySlotsRef)
-        // agent-quality: raw-sql reviewed -- owner: bookings; conditional capacity decrement uses locked, server-owned plan data and Drizzle identifiers.
-        .set({
-          remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE ${availabilitySlotsRef.remainingPax} - ${plan.quantity} END`,
-          updatedAt: now,
-        })
-        .where(
-          and(
-            eq(availabilitySlotsRef.id, plan.toAvailabilitySlotId),
-            ...(plan.productId ? [eq(availabilitySlotsRef.productId, plan.productId)] : []),
-            eq(availabilitySlotsRef.status, "open"),
-            eq(availabilitySlotsRef.pastCutoff, false),
-            eq(availabilitySlotsRef.tooEarly, false),
-            // agent-quality: raw-sql reviewed -- owner: bookings; atomic positive-capacity guard over a Drizzle identifier.
-            or(
-              eq(availabilitySlotsRef.unlimited, true),
-              sql`${availabilitySlotsRef.remainingPax} >= ${plan.quantity}`,
+      if (toCapacityQuantity > 0) {
+        const [claimed] = await tx
+          .update(availabilitySlotsRef)
+          // agent-quality: raw-sql reviewed -- owner: bookings; conditional capacity decrement uses locked, server-owned plan data and Drizzle identifiers.
+          .set({
+            remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE ${availabilitySlotsRef.remainingPax} - ${toCapacityQuantity} END`,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(availabilitySlotsRef.id, plan.toAvailabilitySlotId),
+              ...(plan.productId ? [eq(availabilitySlotsRef.productId, plan.productId)] : []),
+              eq(availabilitySlotsRef.status, "open"),
+              eq(availabilitySlotsRef.pastCutoff, false),
+              eq(availabilitySlotsRef.tooEarly, false),
+              or(
+                eq(availabilitySlotsRef.unlimited, true),
+                sql`${availabilitySlotsRef.remainingPax} >= ${toCapacityQuantity}`,
+              ),
             ),
-          ),
-        )
-        .returning({ id: availabilitySlotsRef.id })
-      if (!claimed) {
-        throw new RosterPlanError(
-          "availability_changed",
-          "The target departure filled up",
-          plan.bookingItemId,
-        )
+          )
+          .returning({ id: availabilitySlotsRef.id })
+        if (!claimed) {
+          throw new RosterPlanError(
+            "availability_changed",
+            "The target departure filled up",
+            plan.bookingItemId,
+          )
+        }
       }
 
-      if (plan.fromAvailabilitySlotId) {
+      if (plan.fromAvailabilitySlotId && fromCapacityQuantity > 0) {
         await tx
           .update(availabilitySlotsRef)
           // agent-quality: raw-sql reviewed -- owner: bookings; capacity restore uses locked, server-owned plan data and Drizzle identifiers.
           .set({
-            remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE ${availabilitySlotsRef.remainingPax} + ${plan.quantity} END`,
+            remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE ${availabilitySlotsRef.remainingPax} + ${fromCapacityQuantity} END`,
             // A departure that sold out only because of this booking becomes
             // sellable again the moment the booking leaves it.
             status: sql`CASE WHEN ${availabilitySlotsRef.status} = 'sold_out' THEN 'open' ELSE ${availabilitySlotsRef.status} END`,
@@ -2434,9 +2474,20 @@ async function finalizeItemMoveApply(
           .where(eq(availabilitySlotsRef.id, plan.fromAvailabilitySlotId))
       }
 
+      if (plan.sourceClaimCarrierAllocationId) {
+        await tx
+          .update(bookingAllocations)
+          .set({ quantity: Math.max(booking.pax ?? plan.quantity, 0), updatedAt: now })
+          .where(eq(bookingAllocations.id, plan.sourceClaimCarrierAllocationId))
+      }
+
       await tx
         .update(bookingAllocations)
-        .set({ availabilitySlotId: plan.toAvailabilitySlotId, updatedAt: now })
+        .set({
+          availabilitySlotId: plan.toAvailabilitySlotId,
+          quantity: toCapacityQuantity,
+          updatedAt: now,
+        })
         .where(eq(bookingAllocations.id, plan.allocationId))
 
       await tx
@@ -2551,35 +2602,86 @@ async function finalizeItemAddApply(
       if (!plan) return { status: "invalid_state" as const }
 
       const now = dependencies.now?.() ?? new Date()
+      const capacityClaimQuantity =
+        plan.capacityClaimQuantity ?? Math.max(booking.pax ?? plan.quantity, 0)
+      let existingSlotAllocations: AllocationRow[] = []
 
       if (plan.availabilitySlotId) {
-        const [updated] = await tx
-          .update(availabilitySlotsRef)
-          // agent-quality: raw-sql reviewed -- owner: bookings; conditional capacity decrement uses locked, server-owned plan data and Drizzle identifiers.
-          .set({
-            remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE ${availabilitySlotsRef.remainingPax} - ${plan.quantity} END`,
-            updatedAt: now,
-          })
+        existingSlotAllocations = await tx
+          .select()
+          .from(bookingAllocations)
           .where(
             and(
-              eq(availabilitySlotsRef.id, plan.availabilitySlotId),
-              // Re-asserted at apply, not just at preview: the decrement
-              // must land on the product the item claims, or capacity
-              // moves on one product while the booking records another.
-              eq(availabilitySlotsRef.productId, plan.productId),
-              eq(availabilitySlotsRef.status, "open"),
-              eq(availabilitySlotsRef.pastCutoff, false),
-              eq(availabilitySlotsRef.tooEarly, false),
-              // agent-quality: raw-sql reviewed -- owner: bookings; atomic positive-capacity guard over a Drizzle identifier.
-              or(
-                eq(availabilitySlotsRef.unlimited, true),
-                sql`${availabilitySlotsRef.remainingPax} >= ${plan.quantity}`,
-              ),
+              eq(bookingAllocations.bookingId, booking.id),
+              eq(bookingAllocations.availabilitySlotId, plan.availabilitySlotId),
+              inArray(bookingAllocations.status, ACTIVE_BOOKING_ALLOCATION_STATUSES),
             ),
           )
-          .returning({ id: availabilitySlotsRef.id })
-        if (!updated) {
-          throw new RosterPlanError("availability_changed", "Departure filled up", PENDING_ITEM_ID)
+          .orderBy(asc(bookingAllocations.createdAt), asc(bookingAllocations.id))
+          .for("update")
+
+        const existingClaim = existingSlotAllocations.reduce(
+          (sum, allocation) => sum + allocation.quantity,
+          0,
+        )
+        const capacityDelta = capacityClaimQuantity - existingClaim
+        if (capacityDelta > 0) {
+          const [updated] = await tx
+            .update(availabilitySlotsRef)
+            // agent-quality: raw-sql reviewed -- owner: bookings; the server-owned booking/departure claim is applied atomically with a positive-capacity guard.
+            .set({
+              remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE ${availabilitySlotsRef.remainingPax} - ${capacityDelta} END`,
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(availabilitySlotsRef.id, plan.availabilitySlotId),
+                eq(availabilitySlotsRef.productId, plan.productId),
+                eq(availabilitySlotsRef.status, "open"),
+                eq(availabilitySlotsRef.pastCutoff, false),
+                eq(availabilitySlotsRef.tooEarly, false),
+                or(
+                  eq(availabilitySlotsRef.unlimited, true),
+                  sql`${availabilitySlotsRef.remainingPax} >= ${capacityDelta}`,
+                ),
+              ),
+            )
+            .returning({ id: availabilitySlotsRef.id })
+          if (!updated) {
+            throw new RosterPlanError(
+              "availability_changed",
+              "Departure filled up",
+              PENDING_ITEM_ID,
+            )
+          }
+        } else if (capacityDelta < 0) {
+          await tx
+            .update(availabilitySlotsRef)
+            // agent-quality: raw-sql reviewed -- owner: bookings; normalizing an over-counted booking claim returns only the server-derived excess.
+            .set({
+              remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE ${availabilitySlotsRef.remainingPax} + ${-capacityDelta} END`,
+              updatedAt: now,
+            })
+            .where(eq(availabilitySlotsRef.id, plan.availabilitySlotId))
+        }
+
+        if (existingSlotAllocations.length > 0) {
+          const [carrier, ...duplicates] = existingSlotAllocations
+          await tx
+            .update(bookingAllocations)
+            .set({ quantity: capacityClaimQuantity, updatedAt: now })
+            .where(eq(bookingAllocations.id, carrier!.id))
+          if (duplicates.length > 0) {
+            await tx
+              .update(bookingAllocations)
+              .set({ quantity: 0, updatedAt: now })
+              .where(
+                inArray(
+                  bookingAllocations.id,
+                  duplicates.map((allocation) => allocation.id),
+                ),
+              )
+          }
         }
       }
 
@@ -2619,7 +2721,7 @@ async function finalizeItemAddApply(
         optionId: plan.optionId,
         optionUnitId: plan.optionUnitId,
         availabilitySlotId: plan.availabilitySlotId,
-        quantity: plan.quantity,
+        quantity: existingSlotAllocations.length > 0 ? 0 : capacityClaimQuantity,
         allocationType: "unit",
         status: "confirmed",
         confirmedAt: now,
@@ -2671,8 +2773,10 @@ async function finalizeItemAddApply(
 async function applyCapacityAndAllocationPlan(
   tx: PostgresJsDatabase,
   plans: BookingAmendmentRosterItemPlan[],
+  bookingPaxBefore: number | null,
   now: Date,
 ) {
+  const lockedAllocations = new Map<string, AllocationRow>()
   for (const plan of plans) {
     const [allocation] = await tx
       .select()
@@ -2683,24 +2787,50 @@ async function applyCapacityAndAllocationPlan(
     if (!allocation || allocation.quantity !== plan.allocationQuantityBefore) {
       throw new RosterPlanError("availability_changed", "Allocation changed", plan.bookingItemId)
     }
-    if (plan.availabilitySlotId && plan.quantityDelta > 0) {
+    lockedAllocations.set(plan.allocationId, allocation)
+  }
+
+  const slotPlans = new Map<string, BookingAmendmentRosterItemPlan>()
+  for (const plan of plans) {
+    if (plan.availabilitySlotId && !slotPlans.has(plan.availabilitySlotId)) {
+      slotPlans.set(plan.availabilitySlotId, plan)
+    }
+  }
+
+  for (const [slotId, plan] of slotPlans) {
+    const allocation = lockedAllocations.get(plan.allocationId)!
+    const liveAllocations = await tx
+      .select()
+      .from(bookingAllocations)
+      .where(
+        and(
+          eq(bookingAllocations.bookingId, allocation.bookingId),
+          eq(bookingAllocations.availabilitySlotId, slotId),
+          inArray(bookingAllocations.status, ACTIVE_BOOKING_ALLOCATION_STATUSES),
+        ),
+      )
+      .orderBy(asc(bookingAllocations.createdAt), asc(bookingAllocations.id))
+      .for("update")
+    const currentClaim = liveAllocations.reduce((sum, candidate) => sum + candidate.quantity, 0)
+    const desiredClaim = Math.max((bookingPaxBefore ?? currentClaim) + plan.quantityDelta, 0)
+    const capacityDelta = desiredClaim - currentClaim
+    if (capacityDelta > 0) {
       const [updated] = await tx
         .update(availabilitySlotsRef)
-        // agent-quality: raw-sql reviewed -- owner: bookings; conditional capacity decrement uses locked, server-owned plan data and Drizzle identifiers.
+        // agent-quality: raw-sql reviewed -- owner: bookings; one passenger-denominated claim delta is applied per booking/departure, regardless of priced line count.
         .set({
-          remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE ${availabilitySlotsRef.remainingPax} - 1 END`,
+          remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE ${availabilitySlotsRef.remainingPax} - ${capacityDelta} END`,
           updatedAt: now,
         })
         .where(
           and(
-            eq(availabilitySlotsRef.id, plan.availabilitySlotId),
+            eq(availabilitySlotsRef.id, slotId),
             eq(availabilitySlotsRef.status, "open"),
             eq(availabilitySlotsRef.pastCutoff, false),
             eq(availabilitySlotsRef.tooEarly, false),
-            // agent-quality: raw-sql reviewed -- owner: bookings; atomic positive-capacity guard over a Drizzle identifier.
             or(
               eq(availabilitySlotsRef.unlimited, true),
-              sql`${availabilitySlotsRef.remainingPax} >= 1`,
+              sql`${availabilitySlotsRef.remainingPax} >= ${capacityDelta}`,
             ),
           ),
         )
@@ -2713,25 +2843,43 @@ async function applyCapacityAndAllocationPlan(
         )
       }
     }
-    if (plan.availabilitySlotId && plan.quantityDelta < 0) {
+    if (capacityDelta < 0) {
       await tx
         .update(availabilitySlotsRef)
-        // agent-quality: raw-sql reviewed -- owner: bookings; conditional capacity release uses locked, server-owned plan data and Drizzle identifiers.
+        // agent-quality: raw-sql reviewed -- owner: bookings; the server-derived passenger claim reduction is returned to the slot.
         .set({
-          remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE COALESCE(${availabilitySlotsRef.remainingPax}, 0) + 1 END`,
+          remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE COALESCE(${availabilitySlotsRef.remainingPax}, 0) + ${-capacityDelta} END`,
           updatedAt: now,
         })
-        .where(eq(availabilitySlotsRef.id, plan.availabilitySlotId))
+        .where(eq(availabilitySlotsRef.id, slotId))
     }
+
+    const [carrier, ...duplicates] = liveAllocations
+    if (carrier) {
+      await tx
+        .update(bookingAllocations)
+        .set({ quantity: desiredClaim, updatedAt: now })
+        .where(eq(bookingAllocations.id, carrier.id))
+    }
+    if (duplicates.length > 0) {
+      await tx
+        .update(bookingAllocations)
+        .set({ quantity: 0, updatedAt: now })
+        .where(
+          inArray(
+            bookingAllocations.id,
+            duplicates.map((candidate) => candidate.id),
+          ),
+        )
+    }
+  }
+
+  for (const plan of plans.filter((candidate) => !candidate.availabilitySlotId)) {
+    const allocation = lockedAllocations.get(plan.allocationId)!
     const [updatedAllocation] = await tx
       .update(bookingAllocations)
       .set({ quantity: allocation.quantity + plan.quantityDelta, updatedAt: now })
-      .where(
-        and(
-          eq(bookingAllocations.id, allocation.id),
-          eq(bookingAllocations.quantity, plan.allocationQuantityBefore),
-        ),
-      )
+      .where(eq(bookingAllocations.id, allocation.id))
       .returning({ id: bookingAllocations.id })
     if (!updatedAllocation) {
       throw new RosterPlanError("availability_changed", "Allocation changed", plan.bookingItemId)

--- a/packages/bookings/src/service-amendments.ts
+++ b/packages/bookings/src/service-amendments.ts
@@ -950,6 +950,11 @@ async function buildItemMovePlan(
   // departure, which would decrement capacity nobody is travelling on.
   const target = await loadAdditionSlot(db, move.availabilitySlotId, item.productId)
   const capacityClaimQuantity = Math.max(booking.pax ?? item.quantity, 0)
+  const sourceClaimAllocations = state.allocations.filter(
+    (allocation) =>
+      allocation.availabilitySlotId === item.availabilitySlotId &&
+      isActiveBookingAllocationStatus(allocation.status),
+  )
   const sourceClaimPeers = state.allocations.filter(
     (allocation) =>
       allocation.bookingItemId !== item.id &&
@@ -962,6 +967,12 @@ async function buildItemMovePlan(
       isActiveBookingAllocationStatus(allocation.status),
   )
   const toCapacityQuantity = targetClaimPeers.length === 0 ? capacityClaimQuantity : 0
+  const sourceClaimAfterMove = sourceClaimPeers.length === 0 ? 0 : capacityClaimQuantity
+  const fromCapacityQuantity = Math.max(
+    sourceClaimAllocations.reduce((sum, allocation) => sum + allocation.quantity, 0) -
+      sourceClaimAfterMove,
+    0,
+  )
   const room = target.unlimited || (target.remainingPax ?? 0) >= toCapacityQuantity
   if (target.status !== "open" || target.pastCutoff || target.tooEarly || !room) {
     throw new RosterPlanError(
@@ -1087,7 +1098,7 @@ async function buildItemMovePlan(
     bookingItemId: item.id,
     allocationId: allocation.id,
     quantity: item.quantity,
-    fromCapacityQuantity: sourceClaimPeers.length === 0 ? capacityClaimQuantity : 0,
+    fromCapacityQuantity,
     toCapacityQuantity,
     sourceClaimCarrierAllocationId: sourceClaimPeers[0]?.id ?? null,
     productId: item.productId,
@@ -2066,6 +2077,46 @@ async function lockAmendment(db: PostgresJsDatabase, amendmentId: string) {
   return amendment ? { booking, amendment } : null
 }
 
+async function lockApplicableAvailabilitySlot(
+  db: PostgresJsDatabase,
+  input: {
+    slotId: string
+    productId: string | null
+    requiredQuantity: number
+    bookingItemId: string
+  },
+) {
+  const [slot] = await db
+    .select({
+      id: availabilitySlotsRef.id,
+      unlimited: availabilitySlotsRef.unlimited,
+      remainingPax: availabilitySlotsRef.remainingPax,
+    })
+    .from(availabilitySlotsRef)
+    .where(
+      and(
+        eq(availabilitySlotsRef.id, input.slotId),
+        ...(input.productId ? [eq(availabilitySlotsRef.productId, input.productId)] : []),
+        eq(availabilitySlotsRef.status, "open"),
+        eq(availabilitySlotsRef.pastCutoff, false),
+        eq(availabilitySlotsRef.tooEarly, false),
+      ),
+    )
+    .for("update")
+    .limit(1)
+  if (
+    !slot ||
+    (!slot.unlimited && (slot.remainingPax ?? 0) < Math.max(input.requiredQuantity, 0))
+  ) {
+    throw new RosterPlanError(
+      "availability_changed",
+      "The target departure is no longer available",
+      input.bookingItemId,
+    )
+  }
+  return slot
+}
+
 async function findProposedRevision(
   db: PostgresJsDatabase,
   amendmentId: string,
@@ -2426,38 +2477,27 @@ async function finalizeItemMoveApply(
       const toCapacityQuantity = plan.toCapacityQuantity ?? plan.quantity
       const fromCapacityQuantity = plan.fromCapacityQuantity ?? plan.quantity
 
-      // Take the new departure's capacity first. If this fails there is
-      // nothing to undo, whereas releasing first and failing here would
-      // leave the booking holding no seat at all.
+      // Revalidate even when another line already carries this booking's
+      // target claim. Capacity may be zero while the departure itself has
+      // closed or crossed its booking window since preview.
+      await lockApplicableAvailabilitySlot(tx, {
+        slotId: plan.toAvailabilitySlotId,
+        productId: plan.productId ?? null,
+        requiredQuantity: toCapacityQuantity,
+        bookingItemId: plan.bookingItemId,
+      })
+
+      // Take the new departure's capacity first. The locked validation above
+      // makes this update safe without repeating status predicates.
       if (toCapacityQuantity > 0) {
-        const [claimed] = await tx
+        await tx
           .update(availabilitySlotsRef)
-          // agent-quality: raw-sql reviewed -- owner: bookings; conditional capacity decrement uses locked, server-owned plan data and Drizzle identifiers.
+          // agent-quality: raw-sql reviewed -- owner: bookings; capacity decrement uses the locked, revalidated slot and server-owned plan data.
           .set({
             remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE ${availabilitySlotsRef.remainingPax} - ${toCapacityQuantity} END`,
             updatedAt: now,
           })
-          .where(
-            and(
-              eq(availabilitySlotsRef.id, plan.toAvailabilitySlotId),
-              ...(plan.productId ? [eq(availabilitySlotsRef.productId, plan.productId)] : []),
-              eq(availabilitySlotsRef.status, "open"),
-              eq(availabilitySlotsRef.pastCutoff, false),
-              eq(availabilitySlotsRef.tooEarly, false),
-              or(
-                eq(availabilitySlotsRef.unlimited, true),
-                sql`${availabilitySlotsRef.remainingPax} >= ${toCapacityQuantity}`,
-              ),
-            ),
-          )
-          .returning({ id: availabilitySlotsRef.id })
-        if (!claimed) {
-          throw new RosterPlanError(
-            "availability_changed",
-            "The target departure filled up",
-            plan.bookingItemId,
-          )
-        }
+          .where(eq(availabilitySlotsRef.id, plan.toAvailabilitySlotId))
       }
 
       if (plan.fromAvailabilitySlotId && fromCapacityQuantity > 0) {
@@ -2625,35 +2665,21 @@ async function finalizeItemAddApply(
           0,
         )
         const capacityDelta = capacityClaimQuantity - existingClaim
+        await lockApplicableAvailabilitySlot(tx, {
+          slotId: plan.availabilitySlotId,
+          productId: plan.productId,
+          requiredQuantity: Math.max(capacityDelta, 0),
+          bookingItemId: PENDING_ITEM_ID,
+        })
         if (capacityDelta > 0) {
-          const [updated] = await tx
+          await tx
             .update(availabilitySlotsRef)
-            // agent-quality: raw-sql reviewed -- owner: bookings; the server-owned booking/departure claim is applied atomically with a positive-capacity guard.
+            // agent-quality: raw-sql reviewed -- owner: bookings; the server-owned claim is applied to the locked, revalidated slot.
             .set({
               remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE ${availabilitySlotsRef.remainingPax} - ${capacityDelta} END`,
               updatedAt: now,
             })
-            .where(
-              and(
-                eq(availabilitySlotsRef.id, plan.availabilitySlotId),
-                eq(availabilitySlotsRef.productId, plan.productId),
-                eq(availabilitySlotsRef.status, "open"),
-                eq(availabilitySlotsRef.pastCutoff, false),
-                eq(availabilitySlotsRef.tooEarly, false),
-                or(
-                  eq(availabilitySlotsRef.unlimited, true),
-                  sql`${availabilitySlotsRef.remainingPax} >= ${capacityDelta}`,
-                ),
-              ),
-            )
-            .returning({ id: availabilitySlotsRef.id })
-          if (!updated) {
-            throw new RosterPlanError(
-              "availability_changed",
-              "Departure filled up",
-              PENDING_ITEM_ID,
-            )
-          }
+            .where(eq(availabilitySlotsRef.id, plan.availabilitySlotId))
         } else if (capacityDelta < 0) {
           await tx
             .update(availabilitySlotsRef)

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -4537,6 +4537,7 @@ const bookingsServiceInternal = {
       const [parent] = await tx
         .select({
           status: bookings.status,
+          bookingPax: bookings.pax,
           quantity: bookingItems.quantity,
           availabilitySlotId: bookingItems.availabilitySlotId,
         })
@@ -4549,7 +4550,11 @@ const bookingsServiceInternal = {
         return null
       }
 
-      if (data.quantity !== undefined && data.quantity !== parent.quantity) {
+      if (
+        parent.bookingPax == null &&
+        data.quantity !== undefined &&
+        data.quantity !== parent.quantity
+      ) {
         const change = await syncAllocationQuantity(
           tx as PostgresJsDatabase,
           itemId,
@@ -4709,6 +4714,7 @@ const bookingsServiceInternal = {
           title: bookingItems.title,
           itemType: bookingItems.itemType,
           bookingStatus: bookings.status,
+          bookingPax: bookings.pax,
         })
         .from(bookingItems)
         .innerJoin(bookings, eq(bookings.id, bookingItems.bookingId))
@@ -4725,18 +4731,80 @@ const bookingsServiceInternal = {
         .where(eq(bookingAllocations.bookingItemId, itemId))
         .for("update")
 
-      const releasedAllocationIds: string[] = []
-      for (const allocation of allocations) {
-        const change = await releaseAllocationCapacity(
-          tx as PostgresJsDatabase,
-          allocation,
-          "modify",
-          { allowTerminalCapacityRelease: true },
+      const releasedAllocationIds = allocations
+        .filter((allocation) => allocationStatusConsumesSlotCapacity(allocation.status))
+        .map((allocation) => allocation.id)
+      const affectedSlotIds = [
+        ...new Set(
+          allocations.flatMap((allocation) =>
+            allocationStatusConsumesSlotCapacity(allocation.status) && allocation.availabilitySlotId
+              ? [allocation.availabilitySlotId]
+              : [],
+          ),
+        ),
+      ]
+
+      for (const slotId of affectedSlotIds) {
+        const liveSlotAllocations = await tx
+          .select()
+          .from(bookingAllocations)
+          .where(
+            and(
+              eq(bookingAllocations.bookingId, item.bookingId),
+              eq(bookingAllocations.availabilitySlotId, slotId),
+              inArray(bookingAllocations.status, ACTIVE_BOOKING_ALLOCATION_STATUSES),
+            ),
+          )
+          .orderBy(asc(bookingAllocations.createdAt), asc(bookingAllocations.id))
+          .for("update")
+        const remaining = liveSlotAllocations.filter(
+          (allocation) => allocation.bookingItemId !== itemId,
         )
-        if (allocationStatusConsumesSlotCapacity(allocation.status)) {
-          releasedAllocationIds.push(allocation.id)
+        const currentClaim = liveSlotAllocations.reduce(
+          (sum, allocation) => sum + allocation.quantity,
+          0,
+        )
+        const desiredClaim =
+          remaining.length === 0
+            ? 0
+            : Math.max(
+                item.bookingPax ??
+                  remaining.reduce((sum, allocation) => sum + allocation.quantity, 0),
+                0,
+              )
+        const remainingPaxDelta = currentClaim - desiredClaim
+        if (remainingPaxDelta !== 0) {
+          const capacity = await adjustSlotCapacity(
+            tx as PostgresJsDatabase,
+            slotId,
+            remainingPaxDelta,
+            "modify",
+            { allowTerminalCapacityRelease: remainingPaxDelta > 0 },
+          )
+          if (capacity.status !== "ok") {
+            throw new BookingServiceError(capacity.status)
+          }
+          if (capacity.slotChange) slotChanges.push(capacity.slotChange)
         }
-        if (change) slotChanges.push(change)
+
+        const [carrier, ...duplicates] = remaining
+        if (carrier) {
+          await tx
+            .update(bookingAllocations)
+            .set({ quantity: desiredClaim, updatedAt: new Date() })
+            .where(eq(bookingAllocations.id, carrier.id))
+        }
+        if (duplicates.length > 0) {
+          await tx
+            .update(bookingAllocations)
+            .set({ quantity: 0, updatedAt: new Date() })
+            .where(
+              inArray(
+                bookingAllocations.id,
+                duplicates.map((allocation) => allocation.id),
+              ),
+            )
+        }
       }
 
       const [row] = await tx

--- a/packages/bookings/tests/integration/booking-amendments.test.ts
+++ b/packages/bookings/tests/integration/booking-amendments.test.ts
@@ -487,6 +487,95 @@ describe.skipIf(!DB_AVAILABLE)("Booking traveler Amendments", () => {
     expect(travelers).toHaveLength(2)
   })
 
+  it("claims departure capacity once when adding a traveler across two priced items", async () => {
+    const { booking, traveler, slot, item, allocation } = await seedOwnedRosterBooking()
+    const [secondItem] = await db
+      .insert(bookingItems)
+      .values({
+        bookingId: booking.id,
+        title: "Second priced line on the same departure",
+        status: "confirmed",
+        quantity: 1,
+        sellCurrency: "EUR",
+        unitSellAmountCents: 5_000,
+        totalSellAmountCents: 5_000,
+        productId: "prod_roster",
+        availabilitySlotId: slot.id,
+      })
+      .returning()
+    const [secondAllocation] = await db
+      .insert(bookingAllocations)
+      .values({
+        bookingId: booking.id,
+        bookingItemId: secondItem!.id,
+        productId: "prod_roster",
+        availabilitySlotId: slot.id,
+        quantity: 0,
+        status: "confirmed",
+      })
+      .returning()
+    await db.insert(bookingItemTravelers).values({
+      bookingItemId: secondItem!.id,
+      travelerId: traveler.id,
+      role: "traveler",
+    })
+    await db.update(bookings).set({ sellAmountCents: 15_000 }).where(eq(bookings.id, booking.id))
+
+    const dependencies = { finance: financeRuntime() }
+    const preview = await bookingAmendmentService.previewTravelerRosterChange(
+      db,
+      booking.id,
+      {
+        expectedBookingRevision: 1,
+        reason: "Add one traveler to every priced line on the departure",
+        change: {
+          type: "traveler_add",
+          bookingItemIds: [item.id, secondItem!.id],
+          traveler: { firstName: "Katherine", lastName: "Johnson" },
+        },
+      },
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "multi-line-preview" },
+      dependencies,
+    )
+    if (preview.status !== "ok") throw new Error(`Expected preview, received ${preview.status}`)
+    const proposed = preview.amendment.revisions!.find(
+      (revision) => revision.role === "proposed_after",
+    )!
+    await bookingAmendmentService.accept(
+      db,
+      preview.amendment.id,
+      proposed.id,
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "multi-line-accept" },
+      dependencies,
+    )
+    await expect(
+      bookingAmendmentService.apply(
+        db,
+        preview.amendment.id,
+        { expectedBookingRevision: 1, proposedRevisionId: proposed.id },
+        { actor: "staff", actorId: "usr_staff", idempotencyKey: "multi-line-apply" },
+        dependencies,
+      ),
+    ).resolves.toMatchObject({ status: "ok" })
+
+    const [currentSlot] = await db
+      .select()
+      .from(availabilitySlotsRef)
+      .where(eq(availabilitySlotsRef.id, slot.id))
+    const currentAllocations = await db
+      .select()
+      .from(bookingAllocations)
+      .where(eq(bookingAllocations.bookingId, booking.id))
+    expect(currentSlot).toMatchObject({ remainingPax: 1 })
+    expect(currentAllocations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: allocation.id, quantity: 2 }),
+        expect.objectContaining({ id: secondAllocation!.id, quantity: 0 }),
+      ]),
+    )
+    expect(currentAllocations.reduce((sum, candidate) => sum + candidate.quantity, 0)).toBe(2)
+  })
+
   it("quotes a refund and releases capacity when dropping a traveler", async () => {
     const { booking, traveler, slot, item, allocation } = await seedOwnedRosterBooking()
     const dependencies = { finance: financeRuntime() }

--- a/packages/bookings/tests/integration/booking-item-addition.test.ts
+++ b/packages/bookings/tests/integration/booking-item-addition.test.ts
@@ -17,6 +17,7 @@ import { optionPriceRulesRef, priceCatalogsRef } from "../../src/pricing-ref.js"
 import { productOptionsRef, productsRef } from "../../src/products-ref.js"
 import type { BookingsFinanceRuntime } from "../../src/runtime-port.js"
 import { bookingAllocations, bookingItems, bookings } from "../../src/schema.js"
+import { bookingsService } from "../../src/service.js"
 import { bookingAmendmentService } from "../../src/service-amendments.js"
 
 const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
@@ -77,7 +78,9 @@ describe.skipIf(!DB_AVAILABLE)("Booking item addition Amendments", () => {
     }
   }
 
-  async function seed(options: { remainingPax?: number; withSlot?: boolean } = {}) {
+  async function seed(
+    options: { remainingPax?: number; withSlot?: boolean; existingPax?: number } = {},
+  ) {
     sequence += 1
     const remainingPax = options.remainingPax ?? 10
     const withSlot = options.withSlot ?? true
@@ -89,6 +92,7 @@ describe.skipIf(!DB_AVAILABLE)("Booking item addition Amendments", () => {
         sellCurrency: "EUR",
         status: "confirmed",
         sellAmountCents: 50_000,
+        pax: options.existingPax ?? null,
       })
       .returning()
 
@@ -154,7 +158,51 @@ describe.skipIf(!DB_AVAILABLE)("Booking item addition Amendments", () => {
           .returning()
       : [null]
 
-    return { booking: booking!, product: product!, option: option!, slot }
+    let existingItem: typeof bookingItems.$inferSelect | null = null
+    let existingAllocation: typeof bookingAllocations.$inferSelect | null = null
+    if (slot && options.existingPax) {
+      ;[existingItem] = await db
+        .insert(bookingItems)
+        .values({
+          bookingId: booking!.id,
+          title: "Original tour service",
+          status: "confirmed",
+          quantity: 1,
+          sellCurrency: "EUR",
+          unitSellAmountCents: 50_000,
+          totalSellAmountCents: 50_000,
+          productId: product!.id,
+          optionId: option!.id,
+          availabilitySlotId: slot.id,
+        })
+        .returning()
+      ;[existingAllocation] = await db
+        .insert(bookingAllocations)
+        .values({
+          bookingId: booking!.id,
+          bookingItemId: existingItem!.id,
+          productId: product!.id,
+          optionId: option!.id,
+          availabilitySlotId: slot.id,
+          quantity: options.existingPax,
+          status: "confirmed",
+          metadata: { availabilityHoldId: "avhd_converted" },
+        })
+        .returning()
+      await db
+        .update(availabilitySlotsRef)
+        .set({ remainingPax: remainingPax - options.existingPax })
+        .where(eq(availabilitySlotsRef.id, slot.id))
+    }
+
+    return {
+      booking: booking!,
+      product: product!,
+      option: option!,
+      slot,
+      existingItem,
+      existingAllocation,
+    }
   }
 
   function context(key: string) {
@@ -280,6 +328,69 @@ describe.skipIf(!DB_AVAILABLE)("Booking item addition Amendments", () => {
     // next move.
     if (applied.status !== "ok") throw new Error("Expected an applied amendment")
     expect(applied.amendment.nextActions).toContain("collect_payment")
+  })
+
+  it("does not spend the same booking pax twice when adding a line on its departure", async () => {
+    const seeded = await seed({ remainingPax: 48, existingPax: 3 })
+    const preview = await previewAddition(seeded, { quantity: 3 })
+    if (preview.status !== "ok") throw new Error("Expected a quote")
+    const proposed = preview.amendment.revisions?.find(
+      (revision) => revision.role === "proposed_after",
+    )
+    if (!proposed) throw new Error("Expected a proposed revision")
+
+    await bookingAmendmentService.accept(
+      db,
+      preview.amendment.id,
+      proposed.id,
+      context("accept-existing-capacity"),
+      { finance: financeRuntime() },
+    )
+    await expect(
+      bookingAmendmentService.apply(
+        db,
+        preview.amendment.id,
+        { expectedBookingRevision: 1, proposedRevisionId: proposed.id },
+        context("apply-existing-capacity"),
+        { finance: financeRuntime() },
+      ),
+    ).resolves.toMatchObject({ status: "ok" })
+
+    const allocations = await db
+      .select()
+      .from(bookingAllocations)
+      .where(eq(bookingAllocations.bookingId, seeded.booking.id))
+    expect(allocations).toHaveLength(2)
+    expect(allocations.reduce((sum, allocation) => sum + allocation.quantity, 0)).toBe(3)
+
+    const [slotAfterAdd] = await db
+      .select()
+      .from(availabilitySlotsRef)
+      .where(eq(availabilitySlotsRef.id, seeded.slot!.id))
+    expect(slotAfterAdd?.remainingPax).toBe(45)
+
+    await bookingsService.deleteItem(db, seeded.existingItem!.id)
+    const [allocationAfterCarrierDelete] = await db
+      .select()
+      .from(bookingAllocations)
+      .where(eq(bookingAllocations.bookingId, seeded.booking.id))
+    expect(allocationAfterCarrierDelete?.quantity).toBe(3)
+    const [slotAfterCarrierDelete] = await db
+      .select()
+      .from(availabilitySlotsRef)
+      .where(eq(availabilitySlotsRef.id, seeded.slot!.id))
+    expect(slotAfterCarrierDelete?.remainingPax).toBe(45)
+
+    const [remainingItem] = await db
+      .select()
+      .from(bookingItems)
+      .where(eq(bookingItems.bookingId, seeded.booking.id))
+    await bookingsService.deleteItem(db, remainingItem!.id)
+    const [slotAfterLastDelete] = await db
+      .select()
+      .from(availabilitySlotsRef)
+      .where(eq(availabilitySlotsRef.id, seeded.slot!.id))
+    expect(slotAfterLastDelete?.remainingPax).toBe(48)
   })
 
   it("refuses a departure that cannot seat the addition", async () => {

--- a/packages/bookings/tests/integration/booking-item-addition.test.ts
+++ b/packages/bookings/tests/integration/booking-item-addition.test.ts
@@ -393,6 +393,55 @@ describe.skipIf(!DB_AVAILABLE)("Booking item addition Amendments", () => {
     expect(slotAfterLastDelete?.remainingPax).toBe(48)
   })
 
+  it("does not normalize a legacy overclaim after the departure closes", async () => {
+    const seeded = await seed({ remainingPax: 48, existingPax: 3 })
+    await db
+      .update(bookingAllocations)
+      .set({ quantity: 5 })
+      .where(eq(bookingAllocations.id, seeded.existingAllocation!.id))
+    await db
+      .update(availabilitySlotsRef)
+      .set({ remainingPax: 43 })
+      .where(eq(availabilitySlotsRef.id, seeded.slot!.id))
+
+    const preview = await previewAddition(seeded, { quantity: 3 })
+    if (preview.status !== "ok") throw new Error("Expected a quote")
+    const proposed = preview.amendment.revisions?.find((r) => r.role === "proposed_after")
+    if (!proposed) throw new Error("Expected a proposed revision")
+    await db
+      .update(availabilitySlotsRef)
+      .set({ status: "closed" })
+      .where(eq(availabilitySlotsRef.id, seeded.slot!.id))
+
+    await bookingAmendmentService.accept(
+      db,
+      preview.amendment.id,
+      proposed.id,
+      context("accept-closed-overclaim"),
+      { finance: financeRuntime() },
+    )
+    await expect(
+      bookingAmendmentService.apply(
+        db,
+        preview.amendment.id,
+        { expectedBookingRevision: 1, proposedRevisionId: proposed.id },
+        context("apply-closed-overclaim"),
+        { finance: financeRuntime() },
+      ),
+    ).resolves.toMatchObject({ status: "availability_changed" })
+
+    const [slot] = await db
+      .select()
+      .from(availabilitySlotsRef)
+      .where(eq(availabilitySlotsRef.id, seeded.slot!.id))
+    expect(slot?.remainingPax).toBe(43)
+    const items = await db
+      .select()
+      .from(bookingItems)
+      .where(eq(bookingItems.bookingId, seeded.booking.id))
+    expect(items).toHaveLength(1)
+  })
+
   it("refuses a departure that cannot seat the addition", async () => {
     const seeded = await seed({ remainingPax: 1 })
     const preview = await previewAddition(seeded, { quantity: 4 })

--- a/packages/bookings/tests/integration/booking-item-move.test.ts
+++ b/packages/bookings/tests/integration/booking-item-move.test.ts
@@ -391,6 +391,100 @@ describe.skipIf(!DB_AVAILABLE)("Booking item move Amendments", () => {
     )
   })
 
+  it("releases a legacy duplicate source claim while moving one shared line", async () => {
+    const seeded = await seed({ quantity: 2 })
+    await db.update(bookings).set({ pax: 2 }).where(eq(bookings.id, seeded.booking.id))
+    const [peerItem] = await db
+      .insert(bookingItems)
+      .values({
+        bookingId: seeded.booking.id,
+        title: "Legacy duplicate line",
+        status: "confirmed",
+        quantity: 2,
+        sellCurrency: "EUR",
+        unitSellAmountCents: 10_000,
+        totalSellAmountCents: 20_000,
+        productId: seeded.product.id,
+        optionId: seeded.option.id,
+        availabilitySlotId: seeded.from.id,
+      })
+      .returning()
+    await db.insert(bookingAllocations).values({
+      bookingId: seeded.booking.id,
+      bookingItemId: peerItem!.id,
+      productId: seeded.product.id,
+      availabilitySlotId: seeded.from.id,
+      quantity: 2,
+      status: "confirmed",
+    })
+
+    const preview = await previewMove({
+      ...seeded,
+      booking: { ...seeded.booking, pax: 2 },
+    })
+    if (preview.status !== "ok") throw new Error(`Expected preview, received ${preview.status}`)
+    await expect(applyMove(preview.amendment, "move-legacy-duplicate")).resolves.toMatchObject({
+      status: "ok",
+    })
+
+    expect((await readSlot(seeded.from.id))?.remainingPax).toBe(2)
+    expect((await readSlot(seeded.to.id))?.remainingPax).toBe(6)
+    const allocations = await db
+      .select()
+      .from(bookingAllocations)
+      .where(eq(bookingAllocations.bookingId, seeded.booking.id))
+    expect(allocations.reduce((sum, allocation) => sum + allocation.quantity, 0)).toBe(4)
+  })
+
+  it("revalidates a closed target even when the booking already claims its capacity", async () => {
+    const seeded = await seed({ quantity: 2 })
+    await db.update(bookings).set({ pax: 2 }).where(eq(bookings.id, seeded.booking.id))
+    const [targetItem] = await db
+      .insert(bookingItems)
+      .values({
+        bookingId: seeded.booking.id,
+        title: "Existing target service",
+        status: "confirmed",
+        quantity: 2,
+        sellCurrency: "EUR",
+        unitSellAmountCents: 10_000,
+        totalSellAmountCents: 20_000,
+        productId: seeded.product.id,
+        optionId: seeded.option.id,
+        availabilitySlotId: seeded.to.id,
+      })
+      .returning()
+    await db.insert(bookingAllocations).values({
+      bookingId: seeded.booking.id,
+      bookingItemId: targetItem!.id,
+      productId: seeded.product.id,
+      availabilitySlotId: seeded.to.id,
+      quantity: 2,
+      status: "confirmed",
+    })
+    await db
+      .update(availabilitySlotsRef)
+      .set({ remainingPax: 6 })
+      .where(eq(availabilitySlotsRef.id, seeded.to.id))
+
+    const preview = await previewMove({
+      ...seeded,
+      booking: { ...seeded.booking, pax: 2 },
+    })
+    if (preview.status !== "ok") throw new Error(`Expected preview, received ${preview.status}`)
+    await db
+      .update(availabilitySlotsRef)
+      .set({ status: "closed" })
+      .where(eq(availabilitySlotsRef.id, seeded.to.id))
+
+    await expect(
+      applyMove(preview.amendment, "move-closed-preclaimed-target"),
+    ).resolves.toMatchObject({ status: "availability_changed" })
+    const [item] = await db.select().from(bookingItems).where(eq(bookingItems.id, seeded.item.id))
+    expect(item?.availabilitySlotId).toBe(seeded.from.id)
+    expect((await readSlot(seeded.from.id))?.remainingPax).toBe(0)
+  })
+
   it("refuses a departure that cannot seat the booking", async () => {
     const seeded = await seed({ quantity: 4, targetPax: 1 })
     expect((await previewMove(seeded)).status).toBe("availability_changed")

--- a/packages/bookings/tests/integration/booking-item-move.test.ts
+++ b/packages/bookings/tests/integration/booking-item-move.test.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: bookings; one focused live-database suite proves move capacity conservation, rollback, supplier, and replay invariants together.
 /**
  * `item_move` Amendments: carrying a Booking Item to a different departure.
  *
@@ -319,6 +320,75 @@ describe.skipIf(!DB_AVAILABLE)("Booking item move Amendments", () => {
       .from(bookingAllocations)
       .where(eq(bookingAllocations.id, seeded.allocation.id))
     expect(allocation?.availabilitySlotId).toBe(seeded.to.id)
+  })
+
+  it("moves a shared-departure line without releasing the booking's source claim", async () => {
+    const seeded = await seed({ quantity: 2 })
+    await db.update(bookings).set({ pax: 2 }).where(eq(bookings.id, seeded.booking.id))
+    const [sharedItem] = await db
+      .insert(bookingItems)
+      .values({
+        bookingId: seeded.booking.id,
+        title: "Second priced line",
+        status: "confirmed",
+        quantity: 2,
+        sellCurrency: "EUR",
+        unitSellAmountCents: 10_000,
+        totalSellAmountCents: 20_000,
+        productId: seeded.product.id,
+        optionId: seeded.option.id,
+        availabilitySlotId: seeded.from.id,
+      })
+      .returning()
+    const [sharedAllocation] = await db
+      .insert(bookingAllocations)
+      .values({
+        bookingId: seeded.booking.id,
+        bookingItemId: sharedItem!.id,
+        productId: seeded.product.id,
+        availabilitySlotId: seeded.from.id,
+        quantity: 0,
+        status: "confirmed",
+      })
+      .returning()
+
+    const preview = await previewMove({
+      ...seeded,
+      booking: { ...seeded.booking, pax: 2 },
+      item: sharedItem!,
+      allocation: sharedAllocation!,
+    })
+    if (preview.status !== "ok") throw new Error(`Expected preview, received ${preview.status}`)
+    await expect(applyMove(preview.amendment, "move-shared-line")).resolves.toMatchObject({
+      status: "ok",
+    })
+
+    const [from, to] = await Promise.all(
+      [seeded.from.id, seeded.to.id].map(async (id) => {
+        const [slot] = await db
+          .select()
+          .from(availabilitySlotsRef)
+          .where(eq(availabilitySlotsRef.id, id))
+        return slot!
+      }),
+    )
+    expect(from.remainingPax).toBe(0)
+    expect(to.remainingPax).toBe(6)
+
+    const allocations = await db
+      .select()
+      .from(bookingAllocations)
+      .where(eq(bookingAllocations.bookingId, seeded.booking.id))
+    expect(
+      allocations
+        .map((allocation) => [allocation.availabilitySlotId, allocation.quantity])
+        .sort(([left], [right]) => String(left).localeCompare(String(right))),
+    ).toEqual(
+      [
+        [seeded.from.id, 2],
+        [seeded.to.id, 2],
+      ].sort(([left], [right]) => String(left).localeCompare(String(right))),
+    )
   })
 
   it("refuses a departure that cannot seat the booking", async () => {

--- a/packages/finance/src/service-planned-cost.ts
+++ b/packages/finance/src/service-planned-cost.ts
@@ -227,11 +227,15 @@ export async function resolveDeparturePlannedCosts(
     executeBoundaryRows<{ slot_id: string; pax: number }>(
       db,
       sql`
-        SELECT ba.availability_slot_id AS slot_id, COALESCE(SUM(b.pax), 0)::int AS pax
-        FROM booking_allocations ba
-        JOIN bookings b ON b.id = ba.booking_id
-        WHERE ba.availability_slot_id IN (${sqlList(versionBoundIds)}) AND ba.status <> 'cancelled'
-        GROUP BY ba.availability_slot_id
+        SELECT claims.slot_id, COALESCE(SUM(b.pax), 0)::int AS pax
+        FROM (
+          SELECT DISTINCT ba.availability_slot_id AS slot_id, ba.booking_id
+          FROM booking_allocations ba
+          WHERE ba.availability_slot_id IN (${sqlList(versionBoundIds)})
+            AND ba.status <> 'cancelled'
+        ) claims
+        JOIN bookings b ON b.id = claims.booking_id
+        GROUP BY claims.slot_id
       `,
     ),
   ])


### PR DESCRIPTION
Closes #4870.

## What changed

- Render item-addition amendment amounts from minor currency units, so `49_500` cents displays as `€495.00`.
- Treat departure capacity as one booking-level passenger claim per `(booking, departure)`, rather than consuming capacity once per commercial line.
- Preserve and transfer the booking-level claim when items are added, moved, deleted, or traveler rosters are amended.
- Keep per-item allocation rows as departure membership links while allowing sibling rows to carry zero quantity.
- Count distinct booking/departure membership when calculating planned passengers in finance.
- Preserve compatibility with amendment plans persisted before the new capacity metadata was added.

## Root cause

Item additions displayed a minor-unit amount as though it were already a major-unit amount. Separately, capacity adjustments treated every priced booking item as an independent passenger claim. Multiple commercial lines for the same booking and departure therefore consumed the same passengers repeatedly.

## Impact

Adding several products on the same departure now consumes the booking's passenger count exactly once. Removing or moving one of those products no longer releases capacity that another item in the booking still depends on.

## Validation

- Live PostgreSQL 16 Docker database with the real operator migration path
- Focused booking amendment, item-addition, and item-move integration tests
- Bookings: 494 passed
- Bookings React: 300 passed
- Finance: 714 passed
- Package typechecks for bookings, bookings-react, and finance
- Full architecture verification
- Operator build and all 115 dependent workspace builds
- Pre-commit affected build/typecheck gate: 232/232 tasks
- Pre-push repository test gate under Node 22: 121/121 tasks
- Playwright operator flow against the local Docker database
- Independent Chrome DevTools MCP verification with no console warnings/errors and successful API requests

The browser scenario added the same €495 item/departure twice. Remaining capacity moved from 20 to 18 on the first addition and stayed at 18 on the second; persisted allocation quantities were 2 and 0.