### PR TITLE
fix: restore hosted MCP OAuth interoperability

### DIFF
--- a/.changeset/restore-mcp-hosted-client-interop.md
+++ b/.changeset/restore-mcp-hosted-client-interop.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/auth": patch
+"@voyant-travel/auth-react": patch
+"@voyant-travel/operator-settings-react": patch
+---
+
+Restore ChatGPT and Claude remote MCP connector interoperability. Scope-less
+dynamic registrations now match authorization-server discovery, resource
+metadata advertises only resource-enforced scopes, and admin-shell OAuth calls
+are scoped into the admin realm exactly once.

--- a/packages/auth-react/src/components/mcp-consent-page.tsx
+++ b/packages/auth-react/src/components/mcp-consent-page.tsx
@@ -25,6 +25,11 @@ import {
 import { Check, Eye, Pencil, ShieldCheck } from "lucide-react"
 import { type ReactNode, useState } from "react"
 import { type McpConsentMessages, useMcpConsentMessages } from "../i18n/mcp-consent.js"
+import {
+  McpConsentError,
+  type McpConsentFetcher,
+  submitMcpConsentDecision,
+} from "../mcp-consent-client.js"
 
 export interface McpConsentPageProps {
   /** Display name of the connecting client, from dynamic registration. */
@@ -40,7 +45,7 @@ export interface McpConsentPageProps {
   oauthQuery: string
   /** Absolute base URL of the API (e.g. `/api`). */
   baseUrl: string
-  fetcher?: (input: string, init?: RequestInit) => Promise<Response>
+  fetcher: McpConsentFetcher
   messages?: McpConsentMessages
 }
 
@@ -61,13 +66,13 @@ export function McpConsentPage({
   scope,
   oauthQuery,
   baseUrl,
-  fetcher = fetch,
+  fetcher,
   messages,
 }: McpConsentPageProps) {
   const fallback = useMcpConsentMessages()
   const t = messages ?? fallback
   const [pending, setPending] = useState<"accept" | "deny" | null>(null)
-  const [failed, setFailed] = useState(false)
+  const [failure, setFailure] = useState<string | null>(null)
 
   const name = clientName?.trim() || t.unknownClient
   const grantedScopes = new Set((scope ?? "").split(/\s+/).filter(Boolean))
@@ -75,24 +80,17 @@ export function McpConsentPage({
 
   const decide = async (accept: boolean) => {
     setPending(accept ? "accept" : "deny")
-    setFailed(false)
+    setFailure(null)
     try {
-      const response = await fetcher(`${baseUrl}/auth/admin/oauth2/consent`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ accept, oauth_query: oauthQuery }),
-      })
-      if (!response.ok) throw new Error("consent failed")
-      const result = (await response.json()) as { redirectURI?: string; url?: string }
-      // Accepting returns `redirectURI`; denying returns a `url` carrying the
-      // `access_denied` error back to the client. Both hand control back.
-      const redirectURI = result.redirectURI ?? result.url
-      if (!redirectURI) throw new Error("missing redirect")
       // Hand control back to the assistant with its authorization code.
-      window.location.href = redirectURI
-    } catch {
-      setFailed(true)
+      window.location.href = await submitMcpConsentDecision({
+        baseUrl,
+        fetcher,
+        accept,
+        oauthQuery,
+      })
+    } catch (error) {
+      setFailure(error instanceof McpConsentError ? error.diagnostic : String(error))
       setPending(null)
     }
   }
@@ -124,7 +122,14 @@ export function McpConsentPage({
           />
         </ul>
 
-        {failed ? <p className="text-sm text-destructive">{t.failed}</p> : null}
+        {failure === null ? null : (
+          <div role="alert" className="flex flex-col gap-1">
+            <p className="text-sm text-destructive">{t.failed}</p>
+            <p className="font-mono text-xs text-muted-foreground">
+              {t.failedDetail.replace("{detail}", failure)}
+            </p>
+          </div>
+        )}
 
         <div className="flex flex-col gap-2">
           <Button onClick={() => void decide(true)} disabled={pending !== null}>

--- a/packages/auth-react/src/i18n/mcp-consent.ts
+++ b/packages/auth-react/src/i18n/mcp-consent.ts
@@ -13,6 +13,7 @@ export interface McpConsentMessages {
   deny: string
   approving: string
   failed: string
+  failedDetail: string
   unknownClient: string
 }
 
@@ -30,6 +31,7 @@ const en: McpConsentMessages = {
   deny: "Cancel",
   approving: "Connecting…",
   failed: "Could not complete the connection. Close this window and try again.",
+  failedDetail: "Technical detail: {detail}",
   unknownClient: "This application",
 }
 
@@ -48,6 +50,7 @@ const ro: McpConsentMessages = {
   deny: "Anuleaza",
   approving: "Se conecteaza…",
   failed: "Conectarea nu a putut fi finalizata. Inchide fereastra si incearca din nou.",
+  failedDetail: "Detaliu tehnic: {detail}",
   unknownClient: "Aceasta aplicatie",
 }
 

--- a/packages/auth-react/src/mcp-consent-client.test.ts
+++ b/packages/auth-react/src/mcp-consent-client.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest"
+import { createAuthBasePathFetcher } from "./client.js"
+import {
+  fetchMcpConsentClient,
+  McpConsentError,
+  submitMcpConsentDecision,
+} from "./mcp-consent-client.js"
+
+const BASE_URL = "/api"
+
+function adminShellFetcher(transport: (url: string, init?: RequestInit) => Promise<Response>) {
+  return createAuthBasePathFetcher(transport, {
+    baseUrl: BASE_URL,
+    authBasePath: "/auth/admin",
+    sharedPaths: ["/me", "/status", "/shell-bootstrap"],
+  })
+}
+
+describe("MCP consent requests through the admin shell fetcher", () => {
+  it("routes consent and client lookup through exactly one admin realm", async () => {
+    const transport = vi.fn(async (url: string) =>
+      url.includes("public-client")
+        ? Response.json({ client_name: "ChatGPT" })
+        : Response.json({ redirectURI: "https://chatgpt.com/cb?code=1" }),
+    )
+    const fetcher = adminShellFetcher(transport)
+
+    await fetchMcpConsentClient({ baseUrl: BASE_URL, fetcher, clientId: "client_abc" })
+    await submitMcpConsentDecision({
+      baseUrl: BASE_URL,
+      fetcher,
+      accept: true,
+      oauthQuery: "client_id=abc&sig=xyz",
+    })
+
+    const urls = transport.mock.calls.map(([url]) => url)
+    expect(urls).toEqual([
+      "/api/auth/admin/oauth2/public-client?client_id=client_abc",
+      "/api/auth/admin/oauth2/consent",
+    ])
+    for (const url of urls) {
+      expect(url.split("/").filter((segment) => segment === "admin")).toHaveLength(1)
+    }
+  })
+
+  it("preserves the signed OAuth query byte for byte", async () => {
+    const oauthQuery =
+      "client_id=abc&ba_param=client_id&ba_param=scope&scope=mcp%3Aread&sig=deadbeef"
+    const transport = vi.fn(async (_url: string, _init?: RequestInit) =>
+      Response.json({ redirectURI: "https://claude.ai/cb" }),
+    )
+
+    await submitMcpConsentDecision({
+      baseUrl: BASE_URL,
+      fetcher: adminShellFetcher(transport),
+      accept: true,
+      oauthQuery,
+    })
+
+    const body = JSON.parse(String(transport.mock.calls[0]?.[1]?.body)) as { oauth_query: string }
+    expect(body.oauth_query).toBe(oauthQuery)
+    expect(new URLSearchParams(body.oauth_query).getAll("ba_param")).toEqual(["client_id", "scope"])
+  })
+
+  it("retains response status and detail when consent fails", async () => {
+    const transport = vi.fn(async () =>
+      Response.json({ error: "invalid_signature" }, { status: 400 }),
+    )
+
+    const error = await submitMcpConsentDecision({
+      baseUrl: BASE_URL,
+      fetcher: adminShellFetcher(transport),
+      accept: true,
+      oauthQuery: "client_id=abc&sig=tampered",
+    }).catch((thrown: unknown) => thrown)
+
+    expect(error).toBeInstanceOf(McpConsentError)
+    expect((error as McpConsentError).diagnostic).toBe("400 invalid_signature")
+  })
+})

--- a/packages/auth-react/src/mcp-consent-client.ts
+++ b/packages/auth-react/src/mcp-consent-client.ts
@@ -1,0 +1,98 @@
+/**
+ * OAuth calls made by the MCP consent screen.
+ *
+ * The admin shell's fetcher maps the shared `/auth` prefix into the admin realm.
+ * Callers must not spell `/auth/admin` themselves or the request becomes
+ * `/api/auth/admin/admin/...`.
+ */
+
+export const MCP_CONSENT_PUBLIC_CLIENT_PATH = "/auth/oauth2/public-client"
+export const MCP_CONSENT_DECISION_PATH = "/auth/oauth2/consent"
+
+export type McpConsentFetcher = (input: string, init?: RequestInit) => Promise<Response>
+
+export interface McpConsentClientDetails {
+  name?: string | null
+  client_name?: string | null
+}
+
+export class McpConsentError extends Error {
+  readonly status: number
+  readonly detail: string | undefined
+
+  constructor(message: string, status: number, detail?: string) {
+    super(message)
+    this.name = "McpConsentError"
+    this.status = status
+    this.detail = detail
+  }
+
+  get diagnostic(): string {
+    return this.detail ? `${this.status} ${this.detail}` : String(this.status)
+  }
+}
+
+async function readErrorDetail(response: Response): Promise<string | undefined> {
+  let text: string
+  try {
+    text = await response.text()
+  } catch {
+    return undefined
+  }
+  if (!text) return undefined
+  try {
+    const body: unknown = JSON.parse(text)
+    if (typeof body === "object" && body !== null) {
+      const record = body as Record<string, unknown>
+      const candidate =
+        record.error_description ?? record.error ?? record.message ?? record.code ?? undefined
+      if (typeof candidate === "string" && candidate) return candidate
+    }
+  } catch {
+    // A non-JSON response is itself the best available diagnostic.
+  }
+  return text.slice(0, 200)
+}
+
+export async function fetchMcpConsentClient(input: {
+  baseUrl: string
+  fetcher: McpConsentFetcher
+  clientId: string
+}): Promise<McpConsentClientDetails | null> {
+  const query = new URLSearchParams({ client_id: input.clientId })
+  const response = await input.fetcher(
+    `${input.baseUrl}${MCP_CONSENT_PUBLIC_CLIENT_PATH}?${query.toString()}`,
+    { credentials: "include" },
+  )
+  if (!response.ok) return null
+  return (await response.json()) as McpConsentClientDetails
+}
+
+export async function submitMcpConsentDecision(input: {
+  baseUrl: string
+  fetcher: McpConsentFetcher
+  accept: boolean
+  oauthQuery: string
+}): Promise<string> {
+  const response = await input.fetcher(`${input.baseUrl}${MCP_CONSENT_DECISION_PATH}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ accept: input.accept, oauth_query: input.oauthQuery }),
+  })
+
+  if (!response.ok) {
+    throw new McpConsentError(
+      "consent request failed",
+      response.status,
+      await readErrorDetail(response),
+    )
+  }
+
+  const result = (await response.json()) as { redirectURI?: string; url?: string }
+  const redirectUri = result.redirectURI ?? result.url
+  if (!redirectUri) {
+    throw new McpConsentError("consent response carried no redirect", response.status)
+  }
+  return redirectUri
+}

--- a/packages/auth-react/src/mcp-consent-routes.tsx
+++ b/packages/auth-react/src/mcp-consent-routes.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react"
 import { z } from "zod"
 import { AuthLayout } from "./components/auth-layout.js"
 import { McpConsentPage } from "./components/mcp-consent-page.js"
+import { fetchMcpConsentClient } from "./mcp-consent-client.js"
 
 /**
  * The OAuth consent screen an MCP connector sends the operator to.
@@ -73,14 +74,7 @@ function McpConsentRoute() {
   const client = useQuery({
     queryKey: ["mcp-consent-client", client_id],
     enabled: Boolean(client_id),
-    queryFn: async () => {
-      const response = await fetcher(
-        `${baseUrl}/auth/admin/oauth2/public-client?client_id=${encodeURIComponent(client_id ?? "")}`,
-        { credentials: "include" },
-      )
-      if (!response.ok) return null
-      return (await response.json()) as { name?: string | null; client_name?: string | null }
-    },
+    queryFn: () => fetchMcpConsentClient({ baseUrl, fetcher, clientId: client_id ?? "" }),
   })
 
   return (

--- a/packages/auth/src/mcp-oauth.ts
+++ b/packages/auth/src/mcp-oauth.ts
@@ -38,6 +38,9 @@ export const MCP_OAUTH_SCOPES = [
   MCP_OAUTH_SCOPE_OFFLINE,
 ] as const
 
+/** Scopes enforced by the MCP resource server itself (RFC 9728 metadata). */
+export const MCP_RESOURCE_SCOPES = [MCP_OAUTH_SCOPE_READ, MCP_OAUTH_SCOPE_WRITE] as const
+
 /**
  * The one action name treated as non-mutating. The access catalog convention is
  * `read` / `write` / `delete`, so anything that is not exactly `read` is
@@ -124,7 +127,9 @@ export function mcpProtectedResourceMetadata(input: {
   return {
     resource: input.resource,
     authorization_servers: [input.authorizationServer],
-    scopes_supported: [...MCP_OAUTH_SCOPES],
+    // `offline_access` requests refresh tokens from the authorization server;
+    // it is not a capability enforced by this resource server.
+    scopes_supported: [...MCP_RESOURCE_SCOPES],
     bearer_methods_supported: ["header"],
     ...(input.resourceName ? { resource_name: input.resourceName } : {}),
   }
@@ -194,9 +199,11 @@ export function mcpOAuthProviderConfig(options: McpOAuthPluginOptions) {
     // of the flow. The consent screen, not registration, is the trust boundary.
     allowDynamicClientRegistration: true,
     allowUnauthenticatedClientRegistration: true,
-    // A newly registered connector starts read-only; asking for write forces it
-    // through consent for the wider grant.
-    clientRegistrationDefaultScopes: [MCP_OAUTH_SCOPE_READ],
+    // Hosted clients omit `scope` during dynamic registration, then request the
+    // scopes discovery advertises. Registering only `mcp:read` would make the
+    // server reject its own advertised scopes at authorization time.
+    // Human consent and resolveMcpGrantScopes remain the authorization bounds.
+    clientRegistrationDefaultScopes: [...MCP_OAUTH_SCOPES],
     clientRegistrationAllowedScopes: [...MCP_OAUTH_SCOPES],
     // Tokens are bearer credentials for the whole operator workspace: never
     // readable from a database dump.

--- a/packages/auth/tests/integration/mcp-oauth-flow.test.ts
+++ b/packages/auth/tests/integration/mcp-oauth-flow.test.ts
@@ -135,6 +135,42 @@ describe("MCP connector OAuth handshake", () => {
   })
 
   maybe()(
+    "accepts advertised scopes after a hosted client registers without a scope field",
+    async () => {
+      const registration = await call("/auth/admin/oauth2/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "Hosted Chat Client",
+          redirect_uris: ["https://chatgpt.com/connector/oauth/callback"],
+          token_endpoint_auth_method: "none",
+          grant_types: ["authorization_code", "refresh_token"],
+          response_types: ["code"],
+        }),
+      })
+      expect(registration.status).toBeLessThan(300)
+      const client = (await registration.json()) as { client_id: string }
+
+      const authorize = await call(
+        "/auth/admin/oauth2/authorize?" +
+          new URLSearchParams({
+            response_type: "code",
+            client_id: client.client_id,
+            redirect_uri: "https://chatgpt.com/connector/oauth/callback",
+            scope: "mcp:read mcp:write offline_access",
+            code_challenge: "a".repeat(43),
+            code_challenge_method: "S256",
+            resource: RESOURCE,
+          }).toString(),
+        { redirect: "manual" },
+      )
+
+      expect(await authorize.text()).not.toContain("invalid_scope")
+      expect(authorize.status).not.toBe(400)
+    },
+  )
+
+  maybe()(
     "completes authorize → consent → token and issues a token the resource server accepts",
     async () => {
       if (!setup) throw new Error("no setup")

--- a/packages/auth/tests/unit/mcp-oauth.test.ts
+++ b/packages/auth/tests/unit/mcp-oauth.test.ts
@@ -138,7 +138,7 @@ describe("mcpProtectedResourceMetadata", () => {
     ).toEqual({
       resource: "https://ops.example.com/api/v1/admin/mcp",
       authorization_servers: ["https://ops.example.com/api/auth/admin"],
-      scopes_supported: ["mcp:read", "mcp:write", "offline_access"],
+      scopes_supported: ["mcp:read", "mcp:write"],
       bearer_methods_supported: ["header"],
       resource_name: "Voyant",
     })
@@ -216,8 +216,12 @@ describe("mcpOAuthProviderConfig", () => {
     expect(config.allowUnauthenticatedClientRegistration).toBe(true)
   })
 
-  it("registers new connectors read-only until consent widens them", () => {
-    expect(config.clientRegistrationDefaultScopes).toEqual([MCP_OAUTH_SCOPE_READ])
+  it("defaults scope-less hosted-client registrations to all authorization scopes", () => {
+    expect(config.clientRegistrationDefaultScopes).toEqual([
+      MCP_OAUTH_SCOPE_READ,
+      "mcp:write",
+      "offline_access",
+    ])
   })
 
   it("hashes tokens and client secrets at rest", () => {

--- a/packages/operator-settings-react/package.json
+++ b/packages/operator-settings-react/package.json
@@ -41,6 +41,7 @@
     "@voyant-travel/react": "workspace:^"
   },
   "devDependencies": {
+    "@voyant-travel/auth-react": "workspace:^",
     "@tanstack/react-query": "^5.101.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/packages/operator-settings-react/src/mcp-connectors.test.ts
+++ b/packages/operator-settings-react/src/mcp-connectors.test.ts
@@ -1,3 +1,4 @@
+import { createAuthBasePathFetcher } from "@voyant-travel/auth-react/client"
 import { describe, expect, it, vi } from "vitest"
 import { listMcpConnectors, revokeMcpConnector, toMcpConnector } from "./mcp-connectors.js"
 
@@ -6,6 +7,14 @@ const consent = {
   clientId: "client_abc",
   scopes: ["mcp:read"],
   createdAt: "2026-07-29T10:00:00.000Z",
+}
+
+function adminShellFetcher(transport: (url: string, init?: RequestInit) => Promise<Response>) {
+  return createAuthBasePathFetcher(transport, {
+    baseUrl: "/api",
+    authBasePath: "/auth/admin",
+    sharedPaths: ["/me", "/status", "/shell-bootstrap"],
+  })
 }
 
 describe("toMcpConnector", () => {
@@ -36,8 +45,12 @@ describe("listMcpConnectors", () => {
         : Response.json({ name: "Claude Desktop" }),
     )
 
-    await expect(listMcpConnectors("/api", fetcher)).resolves.toEqual([
+    await expect(listMcpConnectors("/api", adminShellFetcher(fetcher))).resolves.toEqual([
       expect.objectContaining({ id: "consent_1", name: "Claude Desktop", canWrite: false }),
+    ])
+    expect(fetcher.mock.calls.map(([url]) => url)).toEqual([
+      "/api/auth/admin/oauth2/get-consents",
+      "/api/auth/admin/oauth2/get-client?client_id=client_abc",
     ])
   })
 
@@ -46,7 +59,7 @@ describe("listMcpConnectors", () => {
       url.includes("get-consents") ? Response.json([consent]) : new Response("", { status: 500 }),
     )
 
-    const connectors = await listMcpConnectors("/api", fetcher)
+    const connectors = await listMcpConnectors("/api", adminShellFetcher(fetcher))
 
     // Hiding a live grant because a name lookup failed would keep the operator
     // from revoking something that still has access.
@@ -58,7 +71,7 @@ describe("listMcpConnectors", () => {
   it("throws when the consent list itself cannot be read", async () => {
     const fetcher = vi.fn(async () => new Response("", { status: 401 }))
 
-    await expect(listMcpConnectors("/api", fetcher)).rejects.toThrow()
+    await expect(listMcpConnectors("/api", adminShellFetcher(fetcher))).rejects.toThrow()
   })
 })
 
@@ -66,7 +79,7 @@ describe("revokeMcpConnector", () => {
   it("posts the consent id to the delete endpoint", async () => {
     const fetcher = vi.fn(async () => Response.json({}))
 
-    await revokeMcpConnector("/api", fetcher, "consent_1")
+    await revokeMcpConnector("/api", adminShellFetcher(fetcher), "consent_1")
 
     expect(fetcher).toHaveBeenCalledWith(
       "/api/auth/admin/oauth2/delete-consent",
@@ -77,6 +90,8 @@ describe("revokeMcpConnector", () => {
   it("surfaces a failed revoke instead of reporting success", async () => {
     const fetcher = vi.fn(async () => new Response("", { status: 404 }))
 
-    await expect(revokeMcpConnector("/api", fetcher, "consent_1")).rejects.toThrow()
+    await expect(
+      revokeMcpConnector("/api", adminShellFetcher(fetcher), "consent_1"),
+    ).rejects.toThrow()
   })
 })

--- a/packages/operator-settings-react/src/mcp-connectors.ts
+++ b/packages/operator-settings-react/src/mcp-connectors.ts
@@ -57,7 +57,7 @@ export async function listMcpConnectors(
   baseUrl: string,
   fetcher: McpFetcher,
 ): Promise<McpConnector[]> {
-  const response = await fetcher(`${baseUrl}/auth/admin/oauth2/get-consents`, {
+  const response = await fetcher(`${baseUrl}/auth/oauth2/get-consents`, {
     credentials: "include",
   })
   if (!response.ok) throw new Error("consents")
@@ -67,7 +67,7 @@ export async function listMcpConnectors(
     consents.map(async (consent) => {
       try {
         const clientResponse = await fetcher(
-          `${baseUrl}/auth/admin/oauth2/get-client?client_id=${encodeURIComponent(consent.clientId)}`,
+          `${baseUrl}/auth/oauth2/get-client?client_id=${encodeURIComponent(consent.clientId)}`,
           { credentials: "include" },
         )
         return toMcpConnector(consent, clientResponse.ok ? await clientResponse.json() : null)
@@ -84,7 +84,7 @@ export async function revokeMcpConnector(
   fetcher: McpFetcher,
   consentId: string,
 ): Promise<void> {
-  const response = await fetcher(`${baseUrl}/auth/admin/oauth2/delete-consent`, {
+  const response = await fetcher(`${baseUrl}/auth/oauth2/delete-consent`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     credentials: "include",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4554,6 +4554,9 @@ importers:
       '@voyant-travel/admin-app':
         specifier: workspace:^
         version: link:../admin-app
+      '@voyant-travel/auth-react':
+        specifier: workspace:^
+        version: link:../auth-react
       '@voyant-travel/finance':
         specifier: workspace:^
         version: link:../finance


### PR DESCRIPTION
## What changed

- restore scope-less dynamic client registration for hosted ChatGPT and Claude connectors
- keep `offline_access` in authorization-server discovery while removing it from protected-resource capability metadata
- route consent and connector-management calls through the admin shell realm exactly once
- preserve consent failure diagnostics and add regression tests for both seams

## Root cause

The hosted-client interoperability fix from #4794 was accidentally overwritten by the following generated Admin API merge. Dynamic clients were again stored with only `mcp:read` while discovery told them to request `mcp:read mcp:write offline_access`, and consent UI calls again became `/api/auth/admin/admin/oauth2/...` under the shell fetcher.

## Validation

- `pnpm --filter @voyant-travel/auth exec vitest run tests/unit/mcp-oauth.test.ts`
- `pnpm --filter @voyant-travel/auth-react exec vitest run src/mcp-consent-client.test.ts src/mcp-consent-routes.test.tsx`
- `pnpm --filter @voyant-travel/operator-settings-react exec vitest run src/mcp-connectors.test.ts`
- auth and auth-react package typechecks passed; operator-settings-react typecheck was left to CI after a long local full-graph run
