### PR TITLE
fix: resolve hosted MCP clients from JWT azp claims

### DIFF
--- a/.changeset/fresh-mice-connect.md
+++ b/.changeset/fresh-mice-connect.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/auth": patch
+---
+
+Accept the OAuth `azp` claim on signed MCP access tokens so hosted connectors resolve their approved client and receive their permitted tool catalog.

--- a/packages/auth/src/mcp-oauth.ts
+++ b/packages/auth/src/mcp-oauth.ts
@@ -106,6 +106,21 @@ export function parseOAuthScopeClaim(claim: unknown): string[] {
 }
 
 /**
+ * Read the OAuth client identifier from a verified access-token payload.
+ *
+ * JWT access tokens use the standard authorized-party (`azp`) claim. OAuth
+ * introspection responses expose the same value as `client_id`, so accept both
+ * shapes. When both are present they must agree; otherwise fail closed rather
+ * than checking consent for the wrong client.
+ */
+export function parseOAuthClientIdClaim(claims: Record<string, unknown>): string {
+  const clientId = typeof claims.client_id === "string" ? claims.client_id.trim() : ""
+  const authorizedParty = typeof claims.azp === "string" ? claims.azp.trim() : ""
+  if (clientId && authorizedParty && clientId !== authorizedParty) return ""
+  return clientId || authorizedParty
+}
+
+/**
  * RFC 9728 protected-resource metadata for the MCP endpoint.
  *
  * The authorization server publishes its own metadata, but the *resource*

--- a/packages/auth/src/node-runtime.ts
+++ b/packages/auth/src/node-runtime.ts
@@ -76,6 +76,7 @@ import {
 import {
   mcpOAuthProviderConfig,
   mcpProtectedResourceMetadata,
+  parseOAuthClientIdClaim,
   parseOAuthScopeClaim,
   resolveMcpGrantScopes,
   withPublicApiEndpoints,
@@ -1111,7 +1112,7 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
 
     const userId = typeof claims.sub === "string" ? claims.sub.trim() : ""
     if (!userId) return null
-    const clientId = typeof claims.client_id === "string" ? claims.client_id.trim() : ""
+    const clientId = parseOAuthClientIdClaim(claims)
     if (!clientId) return null
 
     // A signed JWT stays valid until it expires, so the signature alone cannot

--- a/packages/auth/tests/integration/mcp-oauth-flow.test.ts
+++ b/packages/auth/tests/integration/mcp-oauth-flow.test.ts
@@ -17,7 +17,11 @@ import { drizzle } from "drizzle-orm/postgres-js"
 import { decodeJwt } from "jose"
 import postgres from "postgres"
 import { afterAll, describe, expect, it } from "vitest"
-import { parseOAuthScopeClaim, withPublicApiEndpoints } from "../../src/mcp-oauth.js"
+import {
+  parseOAuthClientIdClaim,
+  parseOAuthScopeClaim,
+  withPublicApiEndpoints,
+} from "../../src/mcp-oauth.js"
 import { createBetterAuth } from "../../src/server.js"
 
 const CONNECTION = process.env.MCP_OAUTH_TEST_DATABASE_URL ?? ""
@@ -272,6 +276,8 @@ describe("MCP connector OAuth handshake", () => {
       expect(claims.iss).toBe(`${BASE_URL}/auth/admin`)
       expect([claims.aud].flat()).toContain(RESOURCE)
       expect(claims.sub).toEqual(expect.any(String))
+      expect(claims.azp).toBe(client_id)
+      expect(parseOAuthClientIdClaim(claims)).toBe(client_id)
       expect(parseOAuthScopeClaim(claims.scope)).toEqual(
         expect.arrayContaining(["mcp:read", "mcp:write"]),
       )

--- a/packages/auth/tests/unit/mcp-oauth.test.ts
+++ b/packages/auth/tests/unit/mcp-oauth.test.ts
@@ -5,6 +5,7 @@ import {
   MCP_OAUTH_SCOPE_WRITE,
   mcpOAuthProviderConfig,
   mcpProtectedResourceMetadata,
+  parseOAuthClientIdClaim,
   parseOAuthScopeClaim,
   resolveMcpGrantScopes,
   withPublicApiEndpoints,
@@ -124,6 +125,22 @@ describe("parseOAuthScopeClaim", () => {
     expect(parseOAuthScopeClaim(undefined)).toEqual([])
     expect(parseOAuthScopeClaim(42)).toEqual([])
     expect(parseOAuthScopeClaim([1, "mcp:read"])).toEqual(["mcp:read"])
+  })
+})
+
+describe("parseOAuthClientIdClaim", () => {
+  it("reads the azp claim carried by signed JWT access tokens", () => {
+    expect(parseOAuthClientIdClaim({ azp: "hosted-client" })).toBe("hosted-client")
+  })
+
+  it("keeps compatibility with introspection's client_id shape", () => {
+    expect(parseOAuthClientIdClaim({ client_id: "introspected-client" })).toBe(
+      "introspected-client",
+    )
+  })
+
+  it("fails closed when two client identifiers disagree", () => {
+    expect(parseOAuthClientIdClaim({ azp: "signed-client", client_id: "other-client" })).toBe("")
   })
 })
 


### PR DESCRIPTION
## Summary
- resolve MCP OAuth client identity from the signed JWT `azp` claim used by `@better-auth/oauth-provider`
- preserve compatibility with introspection-style `client_id` claims and fail closed if both disagree
- cover the real provider-issued token shape in unit and integration tests

## Root cause
Better Auth signs JWT access tokens with `azp`. Voyant only read `client_id`, which Better Auth adds only to introspection responses. Because Voyant verifies JWTs directly, every valid ChatGPT/Claude token failed client-consent lookup, producing an empty/unavailable MCP tool catalog after successful OAuth.

## Verification
- `pnpm exec vitest run packages/auth/tests/unit/mcp-oauth.test.ts packages/auth/tests/integration/mcp-oauth-flow.test.ts --maxWorkers=4` (22 passed; DB-backed integration cases skipped locally without `MCP_OAUTH_TEST_DATABASE_URL`)
- `pnpm --filter @voyant-travel/auth typecheck`
- `git diff --check`
- live canary reproduction: fresh ChatGPT DCR + consent succeeds, connector receives no tools before this fix because the JWT client cannot be resolved