### PR TITLE
fix(auth): bind hosted MCP token grants to resource

### DIFF
--- a/.changeset/calm-connectors-bind.md
+++ b/.changeset/calm-connectors-bind.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/auth": patch
+---
+
+Bind MCP OAuth tokens to the deployment's sole protected resource when hosted ChatGPT and Claude clients omit the optional RFC 8707 resource parameter.

--- a/packages/auth/src/mcp-oauth.ts
+++ b/packages/auth/src/mcp-oauth.ts
@@ -41,6 +41,50 @@ export const MCP_OAUTH_SCOPES = [
 /** Scopes enforced by the MCP resource server itself (RFC 9728 metadata). */
 export const MCP_RESOURCE_SCOPES = [MCP_OAUTH_SCOPE_READ, MCP_OAUTH_SCOPE_WRITE] as const
 
+const MCP_OAUTH_TOKEN_PATH_SUFFIX = "/auth/admin/oauth2/token"
+const MCP_OAUTH_RESOURCE_DEFAULT_GRANTS = new Set(["authorization_code", "refresh_token"])
+
+/**
+ * Bind tokens to this deployment's sole MCP resource when a hosted client omits
+ * RFC 8707's optional `resource` token parameter.
+ *
+ * Better Auth deliberately issues an opaque access token when `resource` is
+ * absent. Voyant's resource server verifies signed JWTs against its JWKS, and
+ * both ChatGPT and Claude currently omit the parameter even after discovering
+ * a single protected resource. Because this authorization server has exactly
+ * one valid audience, defaulting an omitted value is unambiguous. An explicit
+ * value is left untouched for Better Auth to validate and reject when invalid.
+ */
+export async function withDefaultMcpOAuthResource(
+  request: Request,
+  resource: string,
+): Promise<Request> {
+  const url = new URL(request.url)
+  if (
+    request.method !== "POST" ||
+    !url.pathname.endsWith(MCP_OAUTH_TOKEN_PATH_SUFFIX) ||
+    !request.headers
+      .get("content-type")
+      ?.toLowerCase()
+      .startsWith("application/x-www-form-urlencoded")
+  ) {
+    return request
+  }
+
+  const body = new URLSearchParams(await request.clone().text())
+  if (
+    body.has("resource") ||
+    !MCP_OAUTH_RESOURCE_DEFAULT_GRANTS.has(body.get("grant_type") ?? "")
+  ) {
+    return request
+  }
+
+  body.set("resource", resource)
+  const headers = new Headers(request.headers)
+  headers.delete("content-length")
+  return new Request(request, { body: body.toString(), headers })
+}
+
 /**
  * The one action name treated as non-mutating. The access catalog convention is
  * `read` / `write` / `delete`, so anything that is not exactly `read` is

--- a/packages/auth/src/node-runtime.ts
+++ b/packages/auth/src/node-runtime.ts
@@ -79,6 +79,7 @@ import {
   parseOAuthClientIdClaim,
   parseOAuthScopeClaim,
   resolveMcpGrantScopes,
+  withDefaultMcpOAuthResource,
   withPublicApiEndpoints,
 } from "./mcp-oauth.js"
 import { PublicApiCustomerAuthResolutionError } from "./public-api-customer-auth-resolver.js"
@@ -2126,7 +2127,11 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
     const { db, dispose } = openDatabase(c.env)
     try {
       const betterAuth = buildAdminBetterAuth(c.env, db)
-      return await betterAuth.handler(c.req.raw)
+      const request = await withDefaultMcpOAuthResource(
+        c.req.raw,
+        `${getPublicApiBaseUrl(c.env)}/v1/admin/mcp`,
+      )
+      return await betterAuth.handler(request)
     } finally {
       c.executionCtx.waitUntil(dispose())
     }

--- a/packages/auth/tests/integration/mcp-oauth-flow.test.ts
+++ b/packages/auth/tests/integration/mcp-oauth-flow.test.ts
@@ -20,6 +20,7 @@ import { afterAll, describe, expect, it } from "vitest"
 import {
   parseOAuthClientIdClaim,
   parseOAuthScopeClaim,
+  withDefaultMcpOAuthResource,
   withPublicApiEndpoints,
 } from "../../src/mcp-oauth.js"
 import { createBetterAuth } from "../../src/server.js"
@@ -66,7 +67,11 @@ const maybe = () => (setup ? it : it.skip)
 
 async function call(path: string, init?: RequestInit): Promise<Response> {
   if (!setup) throw new Error("auth not initialized")
-  return setup.auth.handler(new Request(`${BASE_URL}${path}`, init))
+  const request = await withDefaultMcpOAuthResource(
+    new Request(`${BASE_URL}${path}`, init),
+    RESOURCE,
+  )
+  return setup.auth.handler(request)
 }
 
 describe("MCP connector OAuth handshake", () => {
@@ -213,20 +218,20 @@ describe("MCP connector OAuth handshake", () => {
           token_endpoint_auth_method: "none",
           grant_types: ["authorization_code", "refresh_token"],
           response_types: ["code"],
-          scope: "mcp:read mcp:write",
+          scope: "mcp:read mcp:write offline_access",
         }),
       })
       const { client_id } = (await registration.json()) as { client_id: string }
 
-      // 3. Authorization request with PKCE, bound to the MCP resource.
+      // 3. Authorization request with PKCE. Hosted clients discover the sole
+      //    resource but currently omit RFC 8707's optional `resource` field.
       const verifier = "a".repeat(64)
       const challenge = createHash("sha256").update(verifier).digest("base64url")
       const authorizeUrl =
         `/auth/admin/oauth2/authorize?response_type=code&client_id=${client_id}` +
         `&redirect_uri=${encodeURIComponent("https://claude.ai/api/mcp/auth_callback")}` +
-        `&scope=${encodeURIComponent("mcp:read mcp:write")}` +
-        `&code_challenge=${challenge}&code_challenge_method=S256` +
-        `&resource=${encodeURIComponent(RESOURCE)}&state=xyz`
+        `&scope=${encodeURIComponent("mcp:read mcp:write offline_access")}` +
+        `&code_challenge=${challenge}&code_challenge_method=S256&state=xyz`
       const authorize = await call(authorizeUrl, { headers: { cookie }, redirect: "manual" })
 
       // The operator is sent to the consent screen with a consent code.
@@ -263,12 +268,16 @@ describe("MCP connector OAuth handshake", () => {
           redirect_uri: "https://claude.ai/api/mcp/auth_callback",
           client_id,
           code_verifier: verifier,
-          resource: RESOURCE,
         }).toString(),
       })
       expect(token.status).toBeLessThan(300)
-      const grant = (await token.json()) as { access_token: string; scope?: string }
+      const grant = (await token.json()) as {
+        access_token: string
+        refresh_token: string
+        scope?: string
+      }
       expect(grant.access_token).toEqual(expect.any(String))
+      expect(grant.refresh_token).toEqual(expect.any(String))
 
       // 6. The claims the resource server actually checks. This is the pairing
       //    that was never proven together: issuer AND audience on a real token.
@@ -282,7 +291,22 @@ describe("MCP connector OAuth handshake", () => {
         expect.arrayContaining(["mcp:read", "mcp:write"]),
       )
 
-      // 7. Revoking consent is what makes "Disconnect" immediate.
+      // 7. Hosted clients also omit `resource` when refreshing. The default
+      //    must keep refreshed access tokens JWT-bound to the same audience.
+      const refreshed = await call("/auth/admin/oauth2/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: grant.refresh_token,
+          client_id,
+        }).toString(),
+      })
+      expect(refreshed.status).toBeLessThan(300)
+      const refreshedGrant = (await refreshed.json()) as { access_token: string }
+      expect([decodeJwt(refreshedGrant.access_token).aud].flat()).toContain(RESOURCE)
+
+      // 8. Revoking consent is what makes "Disconnect" immediate.
       const consents = await setup.sql`select id from oauth_consent where client_id = ${client_id}`
       expect(consents.length).toBeGreaterThan(0)
     },

--- a/packages/auth/tests/unit/mcp-oauth.test.ts
+++ b/packages/auth/tests/unit/mcp-oauth.test.ts
@@ -8,6 +8,7 @@ import {
   parseOAuthClientIdClaim,
   parseOAuthScopeClaim,
   resolveMcpGrantScopes,
+  withDefaultMcpOAuthResource,
   withPublicApiEndpoints,
 } from "../../src/mcp-oauth.js"
 
@@ -248,5 +249,41 @@ describe("mcpOAuthProviderConfig", () => {
 
   it("binds tokens to the MCP resource as the audience", () => {
     expect(config.validAudiences).toEqual(["https://ops.example.com/api/v1/admin/mcp"])
+  })
+})
+
+describe("withDefaultMcpOAuthResource", () => {
+  const resource = "https://ops.example.com/api/v1/admin/mcp"
+  const tokenRequest = (body: URLSearchParams, contentType = "application/x-www-form-urlencoded") =>
+    new Request("https://ops.example.com/api/auth/admin/oauth2/token", {
+      method: "POST",
+      headers: { "content-type": contentType },
+      body,
+    })
+
+  it.each([
+    "authorization_code",
+    "refresh_token",
+  ])("defaults an omitted resource for the %s grant", async (grantType) => {
+    const normalized = await withDefaultMcpOAuthResource(
+      tokenRequest(new URLSearchParams({ grant_type: grantType, client_id: "hosted-client" })),
+      resource,
+    )
+
+    expect(new URLSearchParams(await normalized.text()).get("resource")).toBe(resource)
+  })
+
+  it("preserves an explicit resource so the provider can validate it", async () => {
+    const request = tokenRequest(
+      new URLSearchParams({ grant_type: "authorization_code", resource: "https://other.test/mcp" }),
+    )
+
+    expect(await withDefaultMcpOAuthResource(request, resource)).toBe(request)
+  })
+
+  it("does not alter unrelated requests or grant types", async () => {
+    const request = tokenRequest(new URLSearchParams({ grant_type: "client_credentials" }))
+
+    expect(await withDefaultMcpOAuthResource(request, resource)).toBe(request)
   })
 })


### PR DESCRIPTION
## Summary

- default the sole MCP protected resource when hosted clients omit the optional RFC 8707 token parameter
- preserve explicit resources for normal Better Auth validation
- cover authorization-code and refresh-token exchanges used by ChatGPT and Claude

## Root cause

ChatGPT and Claude omit `resource` during token exchange. Better Auth 1.6.23 consequently issues an opaque access token, while Voyant verifies MCP access tokens as audience-bound JWTs against its JWKS. The connector is authorized but fails before `tools/list`.

## Verification

- `pnpm --filter @voyant-travel/auth test -- --maxWorkers=4` (312 passed, 31 skipped)
- `pnpm --filter @voyant-travel/auth typecheck`
- `pnpm --filter @voyant-travel/auth lint`
- `pnpm --filter @voyant-travel/auth build`
- live-Postgres OAuth integration: resource-less authorization-code and refresh exchanges both issue JWTs with the MCP audience
