### PR TITLE
feat(mcp): add exposure policy presets

### DIFF
--- a/.changeset/bright-mcp-presets.md
+++ b/.changeset/bright-mcp-presets.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/operator-settings-react": patch
+---
+
+Add one-click MCP exposure policy presets for enabling every current tool or restoring the recommended low-risk, read-only baseline.

--- a/packages/operator-settings-react/src/mcp-settings-page.tsx
+++ b/packages/operator-settings-react/src/mcp-settings-page.tsx
@@ -33,6 +33,7 @@ import { type ReactNode, useEffect, useMemo, useState } from "react"
 import { listMcpConnectors, revokeMcpConnector } from "./mcp-connectors.js"
 import {
   buildMcpClientConfigs,
+  enableAllMcpTools,
   filterMcpTools,
   isMcpToolExposed,
   MCP_TOKEN_PLACEHOLDER,
@@ -42,6 +43,7 @@ import {
   type McpManifest,
   type McpToolRisk,
   mcpRiskLabel,
+  recommendedMcpPolicy,
   resolveMcpEndpoint,
   useMcpMessages,
 } from "./mcp-ui.js"
@@ -252,6 +254,36 @@ export function McpSettingsPage() {
         <CardContent className="flex flex-col gap-5">
           {policyDraft ? (
             <>
+              <div className="flex flex-col gap-3">
+                <div>
+                  <p className="text-sm font-medium">{t.policyPresets}</p>
+                  <p className="text-sm text-muted-foreground">{t.policyPresetsDescription}</p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    disabled={savePolicy.isPending || tools.length === 0}
+                    onClick={() => {
+                      setPolicySaved(false)
+                      setPolicyDraft(enableAllMcpTools(tools))
+                    }}
+                  >
+                    {t.enableAll}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={savePolicy.isPending}
+                    onClick={() => {
+                      setPolicySaved(false)
+                      setPolicyDraft(recommendedMcpPolicy())
+                    }}
+                  >
+                    {t.useRecommended}
+                  </Button>
+                </div>
+              </div>
               <div className="flex items-start justify-between gap-4">
                 <div>
                   <p className="text-sm font-medium">{t.policyWrites}</p>

--- a/packages/operator-settings-react/src/mcp-ui.test.ts
+++ b/packages/operator-settings-react/src/mcp-ui.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest"
 import {
   buildMcpClientConfigs,
+  enableAllMcpTools,
   filterMcpTools,
   isMcpToolExposed,
   MCP_TOKEN_PLACEHOLDER,
   type McpManifestTool,
+  recommendedMcpPolicy,
   resolveMcpEndpoint,
 } from "./mcp-ui.js"
 
@@ -118,5 +120,33 @@ describe("mcp tool filtering", () => {
         toolOverrides: { "@voyant-travel/operator-settings#tool.update": "allow" },
       }),
     ).toBe(true)
+  })
+
+  it("builds an enable-all draft for every current tool", () => {
+    const policy = enableAllMcpTools(tools)
+
+    expect(policy).toEqual({
+      allowedRiskLevels: ["low", "medium", "high", "critical"],
+      allowWrites: true,
+      allowSensitiveData: true,
+      toolOverrides: {
+        "@voyant-travel/bookings#tool.list": "allow",
+        "@voyant-travel/operator-settings#tool.update": "allow",
+      },
+    })
+    expect(tools.every((tool) => isMcpToolExposed(tool, policy))).toBe(true)
+  })
+
+  it("builds the recommended low-risk read-only baseline", () => {
+    const policy = recommendedMcpPolicy()
+
+    expect(policy).toEqual({
+      allowedRiskLevels: ["low"],
+      allowWrites: false,
+      allowSensitiveData: false,
+      toolOverrides: {},
+    })
+    expect(isMcpToolExposed(tools[0]!, policy)).toBe(true)
+    expect(isMcpToolExposed(tools[1]!, policy)).toBe(false)
   })
 })

