### PR TITLE
Give booking contract rendering a bounded event budget

### DIFF
--- a/.changeset/calm-contract-timeouts.md
+++ b/.changeset/calm-contract-timeouts.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/core": patch
+"@voyant-travel/legal": patch
+---
+
+Give booking-confirmed contract rendering a finite timeout budget longer than the renderer maximum, and identify labeled subscribers in timeout diagnostics.

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -88,6 +88,8 @@ export interface Subscription {
  * Per-subscription options.
  */
 export interface SubscribeOptions {
+  /** Stable identity included in timeout diagnostics. */
+  label?: string
   /**
    * Inline handlers complete before `emit()` resolves even when the
    * emitter supplies a deferral scheduler (see {@link EmitOptions}).
@@ -289,6 +291,7 @@ const DEFAULT_HANDLER_TIMEOUT_MS = 15_000
 
 interface RegisteredHandler {
   inline: boolean
+  label?: string
   /** Per-subscription override of the bus timeout; absent means the default. */
   timeoutMs?: number | false
 }
@@ -366,7 +369,8 @@ export function createEventBus(options: EventBusOptions = {}): EventBus {
           // be worse if the detached run also fails. Reported as a timeout so
           // the retry is not mistaken for a clean one — it will run alongside
           // the attempt still in flight (voyant#4640).
-          const message = `subscriber for "${event}" exceeded ${effectiveTimeoutMs}ms; not awaited`
+          const identity = registered?.label ? ` ${registered.label}` : ""
+          const message = `subscriber${identity} for "${event}" exceeded ${effectiveTimeoutMs}ms; not awaited`
           console.error(`[events] ${message}`)
           notifySubscriberError(event, new Error(message))
           return { message, timedOut: true, permanent: false }
@@ -553,6 +557,7 @@ export function createEventBus(options: EventBusOptions = {}): EventBus {
       }
       registered.set(handler as EventHandler, {
         inline: subscribeOptions?.inline ?? false,
+        ...(subscribeOptions?.label === undefined ? {} : { label: subscribeOptions.label }),
         ...(subscribeOptions?.timeoutMs === undefined
           ? {}
           : { timeoutMs: subscribeOptions.timeoutMs }),

--- a/packages/core/tests/unit/events.test.ts
+++ b/packages/core/tests/unit/events.test.ts
@@ -465,6 +465,22 @@ describe("deliver — redelivery with failure reporting", () => {
 })
 
 describe("per-subscription handler timeout (voyant#4639)", () => {
+  it("names a labeled subscriber in timeout diagnostics", async () => {
+    const bus = createEventBus({ handlerTimeoutMs: 100 })
+    bus.subscribe("test.slow", () => new Promise(() => {}), {
+      label: "@acme/slow#subscriber.test",
+      timeoutMs: 10,
+    })
+
+    const result = await bus.deliver?.({
+      name: "test.slow",
+      data: {},
+      emittedAt: new Date().toISOString(),
+    })
+
+    expect(result?.errors[0]).toContain("@acme/slow#subscriber.test")
+  })
+
   it("gives a slow subscriber its own budget instead of the bus default", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
     const bus = createEventBus({ handlerTimeoutMs: 10 })

--- a/packages/legal/src/booking-contract-confirmed-subscriber.ts
+++ b/packages/legal/src/booking-contract-confirmed-subscriber.ts
@@ -11,6 +11,9 @@ import {
   type LegalDocumentArtifactProvider,
   legalDocumentArtifactProviderPort,
 } from "./contracts/document-artifact-provider.js"
+import { LEGAL_BOOKING_CONFIRMED_SUBSCRIBER_TIMEOUT_MS } from "./document-timeouts.js"
+
+export { LEGAL_BOOKING_CONFIRMED_SUBSCRIBER_TIMEOUT_MS } from "./document-timeouts.js"
 
 export const LEGAL_BOOKING_CONTRACT_CONFIRMED_SUBSCRIBER_ID =
   "@voyant-travel/legal#subscriber.booking-contract-confirmed"
@@ -48,29 +51,36 @@ export function createLegalBookingContractConfirmedSubscriber(
     id: LEGAL_BOOKING_CONTRACT_CONFIRMED_SUBSCRIBER_ID,
     eventType: "booking.confirmed",
     register: ({ eventBus }) => {
-      eventBus.subscribe<LegalBookingConfirmedPayload>("booking.confirmed", async (event) => {
-        const db = await options.resolveDb()
-        if (options.generate) {
-          await options.generate({ db, event })
-          return
-        }
-        // voyant#4634: a deployment without a renderer used to `return` here.
-        // That is the state in which contract generation has never once run,
-        // and it looked identical to a deployment where it always works.
-        if (!options.provider) {
-          await recordUnfulfilledBookingContract(db, {
+      eventBus.subscribe<LegalBookingConfirmedPayload>(
+        "booking.confirmed",
+        async (event) => {
+          const db = await options.resolveDb()
+          if (options.generate) {
+            await options.generate({ db, event })
+            return
+          }
+          // voyant#4634: a deployment without a renderer used to `return` here.
+          // That is the state in which contract generation has never once run,
+          // and it looked identical to a deployment where it always works.
+          if (!options.provider) {
+            await recordUnfulfilledBookingContract(db, {
+              event,
+              reason: "document_renderer_unavailable",
+            })
+            return
+          }
+          await generateBookingContractOnConfirmation({
+            db,
             event,
-            reason: "document_renderer_unavailable",
+            provider: options.provider,
+            eventBus,
           })
-          return
-        }
-        await generateBookingContractOnConfirmation({
-          db,
-          event,
-          provider: options.provider,
-          eventBus,
-        })
-      })
+        },
+        {
+          label: LEGAL_BOOKING_CONTRACT_CONFIRMED_SUBSCRIBER_ID,
+          timeoutMs: LEGAL_BOOKING_CONFIRMED_SUBSCRIBER_TIMEOUT_MS,
+        },
+      )
     },
   }
 }

--- a/packages/legal/src/document-artifact-runtime.ts
+++ b/packages/legal/src/document-artifact-runtime.ts
@@ -10,6 +10,7 @@ import {
   type LegalDocumentArtifactProvider,
   type LegalDocumentRenderDescriptor,
 } from "./contracts/document-artifact-provider.js"
+import { LEGAL_DOCUMENT_RENDER_TIMEOUT_MS } from "./document-timeouts.js"
 
 function escapeHtml(value: string) {
   return value
@@ -114,7 +115,7 @@ export async function createStandardLegalDocumentArtifactProvider(input: {
       const bytes = await renderer.renderPdf({
         html: descriptorHtml(descriptor),
         page: { format: "a4", printBackground: true },
-        navigation: { waitUntil: "networkidle0", timeoutMs: 30_000 },
+        navigation: { waitUntil: "networkidle0", timeoutMs: LEGAL_DOCUMENT_RENDER_TIMEOUT_MS },
         mediaType: "print",
       })
       return {

--- a/packages/legal/src/document-timeouts.ts
+++ b/packages/legal/src/document-timeouts.ts
@@ -1,0 +1,11 @@
+/** Maximum time the managed renderer may spend loading a Legal document. */
+export const LEGAL_DOCUMENT_RENDER_TIMEOUT_MS = 30_000
+
+/**
+ * EventBus budget for booking-confirmed contract generation.
+ *
+ * Rendering is only one part of the handler: admission, artifact storage and
+ * contract promotion also need time. Keep this finite, but strictly above the
+ * renderer's own bound so successful renders are not detached and retried.
+ */
+export const LEGAL_BOOKING_CONFIRMED_SUBSCRIBER_TIMEOUT_MS = 45_000

--- a/packages/legal/tests/unit/booking-contract-confirmed-subscriber.test.ts
+++ b/packages/legal/tests/unit/booking-contract-confirmed-subscriber.test.ts
@@ -9,8 +9,10 @@ import {
 } from "../../src/booking-contract-confirmed.js"
 import {
   createLegalBookingContractConfirmedSubscriber,
+  LEGAL_BOOKING_CONFIRMED_SUBSCRIBER_TIMEOUT_MS,
   LEGAL_BOOKING_CONTRACT_CONFIRMED_SUBSCRIBER_ID,
 } from "../../src/booking-contract-confirmed-subscriber.js"
+import { LEGAL_DOCUMENT_RENDER_TIMEOUT_MS } from "../../src/document-timeouts.js"
 
 vi.mock("../../src/booking-contract-confirmed.js", () => ({
   generateBookingContractOnConfirmation: vi.fn(async () => ({ status: "generated" as const })),
@@ -38,15 +40,35 @@ const confirmed = {
 function captureHandler() {
   const eventBus = createEventBus()
   let handler: ((event: EventEnvelope) => Promise<void> | void) | undefined
-  vi.spyOn(eventBus, "subscribe").mockImplementation((_eventType, registeredHandler) => {
+  let options: Parameters<typeof eventBus.subscribe>[2]
+  vi.spyOn(eventBus, "subscribe").mockImplementation((_eventType, registeredHandler, value) => {
     handler = registeredHandler as typeof handler
+    options = value
     return { unsubscribe: vi.fn() }
   })
-  return { eventBus, handler: () => handler }
+  return { eventBus, handler: () => handler, options: () => options }
 }
 
 describe("Legal booking contract confirmation subscriber", () => {
   beforeEach(() => vi.clearAllMocks())
+
+  it("budgets the full renderer timeout and identifies timeout diagnostics", async () => {
+    const { eventBus, options } = captureHandler()
+    const descriptor = createLegalBookingContractConfirmedSubscriber({
+      resolveDb: async () => createDbClient(UNIT_DATABASE_URL, { adapter: "node" }),
+    })
+
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+
+    expect(LEGAL_BOOKING_CONFIRMED_SUBSCRIBER_TIMEOUT_MS).toBe(45_000)
+    expect(LEGAL_BOOKING_CONFIRMED_SUBSCRIBER_TIMEOUT_MS).toBeGreaterThan(
+      LEGAL_DOCUMENT_RENDER_TIMEOUT_MS,
+    )
+    expect(options()).toEqual({
+      label: LEGAL_BOOKING_CONTRACT_CONFIRMED_SUBSCRIBER_ID,
+      timeoutMs: LEGAL_BOOKING_CONFIRMED_SUBSCRIBER_TIMEOUT_MS,
+    })
+  })
 
   it("runs generation for every delivery and relies on the command's durable replay", async () => {
     const db = createDbClient(UNIT_DATABASE_URL, { adapter: "node" })


### PR DESCRIPTION
## What changed

- gives the Legal booking.confirmed subscriber a labeled 45-second timeout budget
- centralizes the 30-second renderer limit and tests that the subscriber budget is strictly larger
- includes stable subscriber labels in EventBus timeout diagnostics

## Why

The EventBus defaulted handlers to 15 seconds while Legal document rendering alone permits 30 seconds. A successful render could therefore be detached and the durable event retried, leaving complete artifacts alongside misleading timeout attempts.

## Validation

- TDD RED before the timeout module and registration existed
- Legal subscriber tests: 4 passed
- Core EventBus tests: 32 passed
- Legal package typecheck: passed
- focused Biome: passed
- git diff --check: passed

Core package typecheck remains blocked by five unrelated stale graph-contracts export errors in the reused workspace dependency artifacts; none points to a changed file.