### PR TITLE
Fix checkout finalization deadlock

### DIFF
--- a/.changeset/calm-checkouts-finalize.md
+++ b/.changeset/calm-checkouts-finalize.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/commerce": patch
+---
+
+Run paid-checkout finalization without a saga-wide database transaction so each durable finance and legal step can commit its checkpoint and release locks before the next step.

--- a/.changeset/calm-checkouts-finalize.md
+++ b/.changeset/calm-checkouts-finalize.md
@@ -2,4 +2,4 @@
 "@voyant-travel/commerce": patch
 ---
 
-Run paid-checkout finalization without a saga-wide database transaction so each durable finance and legal step can commit its checkpoint and release locks before the next step.
+Run paid-checkout finalization on the primary database without a saga-wide transaction so each durable finance and legal step can read its committed checkpoint and release locks before the next step.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
     # against a hang rather than a budget the lane is already spending.
     #
     # Raised again to 30 for the same reason, with the arithmetic spelled out so
-    # the next person does not have to rediscover it: the lane now names 57
+    # the next person does not have to rediscover it: the lane now names 58
     # files, each paying its own process start and database setup, and the
     # insurance work (voyant#4750, voyant#4756) added four. At 20 it was being
     # cancelled mid-suite with every test passing — a budget, not a backstop.
@@ -387,6 +387,8 @@ jobs:
                 tests/integration/fx-rate-capture.test.ts
               pnpm --filter @voyant-travel/commerce exec vitest run \
                 tests/integration/ancillary-checkout-fulfilment.test.ts
+              pnpm --filter @voyant-travel/commerce exec vitest run \
+                tests/integration/checkout-finalization-store.test.ts
               pnpm --filter @voyant-travel/cruises exec vitest run \
                 tests/integration/created-target-tools.test.ts
               pnpm --filter @voyant-travel/auth exec vitest run \

--- a/packages/commerce/src/runtime.ts
+++ b/packages/commerce/src/runtime.ts
@@ -173,10 +173,13 @@ export function createCommerceRuntime(requirements: CommerceRuntimeRequirements)
       },
     }),
     checkoutDatabase: {
+      // Finalization is a durable saga whose individual finance/legal steps
+      // own their transaction boundaries. A transaction around the whole
+      // delivery turns those boundaries into savepoints and retains their row
+      // locks until every step finishes, inverting the booking-confirmed lock
+      // order and allowing Postgres to deadlock the two deliveries.
       withDb: <T>(bindings: unknown, operation: (db: PostgresJsDatabase) => Promise<T>) =>
-        primitives.database.transaction(bindings, (database) =>
-          operation(database as PostgresJsDatabase),
-        ),
+        operation(primitives.database.resolve<PostgresJsDatabase>(bindings)),
     },
     checkoutLegal: legal,
     promotionRedemptionDatabase: {

--- a/packages/commerce/src/runtime.ts
+++ b/packages/commerce/src/runtime.ts
@@ -178,8 +178,10 @@ export function createCommerceRuntime(requirements: CommerceRuntimeRequirements)
       // delivery turns those boundaries into savepoints and retains their row
       // locks until every step finishes, inverting the booking-confirmed lock
       // order and allowing Postgres to deadlock the two deliveries.
-      withDb: <T>(bindings: unknown, operation: (db: PostgresJsDatabase) => Promise<T>) =>
-        operation(primitives.database.resolve<PostgresJsDatabase>(bindings)),
+      withDb: <T>(bindings: unknown, operation: (db: PostgresJsDatabase) => Promise<T>) => {
+        const database = primitives.database.resolve<PostgresJsDatabase>(bindings)
+        return operation(resolvePrimaryDatabase(database))
+      },
     },
     checkoutLegal: legal,
     promotionRedemptionDatabase: {
@@ -220,6 +222,10 @@ export function createCommerceRuntime(requirements: CommerceRuntimeRequirements)
       },
     },
   }