--- a/packages/operator-settings-react/src/mcp-ui.ts
+++ b/packages/operator-settings-react/src/mcp-ui.ts
@@ -187,6 +187,10 @@ interface McpMessages {
   policyRisk: string
   policyRiskDescription: string
   policyCriticalNote: string
+  policyPresets: string
+  policyPresetsDescription: string
+  enableAll: string
+  useRecommended: string
   savePolicy: string
   savingPolicy: string
   policySaved: string
@@ -279,6 +283,11 @@ const en: McpMessages = {
   policyRiskDescription: "Low risk is the recommended baseline.",
   policyCriticalNote:
     "Critical and package-restricted tools always require an explicit per-tool enable.",
+  policyPresets: "Policy presets",
+  policyPresetsDescription:
+    "Enable all includes every current tool, including writes, sensitive data, and critical or restricted tools. Review the draft below, then save it.",
+  enableAll: "Enable all",
+  useRecommended: "Recommended baseline",
   savePolicy: "Save policy",
   savingPolicy: "Saving…",
   policySaved: "Policy saved. Connected assistants use it on their next request.",
@@ -372,6 +381,11 @@ const ro: McpMessages = {
   policyRiskDescription: "Riscul scazut este baza recomandata.",
   policyCriticalNote:
     "Toolurile critice si restrictionate de pachet necesita intotdeauna activare individuala.",
+  policyPresets: "Preseturi de politica",
+  policyPresetsDescription:
+    "Activarea completa include toate toolurile curente, inclusiv scrieri, date sensibile si tooluri critice sau restrictionate. Verifica schita de mai jos, apoi salveaz-o.",
+  enableAll: "Activeaza tot",
+  useRecommended: "Configuratie recomandata",
   savePolicy: "Salveaza politica",
   savingPolicy: "Se salveaza…",
   policySaved: "Politica a fost salvata. Asistentii o folosesc la urmatoarea cerere.",
@@ -420,4 +434,24 @@ export function isMcpToolExposed(tool: McpManifestTool, policy: McpExposurePolic
   if (override === "allow") return true
   if (tool.deploymentRisk === "critical" || !tool.exposure.remoteSafe) return false
   return policy.allowedRiskLevels.includes(tool.deploymentRisk)
+}
+
+/** Draft that explicitly exposes every tool currently present in the manifest. */
+export function enableAllMcpTools(tools: McpManifestTool[]): McpExposurePolicy {
+  return {
+    allowedRiskLevels: ["low", "medium", "high", "critical"],
+    allowWrites: true,
+    allowSensitiveData: true,
+    toolOverrides: Object.fromEntries(tools.map((tool) => [tool.capabilityId, "allow"])),
+  }
+}
+
+/** Recommended deployment baseline: remote-safe, low-risk, non-sensitive reads only. */
+export function recommendedMcpPolicy(): McpExposurePolicy {
+  return {
+    allowedRiskLevels: ["low"],
+    allowWrites: false,
+    allowSensitiveData: false,
+    toolOverrides: {},
+  }
 }


### PR DESCRIPTION
## Summary

- add an **Enable all** preset that drafts explicit allow overrides for every current MCP tool, including writes, sensitive data, and critical or restricted tools
- add a **Recommended baseline** preset that restores low-risk, read-only exposure
- keep policy activation behind the existing Save action and add English/Romanian copy plus unit coverage

## Validation

- `corepack pnpm --filter @voyant-travel/operator-settings-react test` (50 tests)
- `NODE_OPTIONS=--max-old-space-size=8192 corepack pnpm --filter @voyant-travel/operator-settings-react typecheck`
- `corepack pnpm --filter @voyant-travel/operator-settings-react lint`
- `NODE_OPTIONS=--max-old-space-size=8192 corepack pnpm --filter @voyant-travel/operator-settings-react build`
- pre-commit affected gate: 232/232 tasks passed

## Note

The repository-wide pre-push test hook also ran. 119/121 package tasks passed; unrelated existing failures reproduced independently in `@voyant-travel/flights-react` airport-combobox tests and `@voyant-travel/admin-host` tests where the test environment exposes an undefined `localStorage`. GitHub CI remains the merge gate.