### PR TITLE
fix(auth): verify MCP tokens with local JWKS

### DIFF
--- a/.changeset/quiet-mcp-keys.md
+++ b/.changeset/quiet-mcp-keys.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/auth": patch
+---
+
+Verify MCP OAuth access tokens against Better Auth's in-process JWKS instead of making managed runtimes fetch their own public hostname.

--- a/packages/auth/src/node-runtime.ts
+++ b/packages/auth/src/node-runtime.ts
@@ -31,9 +31,10 @@ import {
 } from "@voyant-travel/hono/middleware/error-boundary"
 import { getRequestId } from "@voyant-travel/hono/observability"
 import type { AccessCatalog } from "@voyant-travel/types/api-keys"
-import { verifyAccessToken } from "better-auth/oauth2"
+import { verifyJwsAccessToken } from "better-auth/oauth2"
 import { jwt } from "better-auth/plugins"
 import { and, eq, sql } from "drizzle-orm"
+import type { JSONWebKeySet } from "jose"
 
 /**
  * Discovery documents are fetched cross-origin by MCP clients before any
@@ -395,6 +396,12 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
   runtimeOptions: CreateOperatorAuthNodeRuntimeOptions<Env>,
 ) {
   type AuthHonoEnv = { Bindings: Env; Variables: { db: VoyantDb } }
+
+  // Better Auth caches function-backed JWKS sources by object identity. Keep
+  // one key for this runtime so ordinary requests do not re-read the signing
+  // key table, while a token with a new `kid` still triggers the library's
+  // built-in refresh path.
+  const mcpJwksCacheKey = {}
 
   const openDatabase =
     runtimeOptions.openDatabase ??
@@ -1090,8 +1097,22 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
     const baseUrl = getPublicApiBaseUrl(env)
     let claims: Record<string, unknown>
     try {
-      claims = (await verifyAccessToken(token, {
-        jwksUrl: `${baseUrl}/auth/admin/jwks`,
+      const betterAuth = buildAdminBetterAuth(env, db)
+      claims = (await verifyJwsAccessToken(token, {
+        // The authorization server and resource server are the same process.
+        // Read the public keys through Better Auth's in-process API instead of
+        // making the managed runtime call its own public hostname. That public
+        // loop can be rejected by the edge/origin boundary even though the
+        // externally published JWKS endpoint is healthy, which made every
+        // otherwise valid connector token fail closed to 401.
+        jwksFetch: async () => {
+          const response = await betterAuth.handler(
+            new Request(`${getAuthBaseUrl(env)}/auth/admin/jwks`),
+          )
+          if (!response.ok) throw new Error(`In-process JWKS request failed: ${response.status}`)
+          return (await response.json()) as JSONWebKeySet
+        },
+        jwksCacheKey: mcpJwksCacheKey,
         verifyOptions: {
           // The audience binds the token to the MCP resource specifically, so a
           // grant issued for another audience on this server cannot be replayed

--- a/packages/auth/tests/integration/mcp-oauth-flow.test.ts
+++ b/packages/auth/tests/integration/mcp-oauth-flow.test.ts
@@ -16,13 +16,14 @@ import { createHash } from "node:crypto"
 import { drizzle } from "drizzle-orm/postgres-js"
 import { decodeJwt } from "jose"
 import postgres from "postgres"
-import { afterAll, describe, expect, it } from "vitest"
+import { afterAll, describe, expect, it, vi } from "vitest"
 import {
   parseOAuthClientIdClaim,
   parseOAuthScopeClaim,
   withDefaultMcpOAuthResource,
   withPublicApiEndpoints,
 } from "../../src/mcp-oauth.js"
+import { createOperatorAuthNodeRuntime } from "../../src/node-runtime.js"
 import { createBetterAuth } from "../../src/server.js"
 
 const CONNECTION = process.env.MCP_OAUTH_TEST_DATABASE_URL ?? ""
@@ -30,6 +31,24 @@ const CONNECTION = process.env.MCP_OAUTH_TEST_DATABASE_URL ?? ""
 const TEST_PASSWORD = "test-operator-password"
 const BASE_URL = "http://localhost:3300"
 const RESOURCE = `${BASE_URL}/api/v1/admin/mcp`
+const ACCESS_CATALOG = {
+  presets: [],
+  resources: [
+    {
+      id: "bookings",
+      unitId: "@voyant-travel/bookings",
+      resource: "bookings",
+      label: "Bookings",
+      description: "",
+      wildcard: "allow" as const,
+      remoteSafe: true,
+      actions: [
+        { action: "read", label: "Read", description: "" },
+        { action: "write", label: "Write", description: "" },
+      ],
+    },
+  ],
+}
 
 // Set up at module scope, not in `beforeAll`: vitest picks `it` vs `it.skip`
 // while collecting the suite, which happens before any hook has run.
@@ -45,14 +64,29 @@ const setup = await (async () => {
     const { oauthProvider } = await import("@better-auth/oauth-provider")
     const { jwt } = await import("better-auth/plugins")
     const { mcpOAuthProviderConfig } = await import("../../src/mcp-oauth.js")
+    const db = drizzle(sql)
     const auth = createBetterAuth({
-      db: drizzle(sql) as never,
+      db: db as never,
       secret: "x".repeat(32),
       baseURL: BASE_URL,
       basePath: "/auth/admin",
       plugins: [jwt(), oauthProvider(mcpOAuthProviderConfig({ resource: RESOURCE }))] as never,
     })
-    return { sql, auth }
+    const runtime = createOperatorAuthNodeRuntime({
+      accessCatalog: ACCESS_CATALOG,
+      appName: "mcp-oauth-flow",
+      authMode: "local",
+      reporter: { captureException: () => {} },
+      openDatabase: () => ({ db: db as never, dispose: async () => {} }),
+    })
+    const env = {
+      API_BASE_URL: `${BASE_URL}/api`,
+      APP_URL: BASE_URL,
+      BETTER_AUTH_ADMIN_SECRET: "x".repeat(32),
+      DATABASE_URL: CONNECTION,
+      SESSION_CLAIMS_ADMIN_SECRET: "x".repeat(32),
+    }
+    return { sql, db, auth, runtime, env }
   } catch (error) {
     console.warn(`[mcp-oauth-flow] skipping: ${(error as Error).message}`)
     return null
@@ -291,7 +325,23 @@ describe("MCP connector OAuth handshake", () => {
         expect.arrayContaining(["mcp:read", "mcp:write"]),
       )
 
-      // 7. Hosted clients also omit `resource` when refreshing. The default
+      // 7. Exercise the resource server too. This must obtain JWKS from the
+      //    in-process authorization server; a self-fetch through the public
+      //    hostname is not available in every managed-runtime topology.
+      const publicFetch = vi
+        .spyOn(globalThis, "fetch")
+        .mockRejectedValue(new Error("managed runtime self-fetch is unavailable"))
+      const resolved = await setup.runtime
+        .resolveMcpAccessToken(setup.env, setup.db as never, grant.access_token)
+        .finally(() => publicFetch.mockRestore())
+      expect(resolved).toMatchObject({
+        userId: claims.sub,
+        callerType: "api_key",
+        actor: "staff",
+        scopes: expect.arrayContaining(["bookings:read", "bookings:write"]),
+      })
+
+      // 8. Hosted clients also omit `resource` when refreshing. The default
       //    must keep refreshed access tokens JWT-bound to the same audience.
       const refreshed = await call("/auth/admin/oauth2/token", {
         method: "POST",
@@ -306,7 +356,7 @@ describe("MCP connector OAuth handshake", () => {
       const refreshedGrant = (await refreshed.json()) as { access_token: string }
       expect([decodeJwt(refreshedGrant.access_token).aud].flat()).toContain(RESOURCE)
 
-      // 8. Revoking consent is what makes "Disconnect" immediate.
+      // 9. Revoking consent is what makes "Disconnect" immediate.
       const consents = await setup.sql`select id from oauth_consent where client_id = ${client_id}`
       expect(consents.length).toBeGreaterThan(0)
     },


### PR DESCRIPTION
## Summary
- verify MCP JWT access tokens against Better Auth’s in-process JWKS
- remove the managed runtime’s self-fetch through its public hostname
- extend the real Postgres OAuth flow through resource-server resolution while public fetch is deliberately unavailable

## Verification
- `./node_modules/.bin/biome check packages/auth/src packages/auth/tests/integration/mcp-oauth-flow.test.ts`
- `./node_modules/.bin/tsc -p packages/auth/tsconfig.typecheck.json --noEmit`
- `./node_modules/.bin/vitest run packages/auth/tests --maxWorkers=4` (308 passed, 31 skipped)
- `MCP_OAUTH_TEST_DATABASE_URL=... ./node_modules/.bin/vitest run packages/auth/tests/integration/mcp-oauth-flow.test.ts --maxWorkers=1` (7 passed)
- `./node_modules/.bin/tsc -p packages/auth/tsconfig.build.json`