### PR TITLE
Allow packaged acceptance browser setup to complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
     name: packaged-acceptance
     needs: build-graph
     runs-on: ubuntu-24.04
-    timeout-minutes: 12
+    timeout-minutes: 25
     env:
       HUSKY: 0
       NODE_OPTIONS: --max-old-space-size=12288


### PR DESCRIPTION
## Summary

- raise the packaged-acceptance job timeout from 12 to 25 minutes
- preserve Playwright OS dependency installation and the full packaged acceptance lane

## Why

PR #4871 passed build, typecheck, tests, architecture, package artifacts, and all database lanes, but two hosted-runner attempts were cancelled during `playwright install --with-deps chromium`. Ubuntu apt mirror access consumed the entire 12-minute job budget before acceptance began.

## Verification

- `git diff --check`
- workflow syntax checked with `actionlint` when available
- this PR CI must complete packaged acceptance before merge
