### PR TITLE
Replace guessed document slugs with the key the coverage checker actually wants

### DIFF
--- a/scripts/check-deployment-graph-openapi-coverage.mjs
+++ b/scripts/check-deployment-graph-openapi-coverage.mjs
@@ -15,6 +15,7 @@ import path from "node:path"
 import {
   buildDeploymentGraphOpenApiCoverageReport,
   formatDeploymentGraphOpenApiCoverageFailure,
+  formatDeploymentGraphOpenApiCoverageGap,
 } from "./lib/deployment-graph-openapi-coverage-report.mjs"
 
 const DEFAULT_GRAPH = "apps/operator/.voyant/deployment-graph.generated.json"
@@ -22,8 +23,9 @@ const DEFAULT_OPENAPI_DIR = "packages"
 const CHECKED_SURFACES = new Set(["admin", "public-api"])
 // Ratchet only. The document names and owners remain authoritative in package
 // manifests; this prevents migrated bundles from silently falling back to the
-// Operator compatibility partition.
-const MIN_PACKAGE_OWNED_API_BUNDLES = 72
+// Operator compatibility partition. The value is data so that a second checker
+// can hold it without matching this file's source text — see the rule file.
+const RATCHET_FILE = "scripts/checks/openapi/graph-coverage-ratchet.json"
 const HTTP_METHODS = new Set([
   "connect",
   "delete",
@@ -48,11 +50,23 @@ for (const [id, reason] of readAllowlistFiles(options.allowlistFiles)) {
 const graphPath = path.resolve(repoRoot, options.graph)
 const openapiDir = path.resolve(repoRoot, options.openapiDir)
 
+/** A stale resolved graph, reported as an instruction rather than a stack trace. */
+class StaleGraphError extends Error {}
+
 const graph = readJson(graphPath)
-const openapiRoots = [
-  ...discoverOpenApiRoots(openapiDir),
-  ...discoverInstalledPackageOpenApiRoots(graph, graphPath),
-]
+let openapiRoots
+try {
+  openapiRoots = [
+    ...discoverOpenApiRoots(openapiDir),
+    ...discoverInstalledPackageOpenApiRoots(graph, graphPath),
+  ]
+} catch (error) {
+  if (!(error instanceof StaleGraphError)) throw error
+  console.error(
+    `check-deployment-graph-openapi-coverage: stale deployment graph.\n\n${error.message}`,
+  )
+  process.exit(1)
+}
 const docs = readOpenApiCoverage(uniqueDirectories(openapiRoots))
 const bundles = readApiBundles(graph)
 const bundlesById = new Map(bundles.map((bundle) => [bundle.apiId, bundle]))
@@ -66,13 +80,10 @@ const coveredBundles = []
 const allowlistedGaps = []
 
 if (options.useDefaultAllowlist) {
+  const minimum = readJson(path.resolve(repoRoot, RATCHET_FILE)).minimum
   const packageOwnedBundles = bundles.filter((bundle) => bundle.openapiDocument).length
-  if (packageOwnedBundles < MIN_PACKAGE_OWNED_API_BUNDLES) {
-    failures.push({
-      kind: "authority-regression",
-      actual: packageOwnedBundles,
-      minimum: MIN_PACKAGE_OWNED_API_BUNDLES,
-    })
+  if (packageOwnedBundles < minimum) {
+    failures.push({ kind: "authority-regression", actual: packageOwnedBundles, minimum })
   }
 }
 
@@ -97,7 +108,7 @@ for (const bundle of bundles) {
   if (reason) {
     allowlistedGaps.push({ bundle, reason })
   } else {
-    failures.push({ kind: "missing-docs", bundle })
+    failures.push({ kind: "missing-docs", bundle, nearby: nearbyDocuments(bundle, docs) })
   }
 }
 
@@ -156,7 +167,14 @@ if (options.json) {
 
 if (allowlistedGaps.length > 0) {
   console.warn("Deployment graph OpenAPI coverage warnings.")
-  for (const gap of allowlistedGaps) console.warn(formatGap(gap.bundle, gap.reason))
+  for (const gap of allowlistedGaps) {
+    console.warn(
+      formatDeploymentGraphOpenApiCoverageGap(gap.bundle, {
+        reason: gap.reason,
+        nearby: nearbyDocuments(gap.bundle, docs),
+      }),
+    )
+  }
 }
 
 if (failures.length > 0) {
@@ -197,7 +215,6 @@ function readApiBundles(resolvedGraph) {
         mount: stringOrEmpty(api.mount),
         openapiDocument:
           api.openapi && typeof api.openapi === "object" ? stringOrEmpty(api.openapi.document) : "",
-        candidateModules: candidateModules(unit, api),
       })
     }
   }
@@ -317,8 +334,18 @@ function discoverInstalledPackageOpenApiRoots(resolvedGraph, resolvedGraphPath) 
       )
     }
     if (record.version && packageJson.version !== record.version) {
-      throw new Error(
-        `${packageName} package record selects ${record.version}, but ${relativeToRepo(packageRoot)} contains ${stringOrEmpty(packageJson.version) || "an unknown version"}`,
+      // The graph is untracked build output, so it goes stale on any version
+      // bump — a release, a rebase, a branch switch. That is the common cause
+      // by a wide margin and the mismatch alone does not say so, which left the
+      // reader debugging an install that was fine.
+      throw new StaleGraphError(
+        `${packageName} package record selects ${record.version}, but ` +
+          `${relativeToRepo(packageRoot)} contains ${stringOrEmpty(packageJson.version) || "an unknown version"}.\n\n` +
+          `${relativeToRepo(resolvedGraphPath)} is generated, untracked, and older than the ` +
+          `installed packages. Regenerate it:\n\n` +
+          "  pnpm --filter operator prepare:verify\n\n" +
+          "If it persists after regenerating, the install is genuinely out of step: " +
+          "pnpm install --frozen-lockfile",
       )
     }
 
@@ -374,46 +401,25 @@ function documentedOperations(doc) {
   return operations
 }
 
-function candidateModules(unit, api) {
-  const candidates = new Set()
-  const unitId = stringOrEmpty(unit.id)
-  const localId = stringOrEmpty(unit.localId)
-  const packageName = stringOrEmpty(unit.packageName)
-  const mount = stringOrEmpty(api.mount)
-  const apiId = stringOrEmpty(api.id)
-
-  addSlugCandidates(candidates, localId)
-  addSlugCandidates(candidates, stripOperatorPrefix(localId))
-  addSlugCandidates(candidates, localId.split(".").at(-1))
-  addSlugCandidates(candidates, mount)
-  addSlugCandidates(candidates, unitId)
-
-  const packageSlug = packageName.replace(/^@voyant-travel\//, "")
-  const fragment = graphFragment(unitId)
-  const apiFragment = graphFragment(apiId)
-    .replace(/^api\.?/, "")
-    .replace(/\.?api(\.(admin|public|public-api))?$/, "")
-  addSlugCandidates(candidates, packageSlug)
-  addSlugCandidates(candidates, fragment)
-  addSlugCandidates(candidates, apiFragment)
-  if (packageSlug && fragment && fragment !== packageSlug) {
-    addSlugCandidates(candidates, `${packageSlug}-${fragment}`)
-    addSlugCandidates(candidates, `${singularFirstSegment(packageSlug)}-${fragment}`)
-  }
-  if (packageSlug && apiFragment && apiFragment !== packageSlug) {
-    addSlugCandidates(candidates, `${packageSlug}-${apiFragment}`)
-    addSlugCandidates(candidates, `${singularFirstSegment(packageSlug)}-${apiFragment}`)
-  }
-
-  return [...candidates].filter(Boolean)
-}
-
-function addSlugCandidates(candidates, value) {
-  const slug = slugify(value)
-  if (!slug) return
-  candidates.add(slug)
-  candidates.add(stripOperatorPrefix(slug))
-  candidates.add(singularFirstSegment(slug))
+/**
+ * What to suggest when a bundle's document is missing.
+ *
+ * A bundle names exactly one document and the lookup is an exact key, so the
+ * only useful thing to say is which key was wanted and what is nearby. This
+ * replaces ~80 lines that derived a dozen candidate slugs from the package
+ * name, mount, local id and graph fragment; every use of that list was a string
+ * in an error message, and it made a failed exact-key lookup read as a naming
+ * search — sending the reader after a document that was never being looked for.
+ *
+ * The two mistakes that actually happen are a document filed under the wrong
+ * surface, and a document that does not exist yet.
+ */
+function nearbyDocuments(bundle, docs) {
+  const wanted = stringOrEmpty(bundle.openapiDocument)
+  if (!wanted) return []
+  return [...docs.documents.keys()]
+    .filter((key) => key.slice(key.indexOf(":") + 1) === wanted)
+    .sort()
 }
 
 function normalizeSurface(surface) {
@@ -425,42 +431,6 @@ function normalizeSurface(surface) {
 
 function coverageKey(surface, module) {
   return `${surface}:${module}`
-}
-
-function graphFragment(id) {
-  const value = String(id ?? "")
-  const index = value.indexOf("#")
-  return index === -1 ? "" : value.slice(index + 1)
-}
-
-function slugify(value) {
-  return String(value ?? "")
-    .trim()
-    .replace(/^@voyant-travel\//, "")
-    .replace(/^operator[/.]/, "")
-    .replace(/[/#.]/g, "-")
-    .replace(/-api(?:-(?:admin|public|public-api))?$/, "")
-    .replace(/^api-?/, "")
-    .replace(/-(admin|public|public-api)$/, "")
-    .replace(/--+/g, "-")
-    .replace(/^-|-$/g, "")
-}
-
-function stripOperatorPrefix(value) {
-  return String(value ?? "").replace(/^operator[-./]/, "")
-}
-
-function singularFirstSegment(value) {
-  const parts = String(value ?? "").split("-")
-  if (parts.length <= 1) return value
-  if (parts[0].endsWith("s")) parts[0] = parts[0].slice(0, -1)
-  return parts.join("-")
-}
-
-function formatGap(bundle, allowlistReason) {
-  const code = allowlistReason ? "allowlisted-gap" : "missing-docs"
-  const suffix = allowlistReason ? ` Allowlist reason: ${allowlistReason}.` : ""
-  return `  - [deployment-graph-openapi-coverage:${code}] ${bundle.apiId} (${bundle.graphSurface} -> ${bundle.surface}, ${bundle.localId || bundle.moduleId}) has no documented OpenAPI paths for candidates: ${bundle.candidateModules.join(", ")}.${suffix}`
 }
 
 function readAllowlistFiles(files) {

--- a/scripts/check-retail-openapi-authority.mjs
+++ b/scripts/check-retail-openapi-authority.mjs
@@ -91,7 +91,19 @@ for (const [file, [apiId, expectedCount]] of exactOperationOwners) {
   )
 }
 
-const coverageChecker = readFileSync("scripts/check-deployment-graph-openapi-coverage.mjs", "utf8")
-assert.match(coverageChecker, /MIN_PACKAGE_OWNED_API_BUNDLES = 72/)
+// The package-owned bundle ratchet, held from a second file so lowering it
+// takes two edits and cannot ride along in a diff about something else.
+//
+// This read the checker's source text and matched the literal `= 72`, which
+// went red when the value ROSE — the one direction that is always safe — and
+// stayed green if the assignment were reformatted or the guard deleted. It
+// measured the spelling, not the rule.
+const ratchet = JSON.parse(
+  readFileSync("scripts/checks/openapi/graph-coverage-ratchet.json", "utf8"),
+)
+assert.ok(
+  ratchet.minimum >= ratchet.floor,
+  `graph-coverage-ratchet.json lowers the package-owned bundle minimum to ${ratchet.minimum}, below the floor of ${ratchet.floor}`,
+)
 
 console.log(`check-retail-openapi-authority: OK (${claims.size} package-owned API bundles)`)

--- a/scripts/checks/openapi/graph-coverage-ratchet.json
+++ b/scripts/checks/openapi/graph-coverage-ratchet.json
@@ -1,0 +1,19 @@
+{
+  "$comment": [
+    "How many API bundles the selected deployment graph must own outright, rather",
+    "than falling back to the Operator compatibility partition. A ratchet: it may",
+    "only rise, and it rises in the same commit that migrates a bundle.",
+    "",
+    "It lived as a constant inside check-deployment-graph-openapi-coverage.mjs, and",
+    "check-retail-openapi-authority.mjs pinned it by matching the assignment's",
+    "source text. That broke on the value changing rather than on the rule being",
+    "weakened, which is the failure mode AGENTS.md describes for substring",
+    "assertions. Both checkers now read this file.",
+    "",
+    "`floor` is a deliberate second copy, and the only reason it exists: lowering",
+    "the ratchet has to be two edits in two files, so it cannot ride along in a",
+    "diff about something else. Raising `minimum` alone is always fine."
+  ],
+  "minimum": 97,
+  "floor": 97
+}

--- a/scripts/lib/deployment-graph-openapi-coverage-report.mjs
+++ b/scripts/lib/deployment-graph-openapi-coverage-report.mjs
@@ -11,7 +11,6 @@ export function buildDeploymentGraphOpenApiCoverageReport(input, relativePath) {
     packageName: bundle.packageName,
     mount: bundle.mount,
     ...(bundle.openapiDocument ? { openapiDocument: bundle.openapiDocument } : {}),
-    candidateModules: [...bundle.candidateModules].sort(),
   })
   const sortedBundles = (bundles) =>
     [...bundles].sort((left, right) => left.apiId.localeCompare(right.apiId))
@@ -31,7 +30,9 @@ export function buildDeploymentGraphOpenApiCoverageReport(input, relativePath) {
           code: "VOYANT_GRAPH_OPENAPI_MISSING_DOCS",
           severity: "error",
           ...bundleSummary(failure.bundle),
-          message: `No documented OpenAPI paths match ${failure.bundle.apiId}.`,
+          expected: expectedKey(failure.bundle),
+          ...(failure.nearby?.length ? { foundOnOtherSurfaces: failure.nearby } : {}),
+          message: `No OpenAPI document ${expectedKey(failure.bundle)} for ${failure.bundle.apiId}.`,
         }
       }
       if (failure.kind === "unknown-docs") {
@@ -85,6 +86,7 @@ export function buildDeploymentGraphOpenApiCoverageReport(input, relativePath) {
           code: "VOYANT_GRAPH_OPENAPI_STALE_ALLOWLIST",
           severity: "error",
           ...bundleSummary(failure.bundle),
+          expected: expectedKey(failure.bundle),
           message: `${failure.bundle.apiId} is allowlisted but now has documented OpenAPI paths.`,
         }
       }
@@ -132,7 +134,7 @@ export function formatDeploymentGraphOpenApiCoverageFailure(failure) {
   if (failure.kind === "authority-regression") {
     return `[deployment-graph-openapi-coverage:authority-regression] selected graph owns ${failure.actual} OpenAPI route bundles; expected at least ${failure.minimum}`
   }
-  if (failure.kind === "missing-docs") return formatGap(failure.bundle)
+  if (failure.kind === "missing-docs") return formatGap(failure)
   if (failure.kind === "unknown-docs") {
     return `[deployment-graph-openapi-coverage:unknown-authority] ${failure.apiId} is documented by ${failure.files.join(", ")} but is absent from the selected graph`
   }
@@ -149,11 +151,39 @@ export function formatDeploymentGraphOpenApiCoverageFailure(failure) {
     return `[deployment-graph-openapi-coverage:duplicate-document-owner] ${failure.document} is owned by multiple packages: ${failure.owners.join(", ")}`
   }
   if (failure.bundle) {
-    return `[deployment-graph-openapi-coverage:stale-allowlist] ${failure.bundle.apiId} is allowlisted but now has documented ${failure.bundle.surface} paths for one of: ${failure.bundle.candidateModules.join(", ")}`
+    return `[deployment-graph-openapi-coverage:stale-allowlist] ${failure.bundle.apiId} is allowlisted but ${expectedKey(failure.bundle)} now exists`
   }
   return `[deployment-graph-openapi-coverage:stale-allowlist] ${failure.apiId} is allowlisted but no longer appears in the deployment graph`
 }
 
-function formatGap(bundle) {
-  return `  - [deployment-graph-openapi-coverage:missing-docs] ${bundle.apiId} (${bundle.graphSurface} -> ${bundle.surface}, ${bundle.localId || bundle.moduleId}) has no documented OpenAPI paths for candidates: ${bundle.candidateModules.join(", ")}.`
+/**
+ * The one document key a bundle asks for. The lookup is exact, so this is the
+ * whole question — anything vaguer sends the reader looking for a document that
+ * was never being searched for.
+ */
+function expectedKey(bundle) {
+  return `${bundle.surface}:${bundle.openapiDocument || "(no document declared)"}`
+}
+
+/**
+ * A missing or allowlisted document gap, in one line.
+ *
+ * Shared by the failure path and the warning path so an allowlisted gap and a
+ * hard failure describe the same thing the same way; they differed before, and
+ * only one of them named the surface.
+ */
+export function formatDeploymentGraphOpenApiCoverageGap(bundle, { reason, nearby } = {}) {
+  const code = reason ? "allowlisted-gap" : "missing-docs"
+  const where = `${bundle.graphSurface} -> ${bundle.surface}, ${bundle.localId || bundle.moduleId}`
+  const hint = nearby?.length
+    ? ` It exists on another surface: ${nearby.join(", ")}.`
+    : bundle.openapiDocument
+      ? " No document of that name exists on any surface."
+      : ""
+  const suffix = reason ? ` Allowlist reason: ${reason}.` : ""
+  return `  - [deployment-graph-openapi-coverage:${code}] ${bundle.apiId} (${where}) expects OpenAPI document ${expectedKey(bundle)}, which is not present.${hint}${suffix}`
+}
+
+function formatGap(failure) {
+  return formatDeploymentGraphOpenApiCoverageGap(failure.bundle, { nearby: failure.nearby })
 }

--- a/scripts/tests/check-deployment-graph-openapi-coverage.test.mjs
+++ b/scripts/tests/check-deployment-graph-openapi-coverage.test.mjs
@@ -254,6 +254,68 @@ describe("check-deployment-graph-openapi-coverage", () => {
     })
   })
 
+  it("names the exact document key it looked for, not a list of guessed names", async () => {
+    const root = await createFixture({
+      "graph.json": graph([
+        {
+          id: "@voyant-travel/proposals",
+          localId: "proposals",
+          packageName: "@voyant-travel/proposals",
+          api: [
+            {
+              id: "@voyant-travel/proposals#api",
+              surface: "admin",
+              mount: "@voyant-travel/proposals",
+              openapi: { document: "proposals" },
+            },
+          ],
+        },
+      ]),
+      "openapi/.keep": "",
+    })
+
+    await assert.rejects(runChecker(root), (error) => {
+      assert.match(error.stderr, /expects OpenAPI document admin:proposals, which is not present/)
+      assert.match(error.stderr, /No document of that name exists on any surface/)
+      // The lookup is an exact key. Offering candidate spellings described a
+      // search the checker never ran.
+      assert.doesNotMatch(error.stderr, /candidates:/)
+      return true
+    })
+  })
+
+  it("says where a document of that name does exist when the surface is wrong", async () => {
+    const root = await createFixture({
+      "graph.json": graph([
+        {
+          id: "@voyant-travel/proposals",
+          localId: "proposals",
+          packageName: "@voyant-travel/proposals",
+          api: [
+            {
+              id: "@voyant-travel/proposals#api.public",
+              surface: "public",
+              mount: "@voyant-travel/proposals",
+              openapi: { document: "proposals" },
+            },
+          ],
+        },
+      ]),
+      "openapi/admin/proposals.json": openapi({
+        "/v1/admin/proposals": { get: { responses: { 200: { description: "ok" } } } },
+      }),
+    })
+
+    await assert.rejects(runChecker(root), (error) => {
+      assert.match(
+        error.stderr,
+        /expects OpenAPI document public-api:proposals, which is not present/,
+      )
+      assert.match(error.stderr, /It exists on another surface: admin:proposals/)
+      return true
+    })
+  })
+
   it("reports an allowlisted missing bundle as a warning without failing", async () => {
     const root = await createFixture({
       "graph.json": graph([

--- a/scripts/tests/check-deployment-graph-openapi-external-packages.test.mjs
+++ b/scripts/tests/check-deployment-graph-openapi-external-packages.test.mjs
@@ -84,6 +84,29 @@ describe("external package deployment graph OpenAPI coverage", () => {
     assert.match(result.stdout, /1 covered graph API bundles/)
   })
 
+  it("reports a version mismatch as a stale graph, with the command that fixes it", async () => {
+    // The graph is untracked build output, so any version bump — a release, a
+    // rebase, a branch switch — leaves it selecting a version that is no longer
+    // installed. This surfaced as a raw stack trace, which reads as a broken
+    // install rather than a regenerable artifact.
+    const packageName = "@acme/plugin-payments"
+    const root = await createFixture([
+      {
+        packageName,
+        version: "1.2.4",
+        source: { kind: "registry", reference: `${packageName}@1.2.4` },
+      },
+    ])
+
+    await assert.rejects(runChecker(root), (error) => {
+      assert.match(error.stderr, /stale deployment graph/)
+      assert.match(error.stderr, /pnpm --filter operator prepare:verify/)
+      assert.match(error.stderr, /selects 1\.2\.4.*contains 1\.2\.3/s)
+      assert.doesNotMatch(error.stderr, /at discoverInstalledPackageOpenApiRoots/)
+      return true
+    })
+  })
+
   it("does not discover installed documents without a selected package record", async () => {
     const root = await createFixture([])
 


### PR DESCRIPTION
Closes #4874.

Three mechanical items from the scoping on that issue. No assertion is removed;
one is converted from source-text matching to a data read.

## 1. ~80 lines of guessed slugs, feeding only error messages

The match between a graph API bundle and its document is an exact key:

```js
docs.documents.has(coverageKey(bundle.surface, bundle.openapiDocument))
```

Around it lived `candidateModules` and five helpers — `slugify`,
`addSlugCandidates`, `singularFirstSegment`, `stripOperatorPrefix`,
`graphFragment` — deriving a dozen candidate names from the package name, mount,
local id and graph fragment. All three uses were **strings in an error message or
the JSON report**. They take part in no assertion and predate `openapi.document`
existing in the graph.

They were worse than dead. A failed exact-key lookup read as a naming search:

```
- ...proposals#api (admin -> admin, proposals) has no documented OpenAPI paths
  for candidates: proposal, proposals, proposals-api, api-proposals, …
```

sending the reader after ten documents that were never being looked for. Now:

```
- ...proposals#api (admin -> admin, proposals) expects OpenAPI document
  admin:proposals, which is not present. It exists on another surface:
  public-api:proposals.
```

Wrong surface, and does-not-exist-at-all, are the two mistakes that actually
happen, so those are the two things it says.

## 2. A ratchet 25 behind the line

`MIN_PACKAGE_OWNED_API_BUNDLES = 72`; the real count is **97**. It moves to
`scripts/checks/openapi/graph-coverage-ratchet.json` and rises to 97.

`check-retail-openapi-authority.mjs` held it by matching the checker's source
text for `MIN_PACKAGE_OWNED_API_BUNDLES = 72`. That assertion **fires when the
value rises** — the one direction that is always safe — and stays green if the
assignment is reformatted or the guard deleted outright. It measured the
spelling, not the rule. It now reads the JSON and asserts `minimum >= floor`,
with `floor` a deliberate second copy so lowering the ratchet takes two edits in
two files and cannot ride along in a diff about something else.

This is the AGENTS.md "convert the assertion you are already fighting" case: a
fact that is data now lives in a rule file.

## 3. A stale graph looked like a broken install

The resolved graph is untracked build output, so it goes stale on any version
bump — a release, a rebase, a branch switch. It failed as:

```
Error: @voyant-travel/catalog package record selects 0.262.3, but
       apps/operator/node_modules/@voyant-travel/catalog contains 0.262.4
    at discoverInstalledPackageOpenApiRoots (...)
```

I listed this as a theoretical cost when filing #4874 and then hit it while
scoping. It now names the cause and the command, with no stack trace.

## On the acceptance bar

I wrote in #4874 that if this is not a net deletion it has not worked. **It is
not**, and I would rather say so than restate the bar:

| | before | after | delta |
|---|---:|---:|---:|
| `check-deployment-graph-openapi-coverage.mjs` | 555 | 525 | **−30** |
| `deployment-graph-openapi-coverage-report.mjs` | 159 | 189 | +30 |
| `check-retail-openapi-authority.mjs` | 97 | 109 | +12 |
| `graph-coverage-ratchet.json` | — | 19 | +19 |

Item 1 on its own is a deletion of roughly 50 lines from the checker. Items 2
and 3 add capability rather than removing it, and the report library grew
because two gap formatters that had **diverged — only one named the surface** —
became one function. That is the honest split; the bar was written for item 1
and applied to all three.

## Verification

- `verify:deployment-graph` — green, `git status` identical before and after
- `verify:retail-openapi-authority`, `verify:openapi-document-closure`,
  `verify:chain-reachability` — green
- 18 + 3 tests pass across the two test files

Two new tests cover the message, one the stale-graph path. The surface-hint test
was **proved red** by stubbing `nearbyDocuments` to return `[]` — exactly one
test failed, the right one. A new test that has never failed is not evidence.
