### PR TITLE
Fix managed MCP consent realm routing

### DIFF
--- a/.changeset/fix-managed-mcp-consent-routing.md
+++ b/.changeset/fix-managed-mcp-consent-routing.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/auth-react": patch
+"@voyant-travel/operator-settings-react": patch
+---
+
+Route managed MCP consent and connector-management requests through the
+canonical admin OAuth realm while keeping realm-scoped fetchers idempotent.

--- a/packages/auth-react/src/client.test.ts
+++ b/packages/auth-react/src/client.test.ts
@@ -12,6 +12,7 @@ describe("createAuthBasePathFetcher", () => {
 
     await customerFetcher("https://storefront.example/api/auth/sign-in/email", { method: "POST" })
     await customerFetcher("https://storefront.example/api/auth/status")
+    await customerFetcher("https://storefront.example/api/auth/customer/oauth2/consent")
     await customerFetcher("https://storefront.example/api/v1/public/products")
     await customerFetcher("https://admin.example/api/auth/status")
 
@@ -27,10 +28,15 @@ describe("createAuthBasePathFetcher", () => {
     )
     expect(fetcher).toHaveBeenNthCalledWith(
       3,
+      "https://storefront.example/api/auth/customer/oauth2/consent",
+      undefined,
+    )
+    expect(fetcher).toHaveBeenNthCalledWith(
+      4,
       "https://storefront.example/api/v1/public/products",
       undefined,
     )
-    expect(fetcher).toHaveBeenNthCalledWith(4, "https://admin.example/api/auth/status", undefined)
+    expect(fetcher).toHaveBeenNthCalledWith(5, "https://admin.example/api/auth/status", undefined)
   })
 
   it("leaves shared deployment-owned auth paths on the default prefix", async () => {

--- a/packages/auth-react/src/client.ts
+++ b/packages/auth-react/src/client.ts
@@ -42,6 +42,15 @@ export function createAuthBasePathFetcher(
   const sharedPaths = (options.sharedPaths ?? []).map(normalizePath)
 
   return (url, init) => {
+    const isRealmAuthRequest =
+      url === realmAuthBaseUrl ||
+      url.startsWith(`${realmAuthBaseUrl}/`) ||
+      url.startsWith(`${realmAuthBaseUrl}?`)
+    // Realm-aware callers may already use the canonical realm URL. Keep the
+    // wrapper idempotent so composing it around those callers cannot produce
+    // paths such as `/auth/admin/admin/*`.
+    if (isRealmAuthRequest) return fetcher(url, init)
+
     const isDefaultAuthRequest =
       url === defaultAuthBaseUrl ||
       url.startsWith(`${defaultAuthBaseUrl}/`) ||

--- a/packages/auth-react/src/mcp-consent-client.test.ts
+++ b/packages/auth-react/src/mcp-consent-client.test.ts
@@ -43,6 +43,27 @@ describe("MCP consent requests through the admin shell fetcher", () => {
     }
   })
 
+  it("uses the admin realm when the managed route receives a raw fetcher", async () => {
+    const transport = vi.fn(async (url: string) =>
+      url.includes("public-client")
+        ? Response.json({ client_name: "ChatGPT" })
+        : Response.json({ redirectURI: "https://chatgpt.com/cb?code=1" }),
+    )
+
+    await fetchMcpConsentClient({ baseUrl: BASE_URL, fetcher: transport, clientId: "client_abc" })
+    await submitMcpConsentDecision({
+      baseUrl: BASE_URL,
+      fetcher: transport,
+      accept: true,
+      oauthQuery: "client_id=abc&sig=xyz",
+    })
+
+    expect(transport.mock.calls.map(([url]) => url)).toEqual([
+      "/api/auth/admin/oauth2/public-client?client_id=client_abc",
+      "/api/auth/admin/oauth2/consent",
+    ])
+  })
+
   it("preserves the signed OAuth query byte for byte", async () => {
     const oauthQuery =
       "client_id=abc&ba_param=client_id&ba_param=scope&scope=mcp%3Aread&sig=deadbeef"

--- a/packages/auth-react/src/mcp-consent-client.ts
+++ b/packages/auth-react/src/mcp-consent-client.ts
@@ -1,13 +1,14 @@
 /**
  * OAuth calls made by the MCP consent screen.
  *
- * The admin shell's fetcher maps the shared `/auth` prefix into the admin realm.
- * Callers must not spell `/auth/admin` themselves or the request becomes
- * `/api/auth/admin/admin/...`.
+ * These are canonical admin-realm endpoints because the managed consent route
+ * can be mounted above the standard admin provider and therefore receive a raw
+ * deployment fetcher. `createAuthBasePathFetcher` is idempotent for callers
+ * mounted inside the provider, so both contexts resolve to exactly one realm.
  */
 
-export const MCP_CONSENT_PUBLIC_CLIENT_PATH = "/auth/oauth2/public-client"
-export const MCP_CONSENT_DECISION_PATH = "/auth/oauth2/consent"
+export const MCP_CONSENT_PUBLIC_CLIENT_PATH = "/auth/admin/oauth2/public-client"
+export const MCP_CONSENT_DECISION_PATH = "/auth/admin/oauth2/consent"
 
 export type McpConsentFetcher = (input: string, init?: RequestInit) => Promise<Response>
 

--- a/packages/operator-settings-react/src/mcp-connectors.test.ts
+++ b/packages/operator-settings-react/src/mcp-connectors.test.ts
@@ -38,6 +38,19 @@ describe("toMcpConnector", () => {
 })
 
 describe("listMcpConnectors", () => {
+  it("uses the admin realm with a raw managed-shell fetcher", async () => {
+    const fetcher = vi.fn(async (url: string) =>
+      url.includes("get-consents") ? Response.json([consent]) : Response.json({ name: "ChatGPT" }),
+    )
+
+    await listMcpConnectors("/api", fetcher)
+
+    expect(fetcher.mock.calls.map(([url]) => url)).toEqual([
+      "/api/auth/admin/oauth2/get-consents",
+      "/api/auth/admin/oauth2/get-client?client_id=client_abc",
+    ])
+  })
+
   it("resolves each consent to its registered client name", async () => {
     const fetcher = vi.fn(async (url: string) =>
       url.includes("get-consents")

--- a/packages/operator-settings-react/src/mcp-connectors.ts
+++ b/packages/operator-settings-react/src/mcp-connectors.ts
@@ -57,7 +57,7 @@ export async function listMcpConnectors(
   baseUrl: string,
   fetcher: McpFetcher,
 ): Promise<McpConnector[]> {
-  const response = await fetcher(`${baseUrl}/auth/oauth2/get-consents`, {
+  const response = await fetcher(`${baseUrl}/auth/admin/oauth2/get-consents`, {
     credentials: "include",
   })
   if (!response.ok) throw new Error("consents")
@@ -67,7 +67,7 @@ export async function listMcpConnectors(
     consents.map(async (consent) => {
       try {
         const clientResponse = await fetcher(
-          `${baseUrl}/auth/oauth2/get-client?client_id=${encodeURIComponent(consent.clientId)}`,
+          `${baseUrl}/auth/admin/oauth2/get-client?client_id=${encodeURIComponent(consent.clientId)}`,
           { credentials: "include" },
         )
         return toMcpConnector(consent, clientResponse.ok ? await clientResponse.json() : null)
@@ -84,7 +84,7 @@ export async function revokeMcpConnector(
   fetcher: McpFetcher,
   consentId: string,
 ): Promise<void> {
-  const response = await fetcher(`${baseUrl}/auth/oauth2/delete-consent`, {
+  const response = await fetcher(`${baseUrl}/auth/admin/oauth2/delete-consent`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     credentials: "include",


### PR DESCRIPTION
## Summary
- make auth realm URL rewriting idempotent for already-scoped callers
- send managed MCP consent and connector-management requests to the canonical admin OAuth realm
- cover both raw managed-shell and wrapped standard-shell fetchers

## Verification
- `pnpm exec vitest run packages/auth-react/src/client.test.ts packages/auth-react/src/mcp-consent-client.test.ts packages/operator-settings-react/src/mcp-connectors.test.ts --maxWorkers=3` (15 passed)
- `pnpm --filter @voyant-travel/auth-react typecheck`
- live trace reproduced the failing POST at `/api/auth/oauth2/consent`; the corrected target is `/api/auth/admin/oauth2/consent`

The broad operator-settings typecheck exhausted the local Node 4 GB heap, and unrelated pre-push flight combobox tests failed; required GitHub checks remain the merge gate.