### PR TITLE
Bound release verification before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,13 @@ jobs:
 
       - name: Verify before publish
         if: steps.release_plan.outputs.publish_pending == 'true'
-        run: pnpm verify:fast
+        # Source changes already passed the full affected typecheck/test graph
+        # before reaching main, and the pending packages were rebuilt above.
+        # Re-running affected tests from a version-only Changesets commit fans
+        # out across most of the workspace and exceeds the hosted job ceiling.
+        # Keep the release-specific architecture and changed-file gates here;
+        # immutable tarball verification remains the next step.
+        run: pnpm verify:release-ready
 
       - name: Verify publish tarballs
         if: steps.release_plan.outputs.publish_pending == 'true'

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "verify:tool-schema-portability": "node --test scripts/tests/check-tool-schema-portability.test.mjs && tsx scripts/check-tool-schema-portability.ts",
     "verify:first-party-tool-output-schemas": "node --test scripts/tests/check-first-party-tool-output-schemas.test.mjs && node scripts/check-first-party-tool-output-schemas.mjs",
     "verify:fast": "pnpm lint:changed && pnpm verify:agent-quality:changed && pnpm verify:operator-product-ui-authority && pnpm verify:date-picker-single-source && pnpm verify:ui-components-barrel && pnpm verify:ui-orientation-selectors && pnpm verify:native-date-inputs && pnpm verify:raw-minor-unit-labels && pnpm typecheck:affected && pnpm test:affected && pnpm verify:architecture",
+    "verify:release-ready": "pnpm lint:changed && pnpm verify:agent-quality:changed && pnpm verify:architecture",
     "verify:full": "pnpm lint && pnpm verify:agent-quality && pnpm verify:operator-product-ui-authority && pnpm verify:date-picker-single-source && pnpm verify:ui-components-barrel && pnpm verify:ui-orientation-selectors && pnpm verify:native-date-inputs && pnpm verify:raw-minor-unit-labels && pnpm typecheck && pnpm test && pnpm verify:architecture && pnpm verify:release-config && pnpm build && pnpm verify:package-exports && pnpm verify:publish-tarballs && pnpm i18n:check",
     "prepare": "husky",
     "regen:routes": "tsx scripts/regen-route-tree.ts",

--- a/scripts/tests/release-plan.test.mjs
+++ b/scripts/tests/release-plan.test.mjs
@@ -1,10 +1,45 @@
 import assert from "node:assert/strict"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { createRequire } from "node:module"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import test from "node:test"
 
 const require = createRequire(import.meta.url)
 const { getReleaseMode } = require("../release-plan.cjs")
-const { collectWorkspaceRangeProblems } = require("../verify-release-config.cjs")
+const {
+  collectReleaseWorkflowProblems,
+  collectWorkspaceRangeProblems,
+} = require("../verify-release-config.cjs")
+
+test("release verification uses the bounded release-specific gate", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "voyant-release-workflow-"))
+  try {
+    const workflowDirectory = join(cwd, ".github/workflows")
+    mkdirSync(workflowDirectory, { recursive: true })
+    writeFileSync(
+      join(workflowDirectory, "release.yml"),
+      `jobs:
+  release:
+    steps:
+      - name: Build pending publish workspaces
+      - name: Verify before publish
+        run: pnpm verify:fast
+      - name: Verify publish tarballs
+      - name: Publish pending packages
+        env:
+          npm_config_ignore_scripts: "true"
+`,
+    )
+
+    assert.match(
+      collectReleaseWorkflowProblems(cwd).join("\n"),
+      /must run pnpm verify:release-ready/,
+    )
+  } finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
 
 test("release PR creation takes priority over pending publication", () => {
   assert.equal(getReleaseMode(true, true), "version")

--- a/scripts/verify-release-config.cjs
+++ b/scripts/verify-release-config.cjs
@@ -10,8 +10,10 @@ const { getPublishablePackages } = require("./release-utils.cjs")
 
 const RELEASE_WORKFLOW_PATH = ".github/workflows/release.yml"
 const BUILD_STEP = "Build pending publish workspaces"
+const VERIFY_STEP = "Verify before publish"
 const TARBALL_STEP = "Verify publish tarballs"
 const PUBLISH_STEP = "Publish pending packages"
+const RELEASE_VERIFY_COMMAND = "pnpm verify:release-ready"
 
 // Publish must consume the Turbo-built, tarball-verified `dist` immutably.
 // Several packages `clean` their dist in prepack, so a concurrent publish
@@ -38,15 +40,24 @@ function collectReleaseWorkflowProblems(cwd) {
 
   const indexOfStep = (name) => steps.findIndex((step) => step?.name === name)
   const buildIdx = indexOfStep(BUILD_STEP)
+  const verifyIdx = indexOfStep(VERIFY_STEP)
   const tarballIdx = indexOfStep(TARBALL_STEP)
   const publishIdx = indexOfStep(PUBLISH_STEP)
 
   for (const [label, idx] of [
     [BUILD_STEP, buildIdx],
+    [VERIFY_STEP, verifyIdx],
     [TARBALL_STEP, tarballIdx],
     [PUBLISH_STEP, publishIdx],
   ]) {
     if (idx === -1) problems.push(`${RELEASE_WORKFLOW_PATH}: missing "${label}" step`)
+  }
+
+  if (verifyIdx !== -1 && steps[verifyIdx]?.run !== RELEASE_VERIFY_COMMAND) {
+    problems.push(
+      `${RELEASE_WORKFLOW_PATH}: "${VERIFY_STEP}" must run ${RELEASE_VERIFY_COMMAND} ` +
+        "so version-only release commits do not repeat the unbounded affected test graph",
+    )
   }
 
   if (publishIdx !== -1) {


### PR DESCRIPTION
## Root cause
The stable release job for `3924f83` was terminated at the hosted job ceiling after `verify:fast` spent 50 minutes repeating the affected typecheck/test graph from a version-only Changesets commit. No package was published and the failing step had no test failure or conclusion.

## Fix
- add a release-specific gate that retains changed-file lint/agent checks plus the full architecture authority suite
- rely on the existing pending-package build and immutable tarball verification for package compilation/artifacts
- make release configuration verification reject a regression back to the unbounded `verify:fast` command

## Verification
- `node --test scripts/tests/release-plan.test.mjs` (13 tests)
- `pnpm verify:release-config`
- `pnpm verify:release-ready` (full gate passed locally)
- Biome on changed JS/JSON
- `git diff --check`

After merge, the normal main release workflow will retry the still-pending versions through npm trusted publishing.