+}
+
+function resolvePrimaryDatabase(database: PostgresJsDatabase): PostgresJsDatabase {
+  return (database as PostgresJsDatabase & { $primary?: PostgresJsDatabase }).$primary ?? database
 }
 
 function stringValue(value: unknown): string | undefined {

--- a/packages/commerce/tests/integration/checkout-finalization-store.test.ts
+++ b/packages/commerce/tests/integration/checkout-finalization-store.test.ts
@@ -1,16 +1,21 @@
 import { eq, sql } from "drizzle-orm"
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   ensureCheckoutFinalization,
+  getCheckoutFinalization,
+  getCheckoutFinalizationDelivery,
   withCheckoutFinalizationLock,
 } from "../../src/checkout/finalization-store.js"
 import {
   checkoutFinalizationDeliveries,
   checkoutFinalizations,
 } from "../../src/checkout/schema-finalizations.js"
+import { createCommerceRuntime } from "../../src/runtime.js"
 
-const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
+const DB_AVAILABLE = !!TEST_DATABASE_URL
 
 describe.skipIf(!DB_AVAILABLE)("checkout finalization store", () => {
   let db: ReturnType<typeof import("@voyant-travel/db/test-utils").createTestDb>
@@ -27,6 +32,110 @@ describe.skipIf(!DB_AVAILABLE)("checkout finalization store", () => {
   afterAll(async () => {
     const { closeTestDb } = await import("@voyant-travel/db/test-utils")
     await closeTestDb()
+  })
+
+  it("commits an early finalization checkpoint when a later saga step fails", async () => {
+    const identity = {
+      bookingId: "booking_checkpoint_survives",
+      paymentSessionId: "session_checkpoint_survives",
+    }
+    const hostTransaction = vi.fn(
+      async <T>(_bindings: unknown, operation: (database: unknown) => Promise<T>): Promise<T> =>
+        db.transaction((tx) => operation(tx)),
+    )
+    const runtime = createCommerceRuntime({
+      primitives: {
+        env: () => ({}),
+        database: {
+          resolve: () => db,
+          fromContext: () => db,
+          transaction: hostTransaction,
+        },
+      },
+      inventoryPolicy: { createPaymentPolicyRuntime: () => ({}) },
+      settings: {},
+      inventory: {},
+      legal: {},
+      catalog: {},
+      publication: {},
+      distribution: {},
+      accommodations: {},
+      cruises: {},
+    } as never)
+
+    await expect(
+      runtime.checkoutDatabase.withDb({}, async (resolvedDb) => {
+        await ensureCheckoutFinalization(resolvedDb, identity)
+        throw new Error("injected failure after checkpoint")
+      }),
+    ).rejects.toThrow("injected failure after checkpoint")
+
+    await expect(getCheckoutFinalization(db, identity.bookingId)).resolves.toMatchObject({
+      bookingId: identity.bookingId,
+      triggerPaymentSessionId: identity.paymentSessionId,
+    })
+    await expect(
+      getCheckoutFinalizationDelivery(db, identity.paymentSessionId),
+    ).resolves.toMatchObject(identity)
+    expect(hostTransaction).not.toHaveBeenCalled()
+  })
+
+  it("does not deadlock finance rows against the legal booking advisory lock", async () => {
+    const identity = {
+      bookingId: "booking_lock_order",
+      paymentSessionId: "session_lock_order",
+    }
+    await ensureCheckoutFinalization(db, identity)
+
+    await withConcurrentDbClients(async (checkoutDb, bookingConfirmedDb) => {
+      const hostTransaction = vi.fn(
+        async <T>(
+          _bindings: unknown,
+          operation: (database: PostgresJsDatabase) => Promise<T>,
+        ): Promise<T> => checkoutDb.transaction((tx) => operation(tx)),
+      )
+      const runtime = createTestCommerceRuntime(checkoutDb, hostTransaction)
+      const legalLockKey = `legal:booking-confirmed:${identity.bookingId}`
+      let rowLocked = () => {}
+      const checkoutHasRowLock = new Promise<void>((resolve) => {
+        rowLocked = resolve
+      })
+      let advisoryLocked = () => {}
+      const bookingConfirmedHasAdvisoryLock = new Promise<void>((resolve) => {
+        advisoryLocked = resolve
+      })
+
+      const paymentCompleted = runtime.checkoutDatabase.withDb({}, async (resolvedDb) => {
+        await resolvedDb.transaction(async (tx) => {
+          await tx.execute(sql`
+            UPDATE checkout_finalizations
+            SET revision = revision + 1
+            WHERE booking_id = ${identity.bookingId}
+          `)
+          rowLocked()
+          await bookingConfirmedHasAdvisoryLock
+        })
+        await resolvedDb.transaction(async (tx) => {
+          await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${legalLockKey}))`)
+        })
+      })
+      const bookingConfirmed = bookingConfirmedDb.transaction(async (tx) => {
+        await checkoutHasRowLock
+        await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${legalLockKey}))`)
+        advisoryLocked()
+        await tx.execute(sql`
+          UPDATE checkout_finalizations
+          SET revision = revision + 1
+          WHERE booking_id = ${identity.bookingId}
+        `)
+      })
+
+      await expect(Promise.all([paymentCompleted, bookingConfirmed])).resolves.toEqual([
+        undefined,
+        undefined,
+      ])
+      expect(hostTransaction).not.toHaveBeenCalled()
+    })
   })
 
   it("serializes distinct payment-session deliveries on one booking authority row", async () => {
@@ -76,3 +185,63 @@ describe.skipIf(!DB_AVAILABLE)("checkout finalization store", () => {
     expect(deliveryRows).toHaveLength(2)
   })
 })
+
+function createTestCommerceRuntime(
+  db: PostgresJsDatabase,
+  transaction: <T>(
+    bindings: unknown,
+    operation: (database: PostgresJsDatabase) => Promise<T>,
+  ) => Promise<T>,
+) {
+  return createCommerceRuntime({
+    primitives: {
+      env: () => ({}),
+      database: {
+        resolve: () => db,
+        fromContext: () => db,
+        transaction,
+      },
+    },
+    inventoryPolicy: { createPaymentPolicyRuntime: () => ({}) },
+    settings: {},
+    inventory: {},
+    legal: {},
+    catalog: {},
+    publication: {},
+    distribution: {},
+    accommodations: {},
+    cruises: {},
+  } as never)
+}
+
+async function withConcurrentDbClients<T>(
+  run: (checkoutDb: PostgresJsDatabase, bookingConfirmedDb: PostgresJsDatabase) => Promise<T>,
+) {
+  const { createDbClient } = await import("@voyant-travel/db")
+  const databaseUrl = process.env.TEST_DATABASE_URL
+  if (!databaseUrl) throw new Error("TEST_DATABASE_URL is required for concurrent DB clients.")
+  const checkoutDb = createDbClient(databaseUrl, {
+    adapter: "node",
+    nodeMaxConnections: 1,
+    timeouts: { statementMs: false, queryMs: false, connectMs: false },
+  }) as PostgresJsDatabaseWithClient
+  const bookingConfirmedDb = createDbClient(databaseUrl, {
+    adapter: "node",
+    nodeMaxConnections: 1,
+    timeouts: { statementMs: false, queryMs: false, connectMs: false },
+  }) as PostgresJsDatabaseWithClient
+  try {
+    return await run(checkoutDb, bookingConfirmedDb)
+  } finally {
+    await Promise.all([
+      checkoutDb.$client?.end?.({ timeout: 0 }),
+      bookingConfirmedDb.$client?.end?.({ timeout: 0 }),
+    ])
+  }
+}
+
+type PostgresJsDatabaseWithClient = PostgresJsDatabase & {
+  $client?: {
+    end?: (options?: { timeout?: number | null }) => Promise<unknown>
+  }
+}

--- a/packages/commerce/tests/unit/runtime-checkout-database.test.ts
+++ b/packages/commerce/tests/unit/runtime-checkout-database.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { catalogCheckoutDatabaseRuntimePort } from "../../src/checkout/runtime-ports.js"
+import { createCommerceRuntimePortContribution } from "../../src/runtime-contributor.js"
+
+describe("commerce checkout database runtime", () => {
+  it("runs checkout finalization against the resolved database without an outer transaction", async () => {
+    const bindings = { requestId: "req_1" }
+    const db = { name: "resolved-db" }
+    const resolve = vi.fn(() => db)
+    const transaction = vi.fn(async () => {
+      throw new Error("checkout finalization must not hold a saga-wide transaction")
+    })
+    const ports = createCommerceRuntimePortContribution({
+      primitives: {
+        database: {
+          fromContext: vi.fn(),
+          resolve,
+          transaction,
+        },
+        env: () => ({}),
+      } as never,
+      getRuntimePort: async (port) => {
+        if (port.id === "finance.inventory-payment-policy.runtime") {
+          return {
+            createPaymentPolicyRuntime: () => ({
+              resolveSupplierPolicy: async () => null,
+              resolveSupplierPolicyById: async () => null,
+              resolveCategoryPolicy: async () => null,
+              resolveListingPolicy: async () => null,
+            }),
+          } as never
+        }
+        if (port.id === "commerce.card-payment.runtime") return undefined as never
+        return {} as never
+      },
+    })
+    const checkoutDatabase = await ports[catalogCheckoutDatabaseRuntimePort.id]
+    const operation = vi.fn(async (resolvedDb: unknown) => {
+      expect(resolvedDb).toBe(db)
+      return "completed"
+    })
+
+    await expect(
+      (
+        checkoutDatabase as {
+          withDb<T>(bindings: unknown, operation: (db: unknown) => Promise<T>): Promise<T>
+        }
+      ).withDb(bindings, operation),
+    ).resolves.toBe("completed")
+
+    expect(resolve).toHaveBeenCalledWith(bindings)
+    expect(transaction).not.toHaveBeenCalled()
+    expect(operation).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/commerce/tests/unit/runtime-checkout-database.test.ts
+++ b/packages/commerce/tests/unit/runtime-checkout-database.test.ts
@@ -6,8 +6,9 @@ import { createCommerceRuntimePortContribution } from "../../src/runtime-contrib
 describe("commerce checkout database runtime", () => {
   it("runs checkout finalization against the resolved database without an outer transaction", async () => {
     const bindings = { requestId: "req_1" }
-    const db = { name: "resolved-db" }
-    const resolve = vi.fn(() => db)
+    const primaryDb = { name: "primary-db" }
+    const replicaAwareDb = { name: "replica-aware-db", $primary: primaryDb }
+    const resolve = vi.fn(() => replicaAwareDb)
     const transaction = vi.fn(async () => {
       throw new Error("checkout finalization must not hold a saga-wide transaction")
     })
@@ -37,7 +38,7 @@ describe("commerce checkout database runtime", () => {
     })
     const checkoutDatabase = await ports[catalogCheckoutDatabaseRuntimePort.id]
     const operation = vi.fn(async (resolvedDb: unknown) => {
-      expect(resolvedDb).toBe(db)
+      expect(resolvedDb).toBe(primaryDb)
       return "completed"
     })
 


### PR DESCRIPTION
## Summary

- remove the accidental transaction around the entire paid-checkout finalization saga
- let the existing finance and Legal step transactions commit their durable checkpoints and release locks independently
- add real-Postgres regressions for checkpoint durability and the production Legal-advisory/finance-row deadlock cycle

## Incident evidence

Sandbox paid bookings reproduced PostgreSQL `40P01`: `payment.completed` held finance row/XID locks and then requested `legal:booking-confirmed:<booking>`, while `booking.confirmed` held that advisory lock and waited on the finance transaction. Durable retries eventually created the customer artifacts, but payment completion took roughly 103 seconds and the event remained pending after five attempts.

## Verification

- exact RED on the old boundary: checkpoint rolled back and the two-connection test raised PostgreSQL `40P01` with the production-equivalent lock cycle
- exact GREEN on the patch: 2 files, 4 tests passed against a fresh migrated PostgreSQL 16 database
- all 32 migration groups applied cleanly to the test database
- full Commerce suite: 218 passed, 24 database-gated skipped (`--maxWorkers=4`)
- Biome and `git diff --check`: passed
- package typecheck reached the 6 GB heap limit locally and 2/4 GB remotely without emitting a TypeScript diagnostic; CI is the high-memory typecheck gate
