### PR TITLE
fix(auth): revalidate managed MCP grants after rollout

### DIFF
--- a/packages/auth/src/node-runtime.ts
+++ b/packages/auth/src/node-runtime.ts
@@ -1149,6 +1149,30 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
       .limit(1)
     if (!consent) return null
 
+    // A managed release advances VOYANT_CLOUD_DEPLOYMENT_ID while preserving
+    // the tenant database and OAuth grants. The mirrored Cloud user link can
+    // therefore still name the previous deployment even though the member's
+    // access remains active. Session and API-token authentication already
+    // revalidate that link (which safely retargets deployment drift); MCP must
+    // do the same before resolveStaffAccess applies its deployment fence, or
+    // every connector starts returning 401 immediately after a rollout.
+    if (isVoyantCloudAuthMode(env)) {
+      const revalidateConfig = getCloudAuthRevalidateConfig(env)
+      if (!revalidateConfig) return null
+
+      try {
+        const revalidation = await revalidateVoyantCloudAdminAuthUser({
+          db: db as Parameters<typeof revalidateVoyantCloudAdminAuthUser>[0]["db"],
+          userId,
+          config: revalidateConfig,
+        })
+        if (!revalidation.ok) return null
+      } catch (error) {
+        console.error("[auth/mcp-token] Cloud revalidation failed:", error)
+        return null
+      }
+    }
+
     const staffAccess = await resolveStaffAccess({
       accessCatalog: runtimeOptions.accessCatalog,
       authMode: resolveOperatorAuthMode(env),

--- a/packages/auth/tests/integration/mcp-oauth-flow.test.ts
+++ b/packages/auth/tests/integration/mcp-oauth-flow.test.ts
@@ -341,6 +341,72 @@ describe("MCP connector OAuth handshake", () => {
         scopes: expect.arrayContaining(["bookings:read", "bookings:write"]),
       })
 
+      // Managed operators resolve the same grant through the deployment-scoped
+      // Cloud staff link rather than the local profile fallback. Keep this in
+      // the real OAuth flow: a local-only assertion can pass while every hosted
+      // connector still fails after token verification.
+      const previousManagedDeploymentId = "dpl_mcp_oauth_flow_previous"
+      const managedDeploymentId = "dpl_mcp_oauth_flow_current"
+      await setup.sql`
+        insert into cloud_auth_user_links (
+          user_id,
+          provider_id,
+          provider_account_id,
+          deployment_id,
+          platform_organization_id,
+          workos_organization_id,
+          role_slug
+        ) values (
+          ${claims.sub},
+          'voyant-cloud',
+          'provider-account-mcp-flow',
+          ${previousManagedDeploymentId},
+          'org_mcp_flow',
+          'org_workos_mcp_flow',
+          'admin'
+        )
+      `
+      const managedRuntime = createOperatorAuthNodeRuntime({
+        accessCatalog: ACCESS_CATALOG,
+        appName: "managed-mcp-oauth-flow",
+        authMode: "voyant-cloud",
+        reporter: { captureException: () => {} },
+        openDatabase: () => ({ db: setup.db as never, dispose: async () => {} }),
+      })
+      const cloudRevalidation = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(Response.json({ ok: true, status: "active" }))
+      let managedResolved: Awaited<ReturnType<typeof managedRuntime.resolveMcpAccessToken>>
+      try {
+        managedResolved = await managedRuntime.resolveMcpAccessToken(
+          {
+            ...setup.env,
+            VOYANT_CLOUD_DEPLOYMENT_ID: managedDeploymentId,
+            VOYANT_CLOUD_ADMIN_AUTH_REVALIDATE_URL:
+              "https://api.voyant.test/cloud/v1/admin-auth/revalidate",
+            VOYANT_CLOUD_ADMIN_AUTH_CLIENT_TOKEN: "deployment-test-token",
+          },
+          setup.db as never,
+          grant.access_token,
+        )
+        expect(cloudRevalidation).toHaveBeenCalledOnce()
+      } finally {
+        cloudRevalidation.mockRestore()
+      }
+      expect(managedResolved).toMatchObject({
+        userId: claims.sub,
+        organizationId: "org_mcp_flow",
+        callerType: "api_key",
+        actor: "staff",
+        scopes: expect.arrayContaining(["bookings:read", "bookings:write"]),
+      })
+      const [retargeted] = await setup.sql`
+        select deployment_id
+        from cloud_auth_user_links
+        where user_id = ${claims.sub}
+      `
+      expect(retargeted?.deployment_id).toBe(managedDeploymentId)
+
       // 8. Hosted clients also omit `resource` when refreshing. The default
       //    must keep refreshed access tokens JWT-bound to the same audience.
       const refreshed = await call("/auth/admin/oauth2/token", {


### PR DESCRIPTION
## Summary
- revalidate managed Cloud staff access before resolving an MCP OAuth grant
- retarget stale deployment-scoped user links after a managed rollout
- cover the real managed authorize/consent/token flow with deployment drift

## Root cause
Managed rollouts preserve the tenant database and OAuth consent but advance `VOYANT_CLOUD_DEPLOYMENT_ID`. Session and API-token paths revalidated and retargeted the mirrored Cloud user link; MCP went directly to the deployment-fenced staff lookup, so a valid connector token returned 401 after every rollout.

## Validation
- `MCP_OAUTH_TEST_DATABASE_URL=... pnpm --filter @voyant-travel/auth exec vitest run tests/integration/mcp-oauth-flow.test.ts --maxWorkers=1`
- `pnpm --filter @voyant-travel/auth test -- --maxWorkers=2`
- `pnpm --filter @voyant-travel/auth typecheck`
- `pnpm exec biome check packages/auth/src/node-runtime.ts packages/auth/tests/integration/mcp-oauth-flow.test.ts`
- `git diff --check`